### PR TITLE
Refactor/capability symbols

### DIFF
--- a/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/shared/src/main/scala/effekt/core/Transformer.scala
@@ -210,9 +210,9 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
   }).map { _.inheritPosition(tree) }
 
   def transform(tree: source.MatchPattern)(implicit C: TransformerContext): (Pattern, List[core.ValueParam]) = tree match {
-    case source.IgnorePattern()   => (core.IgnorePattern(), Nil)
-    case source.LiteralPattern(l) => (core.LiteralPattern(transformLit(l)), Nil)
-    case source.AnyPattern(id)    => (core.AnyPattern(), List(core.ValueParam(id.symbol)))
+    case source.IgnorePattern()    => (core.IgnorePattern(), Nil)
+    case source.LiteralPattern(l)  => (core.LiteralPattern(transformLit(l)), Nil)
+    case p @ source.AnyPattern(id) => (core.AnyPattern(), List(core.ValueParam(p.symbol)))
     case p @ source.TagPattern(id, ps) =>
       val (patterns, params) = ps.map(transform).unzip
       (core.TagPattern(p.definition, patterns), params.flatten)

--- a/shared/src/main/scala/effekt/core/Tree.scala
+++ b/shared/src/main/scala/effekt/core/Tree.scala
@@ -2,7 +2,7 @@ package effekt
 package core
 
 import effekt.context.Context
-import effekt.symbols.{ Name, Symbol }
+import effekt.symbols.{ Name, Symbol, ValueSymbol, BlockSymbol }
 
 sealed trait Tree extends Product {
   def inheritPosition(from: source.Tree)(implicit C: Context): this.type = {
@@ -43,8 +43,8 @@ case class Select(target: Expr, field: Symbol) extends Expr
  * Blocks
  */
 sealed trait Param extends Tree { def id: Symbol }
-case class ValueParam(id: Symbol) extends Param
-case class BlockParam(id: Symbol) extends Param
+case class ValueParam(id: ValueSymbol) extends Param
+case class BlockParam(id: BlockSymbol) extends Param
 
 sealed trait Block extends Tree with Argument
 case class BlockVar(id: Symbol) extends Block

--- a/shared/src/main/scala/effekt/core/Tree.scala
+++ b/shared/src/main/scala/effekt/core/Tree.scala
@@ -2,7 +2,7 @@ package effekt
 package core
 
 import effekt.context.Context
-import effekt.symbols.{ Name, Symbol, ValueSymbol, BlockSymbol }
+import effekt.symbols.{ Name, Symbol, TermSymbol, ValueSymbol, BlockSymbol, Effect, EffectOp }
 
 sealed trait Tree extends Product {
   def inheritPosition(from: source.Tree)(implicit C: Context): this.type = {
@@ -25,7 +25,7 @@ sealed trait Argument extends Tree
  * Expressions
  */
 sealed trait Expr extends Tree with Argument
-case class ValueVar(id: Symbol) extends Expr
+case class ValueVar(id: ValueSymbol) extends Expr
 
 sealed trait Literal[T] extends Expr {
   def value: T
@@ -42,12 +42,12 @@ case class Select(target: Expr, field: Symbol) extends Expr
 /**
  * Blocks
  */
-sealed trait Param extends Tree { def id: Symbol }
+sealed trait Param extends Tree { def id: TermSymbol }
 case class ValueParam(id: ValueSymbol) extends Param
 case class BlockParam(id: BlockSymbol) extends Param
 
 sealed trait Block extends Tree with Argument
-case class BlockVar(id: Symbol) extends Block
+case class BlockVar(id: BlockSymbol) extends Block
 
 // introduced by lift inference only
 case class ScopeAbs(scope: Symbol, body: Block) extends Block
@@ -55,15 +55,15 @@ case class ScopeApp(b: Block, evidence: Scope) extends Block
 case class Lifted(s: Scope, b: Block) extends Block
 
 case class BlockLit(params: List[Param], body: Stmt) extends Block
-case class Member(b: Block, field: Symbol) extends Block
+case class Member(b: Block, field: EffectOp) extends Block
 case class Extern(params: List[Param], body: String) extends Block
 
 /**
  * Statements
  */
 sealed trait Stmt extends Tree
-case class Def(id: Symbol, block: Block, rest: Stmt) extends Stmt
-case class Val(id: Symbol, binding: Stmt, body: Stmt) extends Stmt
+case class Def(id: BlockSymbol, block: Block, rest: Stmt) extends Stmt
+case class Val(id: ValueSymbol, binding: Stmt, body: Stmt) extends Stmt
 case class Data(id: Symbol, ctors: List[Symbol], rest: Stmt) extends Stmt
 case class Record(id: Symbol, fields: List[Symbol], rest: Stmt) extends Stmt
 
@@ -85,10 +85,10 @@ case class Include(contents: String, rest: Stmt) extends Stmt
 
 case object Hole extends Stmt
 
-case class State(id: Symbol, get: Symbol, put: Symbol, init: Stmt, body: Block) extends Stmt
+case class State(id: Effect, get: EffectOp, put: EffectOp, init: Stmt, body: Block) extends Stmt
 case class Handle(body: Block, handler: List[Handler]) extends Stmt
 // TODO change to Map
-case class Handler(id: Symbol, clauses: List[(Symbol, BlockLit)]) extends Tree
+case class Handler(id: Effect, clauses: List[(EffectOp, BlockLit)]) extends Tree
 
 /**
  * Explicit Lifts

--- a/shared/src/main/scala/effekt/generator/JavaScript.scala
+++ b/shared/src/main/scala/effekt/generator/JavaScript.scala
@@ -159,13 +159,15 @@ trait JavaScriptBase extends ParenPrettyPrinter {
 
   // we prefix op$ to effect operations to avoid clashes with reserved names like `get` and `set`
   def nameDef(id: Symbol)(implicit C: Context): Doc = id match {
+    case _: effekt.core.CapabilitySymbol => id.name.toString + "_" + id.id
     case _: symbols.EffectOp => "op$" + id.name.toString
-    case _                   => toDoc(id.name)
+    case _ => toDoc(id.name)
   }
 
   def nameRef(id: Symbol)(implicit C: Context): Doc = id match {
-    case _: symbols.Effect   => toDoc(id.name)
-    case _: symbols.EffectOp => "op$" + id.name.toString
+    case _: symbols.Effect               => toDoc(id.name)
+    case _: effekt.core.CapabilitySymbol => id.name.toString + "_" + id.id
+    case _: symbols.EffectOp             => "op$" + id.name.toString
     case _ => id.name match {
       case name: NestedName if name.parent != C.module.name => link(name, jsModuleName(name.parent) + "." + name.localName)
       case name => toDoc(name)


### PR DESCRIPTION
So far we use shadowing in the target language to establish lexical scoping of capabilities. To be more future proof, here I introduce fresh capabilities. This has the positive side-effect that capabilities are now finally **term symbols**.