### PR TITLE
Fix EffectOp.isBidirectional

### DIFF
--- a/shared/src/main/scala/effekt/Namer.scala
+++ b/shared/src/main/scala/effekt/Namer.scala
@@ -115,7 +115,7 @@ class Namer extends Phase[Module, Module] { namer =>
             val tps = tparams map resolve
             val Effectful(tpe, otherEffs) = resolve(ret)
             val retResolved = Effectful(tpe, otherEffs + effectSym)
-            val op = EffectOp(Name(id), tps, params map resolve, Some(retResolved), effectSym)
+            val op = EffectOp(Name(id), tps, params map resolve, Some(retResolved), effectSym, otherEffs.nonEmpty)
             Context.define(id, op)
             op
           }

--- a/shared/src/main/scala/effekt/Namer.scala
+++ b/shared/src/main/scala/effekt/Namer.scala
@@ -115,7 +115,7 @@ class Namer extends Phase[Module, Module] { namer =>
             val tps = tparams map resolve
             val Effectful(tpe, otherEffs) = resolve(ret)
             val retResolved = Effectful(tpe, otherEffs + effectSym)
-            val op = EffectOp(Name(id), tps, params map resolve, Some(retResolved), effectSym, otherEffs.nonEmpty)
+            val op = EffectOp(Name(id), tps, params map resolve, Some(retResolved), effectSym, otherEffs)
             Context.define(id, op)
             op
           }

--- a/shared/src/main/scala/effekt/Parser.scala
+++ b/shared/src/main/scala/effekt/Parser.scala
@@ -426,7 +426,7 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     idRef ~ maybeTypeArgs ~ some(args) ^^ Call
 
   lazy val resumeExpr: P[Expr] =
-(`resume` ^^^ IdRef("resume")) ~ args ^^ { case r ~ args => Call(r, Nil, List(args)) withPositionOf r }
+    (`resume` ^^^ IdRef("resume")) ~ args ^^ { case r ~ args => Call(r, Nil, List(args)) withPositionOf r }
 
   lazy val handleExpr: P[Expr] =
     `try` ~/> stmt ~ some(handler) ^^ TryHandle

--- a/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/shared/src/main/scala/effekt/core/Transformer.scala
@@ -230,8 +230,8 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
   def synthesizeStateEffect(binder: VarBinder)(implicit C: Context): StateEffect = {
     val tpe = C.valueTypeOf(binder)
     val eff = UserEffect(binder.name, Nil)
-    val get = EffectOp(binder.name.rename(name => "get"), Nil, List(Nil), Some(tpe / Pure), eff, false)
-    val put = EffectOp(binder.name.rename(name => "put"), Nil, List(List(ValueParam(binder.name, Some(tpe)))), Some(builtins.TUnit / Pure), eff, false)
+    val get = EffectOp(binder.name.rename(name => "get"), Nil, List(Nil), Some(tpe / Pure), eff, Pure)
+    val put = EffectOp(binder.name.rename(name => "put"), Nil, List(List(ValueParam(binder.name, Some(tpe)))), Some(builtins.TUnit / Pure), eff, Pure)
     eff.ops = List(get, put)
     StateEffect(eff, get, put)
   }

--- a/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/shared/src/main/scala/effekt/core/Transformer.scala
@@ -230,8 +230,8 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
   def synthesizeStateEffect(binder: VarBinder)(implicit C: Context): StateEffect = {
     val tpe = C.valueTypeOf(binder)
     val eff = UserEffect(binder.name, Nil)
-    val get = EffectOp(binder.name.rename(name => "get"), Nil, List(Nil), Some(tpe / Pure), eff)
-    val put = EffectOp(binder.name.rename(name => "put"), Nil, List(List(ValueParam(binder.name, Some(tpe)))), Some(builtins.TUnit / Pure), eff)
+    val get = EffectOp(binder.name.rename(name => "get"), Nil, List(Nil), Some(tpe / Pure), eff, false)
+    val put = EffectOp(binder.name.rename(name => "put"), Nil, List(List(ValueParam(binder.name, Some(tpe)))), Some(builtins.TUnit / Pure), eff, false)
     eff.ops = List(get, put)
     StateEffect(eff, get, put)
   }

--- a/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -243,8 +243,8 @@ package object symbols {
   }
 
   case class UserEffect(name: Name, tparams: List[TypeVar], var ops: List[EffectOp] = Nil) extends Effect
-  case class EffectOp(name: Name, tparams: List[TypeVar], params: List[List[ValueParam]], ret: Option[Effectful], effect: UserEffect, isBidirectional: Boolean) extends Fun {
-    def otherEffects: Effects = ret.get.effects - effect
+  case class EffectOp(name: Name, tparams: List[TypeVar], params: List[List[ValueParam]], ret: Option[Effectful], effect: UserEffect, otherEffects: Effects) extends Fun {
+    def isBidirectional: Boolean = otherEffects.nonEmpty
   }
 
   /**

--- a/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -243,9 +243,8 @@ package object symbols {
   }
 
   case class UserEffect(name: Name, tparams: List[TypeVar], var ops: List[EffectOp] = Nil) extends Effect
-  case class EffectOp(name: Name, tparams: List[TypeVar], params: List[List[ValueParam]], ret: Option[Effectful], effect: UserEffect) extends Fun {
+  case class EffectOp(name: Name, tparams: List[TypeVar], params: List[List[ValueParam]], ret: Option[Effectful], effect: UserEffect, isBidirectional: Boolean) extends Fun {
     def otherEffects: Effects = ret.get.effects - effect
-    def isBidirectional: Boolean = otherEffects.nonEmpty
   }
 
   /**


### PR DESCRIPTION
`EffectOp.isBidirectional` has wrong behavior in following program:

```scala
module bug

effect Exn(msg: String) : Unit / { Exn }

def main() = {
  var exit = false
  try {
    try {
      do Exn("throw")
    }
    with Exn { msg =>
      resume { do Exn("re-throw") }
    }
  }
  with Exn { msg => resume { () } }
}
```

The compiler outputs following error:

```
[error] bug.effekt:12:7: Wrong type of argument section
      resume { do Exn("re-throw") }
      ^^^^^^
```

The reason of this error is that `EffectOp.isBidirectional` of `Exn` is `false` because `EffectOp.otherEffects` is empty (`{Exn} - Exn = {}`). We expects that it's `true` because `Exn` is bidirectional effect.