### PR TITLE
Refactoring usage of IDs

### DIFF
--- a/shared/src/main/scala/effekt/Parser.scala
+++ b/shared/src/main/scala/effekt/Parser.scala
@@ -238,7 +238,7 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
   lazy val effectDef: P[Def] =
     ( `effect` ~> effectOp ^^ {
         case op =>
-          EffDef(IdRef(op.id.name) withPositionOf op.id, List(op))
+          EffDef(IdDef(op.id.name) withPositionOf op.id, List(op))
       }
     | `effect` ~> idDef ~ (`{` ~/> some(`def` ~> effectOp)  <~ `}`) ^^ EffDef
     )

--- a/shared/src/main/scala/effekt/source/Tree.scala
+++ b/shared/src/main/scala/effekt/source/Tree.scala
@@ -86,9 +86,8 @@ case class BlockArg(params: ValueParams, body: Stmt) extends ArgSection
 /**
  * Global (and later, local) definitions
  */
-sealed trait Def extends Definition {
-  def id: IdDef
-}
+sealed trait Def extends Definition
+
 case class FunDef(id: IdDef, tparams: List[Id], params: List[ParamSection], ret: Option[Effectful], body: Stmt) extends Def {
   type symbol = symbols.UserFunction
 }


### PR DESCRIPTION
IDs can be references or definitions. Currently the property `id` of `effekt.source.Definition` and `effekt.source.Reference` is just typed as `Id`. 

To ensure the correct usage of both traits `Definition.id` and `Reference.id` should be typed as `IdDef` and `IdRef` respectively.