### PR TITLE
Case insensitivity of the import statement

### DIFF
--- a/examples/neg/importcase.check
+++ b/examples/neg/importcase.check
@@ -1,0 +1,3 @@
+[error] examples/neg/importcase.effekt:1:1: Cannot find source for examples/pos/liStS
+import examples/pos/liStS
+^

--- a/examples/neg/importcase.check
+++ b/examples/neg/importcase.check
@@ -1,3 +1,4 @@
-[error] examples/neg/importcase.effekt:1:1: Cannot find source for examples/pos/liStS
+[error] examples/neg/importcase.effekt:2:1: Could find an import, but has wrong module path.
+Path declared in the module: examples/pos/lists
 import examples/pos/liStS
 ^

--- a/examples/neg/importcase.effekt
+++ b/examples/neg/importcase.effekt
@@ -1,5 +1,5 @@
 module importcase
-import examples/pos/liStS //should fail, but does not
+import examples/pos/liStS
 // the following uses foreach from lists.effekt.
 // Execution of main() still fails as .js transpilation
 // imports "liStS" but calls lists.foreach()

--- a/examples/neg/importcase.effekt
+++ b/examples/neg/importcase.effekt
@@ -1,0 +1,10 @@
+module importcase
+import examples/pos/liStS //should fail, but does not
+// the following uses foreach from lists.effekt.
+// Execution of main() still fails as .js transpilation
+// imports "liStS" but calls lists.foreach()
+def main() = {
+    val l = Cons(1, Cons(2, Nil()));
+    foreach(l) { el => println(el) };
+    ()
+}

--- a/jvm/src/test/scala/effekt/RegressionTests.scala
+++ b/jvm/src/test/scala/effekt/RegressionTests.scala
@@ -10,7 +10,6 @@ import scala.util.matching._
 import org.scalatest.funspec.AnyFunSpec
 
 import scala.language.implicitConversions
-import scala.util.control.NonFatal
 
 class RegressionTests extends AnyFunSpec with TestUtils {
 

--- a/jvm/src/test/scala/effekt/RegressionTests.scala
+++ b/jvm/src/test/scala/effekt/RegressionTests.scala
@@ -10,6 +10,7 @@ import scala.util.matching._
 import org.scalatest.funspec.AnyFunSpec
 
 import scala.language.implicitConversions
+import scala.util.control.NonFatal
 
 class RegressionTests extends AnyFunSpec with TestUtils {
 
@@ -29,7 +30,11 @@ class RegressionTests extends AnyFunSpec with TestUtils {
         }
 
         it(f.getName) {
-          val out = interpret(f)
+          val out = try { interpret(f) } catch {
+            case e: RuntimeException => println("RuntimeException caught:" + e)
+            // as described in https://stackoverflow.com/questions/21170322/scala-silently-catch-all-exceptions
+            case NonFatal(t)         => ()
+          }
 
           if (checkfile.exists()) {
             assert(IO.read(checkfile).toString == out)

--- a/jvm/src/test/scala/effekt/RegressionTests.scala
+++ b/jvm/src/test/scala/effekt/RegressionTests.scala
@@ -30,11 +30,7 @@ class RegressionTests extends AnyFunSpec with TestUtils {
         }
 
         it(f.getName) {
-          val out = try { interpret(f) } catch {
-            case e: RuntimeException => println("RuntimeException caught:" + e)
-            // as described in https://stackoverflow.com/questions/21170322/scala-silently-catch-all-exceptions
-            case NonFatal(t)         => ()
-          }
+          val out = interpret(f)
 
           if (checkfile.exists()) {
             assert(IO.read(checkfile).toString == out)

--- a/shared/src/main/scala/effekt/Namer.scala
+++ b/shared/src/main/scala/effekt/Namer.scala
@@ -45,6 +45,10 @@ class Namer extends Phase[Module, Module] { namer =>
     val imports = mod.decl.imports map {
       case im @ source.Import(path) => Context.at(im) {
         val modImport = Context.moduleOf(path)
+        // compare path with modImport.path to ensure correct handling of case sensitivity
+        if (modImport.decl.path != path) {
+          Context.abort(s"Could find an import, but has wrong module path.\nPath declared in the module: ${modImport.decl.path}")
+        }
         scope.defineAll(modImport.terms, modImport.types)
         modImport
       }

--- a/shared/src/main/scala/effekt/Namer.scala
+++ b/shared/src/main/scala/effekt/Namer.scala
@@ -47,7 +47,7 @@ class Namer extends Phase[Module, Module] { namer =>
         val modImport = Context.moduleOf(path)
         // compare path with modImport.path to ensure correct handling of case sensitivity
         if (modImport.decl.path != path) {
-          Context.abort(s"Could find an import, but has wrong module path.\nPath declared in the module: ${modImport.decl.path}")
+          Context.abort(s"Could find an import, but has wrong module path.\nPath declared in the imported module: ${modImport.decl.path}")
         }
         scope.defineAll(modImport.terms, modImport.types)
         modImport

--- a/shared/src/main/scala/effekt/util/ColoredMessaging.scala
+++ b/shared/src/main/scala/effekt/util/ColoredMessaging.scala
@@ -21,10 +21,10 @@ class ColoredMessaging(positions: Positions) extends Messaging(positions) {
       case Some(pos) =>
         val severity = severityToWord(message.severity)
         val context = util.Highlight(pos.optContext.getOrElse(""))
-        s"[$severity] ${pos.format} ${homogenizePath(message.label)}\n$context\n"
+        s"[$severity] ${homogenizePath(pos.format)} ${message.label}\n$context\n"
       case None =>
         val severity = severityToWord(message.severity)
-        s"[$severity] ${homogenizePath(message.label)}\n"
+        s"[$severity] ${message.label}\n"
     }
 
   /**


### PR DESCRIPTION
The import statement allowed import of files without checking for cases in file names.
This branch should fix the issue (by aborting translation when the name of the import file is unequal to the file name of the imported module itself) and introduce an according test scenario.