### PR TITLE
Refactor/simplify transformer

### DIFF
--- a/js/src/main/scala/effekt/EffektConfig.scala
+++ b/js/src/main/scala/effekt/EffektConfig.scala
@@ -13,4 +13,6 @@ trait EffektConfig {
   def generator(): String = "js"
 
   def outputPath(): String = "out"
+
+  def requiresLift(): Boolean = false
 }

--- a/js/src/main/scala/effekt/LanguageServer.scala
+++ b/js/src/main/scala/effekt/LanguageServer.scala
@@ -62,7 +62,7 @@ class LanguageServer extends Intelligence {
     /**
      * Don't output amdefine module declarations
      */
-    override def generatorPhase(implicit C: Context) = new JavaScriptVirtual
+    override def codeGenerator(implicit C: Context) = new JavaScriptVirtual
 
     override def saveOutput(js: String, path: String)(implicit C: Context): Unit = {
       file(path).write(js)

--- a/js/src/main/scala/effekt/context/VirtualModuleDB.scala
+++ b/js/src/main/scala/effekt/context/VirtualModuleDB.scala
@@ -4,7 +4,7 @@ package context
 import effekt.util.Resources
 import effekt.util.paths._
 
-import org.bitbucket.inkytonik.kiama.util.{ Source, StringSource }
+import org.bitbucket.inkytonik.kiama.util.Source
 
 trait VirtualModuleDB extends ModuleDB { self: Context =>
 

--- a/js/src/main/scala/effekt/generator/JavaScriptVirtual.scala
+++ b/js/src/main/scala/effekt/generator/JavaScriptVirtual.scala
@@ -2,7 +2,6 @@ package effekt.generator
 
 import effekt.context.Context
 import effekt.core.ModuleDecl
-import effekt.symbols.Name
 import org.bitbucket.inkytonik.kiama.output.PrettyPrinterTypes.Document
 
 import scala.language.implicitConversions

--- a/jvm/src/main/scala/effekt/Driver.scala
+++ b/jvm/src/main/scala/effekt/Driver.scala
@@ -136,7 +136,7 @@ trait Driver extends CompilerWithConfig[Tree, ModuleDecl, EffektConfig] { outer 
   def evalJS(mod: Module)(implicit C: Context): Unit = C.at(mod.decl) {
     try {
       C.checkMain(mod)
-      val jsFile = C.generatorPhase.path(mod)
+      val jsFile = C.codeGenerator.path(mod)
       val jsScript = s"require('${jsFile}').main().run()"
       val command = Process(Seq("node", "--eval", jsScript))
       C.config.output().emit(command.!!)
@@ -149,7 +149,7 @@ trait Driver extends CompilerWithConfig[Tree, ModuleDecl, EffektConfig] { outer 
   def evalCS(mod: Module)(implicit C: Context): Unit = C.at(mod.decl) {
     try {
       C.checkMain(mod)
-      val csFile = C.generatorPhase.path(mod)
+      val csFile = C.codeGenerator.path(mod)
       val command = Process(Seq("scheme", "--script", csFile))
       C.config.output().emit(command.!!)
     } catch {

--- a/jvm/src/main/scala/effekt/Driver.scala
+++ b/jvm/src/main/scala/effekt/Driver.scala
@@ -7,12 +7,11 @@ import effekt.source.{ ModuleDecl, Tree }
 import effekt.symbols.Module
 import effekt.context.{ Context, IOModuleDB }
 import effekt.util.{ ColoredMessaging, MarkdownSource }
-import effekt.util.paths._
 import org.bitbucket.inkytonik.kiama
 import kiama.output.PrettyPrinterTypes.Document
 import kiama.parsing.ParseResult
 import kiama.util.{ Client, CompilerWithConfig, IO, Services, Source }
-import java.io.{ InputStream, OutputStream, PrintWriter, File => JFile }
+import java.io.{ InputStream, OutputStream }
 
 import effekt.util.messages.FatalPhaseError
 import org.eclipse.lsp4j.jsonrpc.Launcher

--- a/jvm/src/main/scala/effekt/Driver.scala
+++ b/jvm/src/main/scala/effekt/Driver.scala
@@ -130,6 +130,21 @@ trait Driver extends CompilerWithConfig[Tree, ModuleDecl, EffektConfig] { outer 
    * server on port 5007 instead of stdin and out. This way a modified
    * vscode client can connect to the running server, aiding development
    * of the language server and clients.
+   *
+   * In a vscode extension, the vscode client can connect to the server using
+   * the following example code:
+   *
+   *   let serverOptions = () => {
+   *     // Connect to language server via socket
+   *     let socket: any = net.connect({ port: 5007 });
+   *     let result: StreamInfo = {
+   *       writer: socket,
+   *       reader: socket
+   *     };
+   *     return Promise.resolve(result);
+   *   };
+   *
+   * @see https://github.com/microsoft/language-server-protocol/issues/160
    */
   override def launch(config: EffektConfig): Unit = {
     if (config.debug()) {

--- a/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -91,6 +91,8 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
 
   def requiresCompilation(): Boolean = !server()
 
+  def requiresLift(): Boolean = generator().endsWith("lift")
+
   def interpret(): Boolean = !server() && !compile()
 
   validateFilesIsDirectory(includePath)

--- a/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import effekt.util.paths.file
 import org.bitbucket.inkytonik.kiama.util.REPLConfig
-import org.rogach.scallop.{ ScallopOption, ValueConverter }
+import org.rogach.scallop.ScallopOption
 
 class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
 

--- a/jvm/src/main/scala/effekt/Server.scala
+++ b/jvm/src/main/scala/effekt/Server.scala
@@ -133,7 +133,7 @@ trait LSPServer extends Driver with Intelligence {
     pos <- positions.getStart(fun)
     ret <- fun.ret
     // the inferred type
-    tpe <- C.inferredTypeOf(fun)
+    tpe <- C.inferredTypeOption(fun)
     // the annotated type
     ann = fun.symbol.ret
     if ann.map { a => needsUpdate(a, tpe) }.getOrElse(true)
@@ -146,8 +146,8 @@ trait LSPServer extends Driver with Intelligence {
 
   def closeHoleAction(hole: Hole)(implicit C: Context): Option[TreeAction] = for {
     pos <- positions.getStart(hole)
-    (holeTpe / _) <- C.inferredTypeOf(hole)
-    (contentTpe / _) <- C.inferredTypeOf(hole.stmts)
+    (holeTpe / _) <- C.inferredTypeOption(hole)
+    (contentTpe / _) <- C.inferredTypeOption(hole.stmts)
     if holeTpe == contentTpe
     res <- hole match {
       case Hole(source.Return(exp)) => for {

--- a/jvm/src/main/scala/effekt/Server.scala
+++ b/jvm/src/main/scala/effekt/Server.scala
@@ -32,7 +32,7 @@ trait LSPServer extends Driver with Intelligence {
    */
   override def afterCompilation(source: Source, config: EffektConfig)(implicit C: Context): Unit = {
     super.afterCompilation(source, config)
-    for (mod <- C.frontend(source); core <- C.lower(source); js <- C.generate(source)) {
+    for (mod <- C.frontend(source); core <- C.backend(source); js <- C.generate(source)) {
 
       if (C.config.server() && settingBool("showCore")) {
         publishProduct(source, "target", "effekt", prettyCore.format(core))

--- a/shared/src/main/scala/effekt/Compiler.scala
+++ b/shared/src/main/scala/effekt/Compiler.scala
@@ -20,31 +20,55 @@ import kiama.util.{ Positions, Source }
  * We distinguish between Phases and Tasks. Phases, by default, perform no memoization
  * while task use the "build system" abstraction in `Task`, track dependencies and
  * avoid rebuilding by memoization.
+ *
+ * The Compiler is set up in the following large tasks that consist of potentially multiple phases
+ *
+ * (1) Parser    (Source      -> source.Tree)  Load file and parse it into an AST
+ *
+ * (2) Frontend  (source.Tree -> source.Tree)  Perform name analysis, typechecking, and other
+ *                                             rewriting of the source AST
+ *
+ * (3) Backend   (source.Tree -> core.Tree)    Perform an ANF transformation into core, and
+ *                                             other rewritings on the core AST
+ *
+ * (4) Code Gen  (core.Tree   -> Document)     Generate code in a target language
+ *
  */
 trait Compiler {
 
   val positions: Positions
 
-  // Frontend phases
-  // ===============
 
-  // The parser needs to be created freshly since otherwise the memo tables will maintain wrong results for
-  // new input sources. Even though the contents differ, two sources are considered equal since only the paths are
-  // compared.
+  /**
+   * (1) Parser
+   *
+   * Note: The parser needs to be created freshly since otherwise the memo tables will maintain wrong results for
+   * new input sources. Even though the contents differ, two sources are considered equal since only the paths are
+   * compared.
+   */
   def parser = new Parser(positions)
 
+  /**
+   * (2) Frontend
+   */
   val frontendPhases: List[Phase[ModuleDecl, ModuleDecl]] = List(
     new Namer,
     new Typer,
     new CapabilityPassing
   )
 
-  // Backend phases
-  // ==============
+  /**
+   * (3) Backend
+   */
   object transformer extends Transformer
-  object lifter extends LiftInference
+  val backendPhases: List[Phase[core.ModuleDecl, core.ModuleDecl]] = List(
+    new LiftInference
+  )
 
-  def generatorPhase(implicit C: Context) = C.config.generator() match {
+  /**
+   * (4) Code Generation
+   */
+  def codeGenerator(implicit C: Context) = C.config.generator() match {
     case "js"           => new effekt.generator.JavaScript
     case "js-lift"      => new effekt.generator.JavaScriptLift
     case "chez-callcc"  => new effekt.generator.ChezSchemeCallCC
@@ -72,24 +96,19 @@ trait Compiler {
     } yield mod.setAst(transformedAst)
   }
 
-  object lower extends SourceTask[core.ModuleDecl]("lower") {
+  object backend extends SourceTask[core.ModuleDecl]("backend") {
     def run(source: Source)(implicit C: Context): Option[core.ModuleDecl] = for {
       mod <- frontend(source)
       core <- C.using(module = mod) { transformer(mod) }
-    } yield core
-  }
-
-  object inferLifts extends SourceTask[core.ModuleDecl]("lifts") {
-    def run(source: Source)(implicit C: Context): Option[core.ModuleDecl] = for {
-      mod <- frontend(source)
-      core <- lower(source)
-      lifted <- C.using(module = mod) { lifter(core) }
-    } yield lifted
+      transformed <- C.using(module = mod) {
+        Phase.run(core, backendPhases)
+      }
+    } yield transformed
   }
 
   object generate extends SourceTask[Document]("generate") {
     def run(source: Source)(implicit C: Context): Option[Document] =
-      generatorPhase.apply(source)
+      codeGenerator.apply(source)
   }
 
   /**

--- a/shared/src/main/scala/effekt/Compiler.scala
+++ b/shared/src/main/scala/effekt/Compiler.scala
@@ -50,8 +50,11 @@ trait Compiler {
    * (2) Frontend
    */
   val frontendPhases: List[Phase[ModuleDecl, ModuleDecl]] = List(
+    // performs name analysis and associates Id-trees with symbols
     new Namer,
+    // type checks and annotates trees with inferred types and effects
     new Typer,
+    // uses annotated effects to translate to explicit capability passing
     new CapabilityPassing
   )
 
@@ -60,6 +63,7 @@ trait Compiler {
    */
   object transformer extends Transformer
   val backendPhases: List[Phase[core.ModuleDecl, core.ModuleDecl]] = List(
+    // optional phase, only run for `Config.requiresLift`
     new LiftInference
   )
 

--- a/shared/src/main/scala/effekt/Compiler.scala
+++ b/shared/src/main/scala/effekt/Compiler.scala
@@ -5,7 +5,6 @@ import effekt.core.{ LiftInference, Transformer }
 import effekt.namer.Namer
 import effekt.source.{ CapabilityPassing, ModuleDecl }
 import effekt.symbols.Module
-import effekt.generator.{ ChezSchemeCallCC, ChezSchemeLift, ChezSchemeMonadic, Generator, JavaScript, JavaScriptLift }
 import effekt.typer.Typer
 import effekt.util.{ SourceTask, VirtualSource }
 import org.bitbucket.inkytonik.kiama
@@ -37,7 +36,6 @@ import kiama.util.{ Positions, Source }
 trait Compiler {
 
   val positions: Positions
-
 
   /**
    * (1) Parser

--- a/shared/src/main/scala/effekt/Compiler.scala
+++ b/shared/src/main/scala/effekt/Compiler.scala
@@ -3,7 +3,7 @@ package effekt
 import effekt.context.Context
 import effekt.core.{ LiftInference, Transformer }
 import effekt.namer.Namer
-import effekt.source.ModuleDecl
+import effekt.source.{ CapabilityPassing, ModuleDecl }
 import effekt.symbols.Module
 import effekt.generator.{ ChezSchemeCallCC, ChezSchemeLift, ChezSchemeMonadic, Generator, JavaScript, JavaScriptLift }
 import effekt.typer.Typer
@@ -38,6 +38,7 @@ trait Compiler {
   // Backend phases
   // ==============
   object transformer extends Transformer
+  object capabilityPassing extends CapabilityPassing
   object lifter extends LiftInference
 
   def generatorPhase(implicit C: Context) = C.config.generator() match {

--- a/shared/src/main/scala/effekt/Compiler.scala
+++ b/shared/src/main/scala/effekt/Compiler.scala
@@ -34,11 +34,11 @@ trait Compiler {
   def parser = new Parser(positions)
   object namer extends Namer
   object typer extends Typer
+  object capabilityPassing extends CapabilityPassing
 
   // Backend phases
   // ==============
   object transformer extends Transformer
-  object capabilityPassing extends CapabilityPassing
   object lifter extends LiftInference
 
   def generatorPhase(implicit C: Context) = C.config.generator() match {

--- a/shared/src/main/scala/effekt/Intelligence.scala
+++ b/shared/src/main/scala/effekt/Intelligence.scala
@@ -86,8 +86,8 @@ trait Intelligence {
   }
 
   def getHoleInfo(hole: source.Hole)(implicit C: Context): Option[String] = for {
-    outerTpe <- C.inferredTypeOf(hole)
-    innerTpe <- C.inferredTypeOf(hole.stmts)
+    outerTpe <- C.inferredTypeOption(hole)
+    innerTpe <- C.inferredTypeOption(hole.stmts)
   } yield s"""| | Outside       | Inside        |
               | |:------------- |:------------- |
               | | `${outerTpe}` | `${innerTpe}` |

--- a/shared/src/main/scala/effekt/Namer.scala
+++ b/shared/src/main/scala/effekt/Namer.scala
@@ -5,12 +5,10 @@ package namer
  * In this file we fully qualify source types, but use symbols directly
  */
 import effekt.context.{ Context, ContextOps }
-import effekt.context.assertions.{ SymbolAssertions, TypeAssertions }
+import effekt.context.assertions.SymbolAssertions
 import effekt.source.{ Def, Id, Tree, ModuleDecl }
 import effekt.symbols._
-import effekt.util.Task
 import scopes._
-import org.bitbucket.inkytonik.kiama.util.Source
 
 /**
  * The output of this phase: a mapping from source identifier to symbol

--- a/shared/src/main/scala/effekt/Namer.scala
+++ b/shared/src/main/scala/effekt/Namer.scala
@@ -169,7 +169,7 @@ class Namer extends Phase[Module, Module] {
       Context scoped { resolveGeneric(body) }
       resolveAll(handlers)
 
-    case source.Handler(name, clauses) =>
+    case source.Handler(name, _, clauses) =>
       val eff = Context.at(name) { Context.resolveType(name) }.asUserEffect
 
       clauses.foreach {
@@ -198,9 +198,9 @@ class Namer extends Phase[Module, Module] {
       }
 
     case source.BlockArg(params, stmt) =>
-      val ps = resolve(params)
+      val ps = params.map(resolve)
       Context scoped {
-        Context.bind(List(ps))
+        Context.bind(ps)
         resolveGeneric(stmt)
       }
 

--- a/shared/src/main/scala/effekt/Namer.scala
+++ b/shared/src/main/scala/effekt/Namer.scala
@@ -266,6 +266,10 @@ class Namer extends Phase[Module, Module] {
       val sym = BlockParam(Name(id), resolve(tpe))
       Context.assignSymbol(id, sym)
       List(sym)
+    case source.CapabilityParam(id, tpe) =>
+      val sym = CapabilityParam(Name(id), resolve(tpe))
+      Context.assignSymbol(id, sym)
+      List(sym)
   }
   def resolve(ps: source.ValueParams)(implicit C: Context): List[ValueParam] =
     ps.params map { p =>
@@ -400,10 +404,14 @@ class Namer extends Phase[Module, Module] {
       TypeApp(data, args.map(resolve))
     case source.TypeVar(id) =>
       Context.resolveType(id).asValueType
+    case source.ValueTypeTree(tpe) => tpe
   }
 
   def resolve(tpe: source.BlockType)(implicit C: Context): BlockType =
     BlockType(Nil, List(tpe.params.map(resolve)), resolve(tpe.ret))
+
+  def resolve(tpe: source.CapabilityType)(implicit C: Context): CapabilityType =
+    CapabilityType(tpe.eff)
 
   def resolve(tpe: source.Effect)(implicit C: Context): Effect =
     Context.resolveType(tpe.id).asEffect

--- a/shared/src/main/scala/effekt/Phase.scala
+++ b/shared/src/main/scala/effekt/Phase.scala
@@ -24,3 +24,10 @@ trait Phase[In, Out] {
    */
   def Context(implicit ctx: Context): Context = ctx
 }
+
+object Phase {
+  def run[A](a: A, phases: List[Phase[A, A]])(implicit C: Context): Option[A] =
+    phases.foldLeft[Option[A]](Some(a)) {
+      case (prev, phase) => prev.flatMap { a => phase(a) }
+    }
+}

--- a/shared/src/main/scala/effekt/Substitution.scala
+++ b/shared/src/main/scala/effekt/Substitution.scala
@@ -19,6 +19,9 @@ object subtitutions {
 
     def getUnifier(implicit error: ErrorReporter): Unifier = this
 
+    def addAll(unifier: Map[TypeVar, ValueType]): Unifier =
+      Unifier(substitutions ++ unifier)
+
     def add(k: TypeVar, v: ValueType): UnificationResult = {
       substitutions.get(k).foreach { v2 =>
         if (v != v2) {

--- a/shared/src/main/scala/effekt/Substitution.scala
+++ b/shared/src/main/scala/effekt/Substitution.scala
@@ -1,6 +1,6 @@
 package effekt
 
-import effekt.symbols.{ Type, ValueType, RigidVar, TypeVar, BlockType, Effectful, TypeApp, Sections }
+import effekt.symbols.{ Type, ValueType, RigidVar, TypeVar, BlockType, CapabilityType, InterfaceType, Effectful, TypeApp, Sections }
 import effekt.symbols.builtins.THole
 
 import effekt.util.messages.ErrorReporter
@@ -48,8 +48,9 @@ object subtitutions {
       rigids.filterNot { substitutions.isDefinedAt }
 
     def substitute(t: Type): Type = t match {
-      case t: ValueType => substitute(t)
-      case b: BlockType => substitute(b)
+      case t: ValueType      => substitute(t)
+      case b: BlockType      => substitute(b)
+      case b: CapabilityType => b
     }
 
     def substitute(t: ValueType): ValueType = t match {
@@ -64,7 +65,8 @@ object subtitutions {
       case Effectful(tpe, effs) => Effectful(substitute(tpe), effs)
     }
 
-    def substitute(t: BlockType): BlockType = t match {
+    def substitute(t: InterfaceType): InterfaceType = t match {
+      case b: CapabilityType => b
       case BlockType(tps, ps, ret) =>
         val substWithout = Unifier(substitutions.filterNot { case (t, _) => ps.contains(t) })
         BlockType(tps, substWithout.substitute(ps), substWithout.substitute(ret))
@@ -72,8 +74,8 @@ object subtitutions {
 
     def substitute(t: Sections): Sections = t map {
       _ map {
-        case v: ValueType => substitute(v)
-        case b: BlockType => substitute(b)
+        case v: ValueType     => substitute(v)
+        case b: InterfaceType => substitute(b)
       }
     }
   }

--- a/shared/src/main/scala/effekt/Substitution.scala
+++ b/shared/src/main/scala/effekt/Substitution.scala
@@ -94,7 +94,7 @@ object subtitutions {
     def checkFullyDefined(rigids: List[RigidVar]) = this
   }
 
-  object Substitution {
+  object Unification {
 
     // just for backwards compat
     def unify(tpe1: Type, tpe2: Type)(implicit C: ErrorReporter): Unifier =

--- a/shared/src/main/scala/effekt/Typer.scala
+++ b/shared/src/main/scala/effekt/Typer.scala
@@ -106,7 +106,7 @@ class Typer extends Phase[Module, Module] { typer =>
         checkOverloadedCall(c, targs map { resolveValueType }, args, expected)
 
       case c @ source.MethodCall(b, fun, targs, args) =>
-        ???
+        Context.panic("Method call syntax not allowed in source programs.")
 
       case source.TryHandle(prog, handlers) =>
 
@@ -267,7 +267,7 @@ class Typer extends Phase[Module, Module] { typer =>
             case (pat, par: ValueType) =>
               bindings ++= checkPattern(par, pat)
             case _ =>
-              sys error "Should not happen, since constructors can only take value parameters"
+              Context.panic("Should not happen, since constructors can only take value parameters")
           }
       }
       bindings
@@ -398,7 +398,7 @@ class Typer extends Phase[Module, Module] { typer =>
   def extractTypes(params: List[Param])(implicit C: Context): List[Type] = params map {
     case BlockParam(_, tpe) => tpe
     case ValueParam(_, Some(tpe)) => tpe
-    case _ => Context.abort("Cannot extract type")
+    case _ => Context.panic("Cannot extract type")
   }
 
   /**
@@ -416,7 +416,7 @@ class Typer extends Phase[Module, Module] { typer =>
 
     (atCallee zip atCaller).flatMap[(Symbol, Type)] {
       case (List(b1: BlockType), b2: source.BlockParam) =>
-        Context.at(b2) { Context.abort("Internal Compiler Error: Not yet supported") }
+        Context.at(b2) { Context.panic("Internal Compiler Error: Not yet supported") }
         ???
 
       case (ps1: List[ValueType @unchecked], source.ValueParams(ps2)) =>
@@ -751,7 +751,7 @@ trait TyperOps extends ContextOps { self: Context =>
     bs foreach {
       case (v: ValueSymbol, t: ValueType) => define(v, t)
       case (v: BlockSymbol, t: BlockType) => define(v, t)
-      case other => abort(s"Internal Error: wrong combination of symbols and types: ${other}")
+      case other => panic(s"Internal Error: wrong combination of symbols and types: ${other}")
     }; this
   }
 
@@ -759,7 +759,7 @@ trait TyperOps extends ContextOps { self: Context =>
     ps.flatten.foreach {
       case s @ ValueParam(name, Some(tpe)) => define(s, tpe)
       case s @ BlockParam(name, tpe) => define(s, tpe)
-      case s => abort(s"Internal Error: Cannot add $s to context.")
+      case s => panic(s"Internal Error: Cannot add $s to context.")
     }
     this
   }

--- a/shared/src/main/scala/effekt/Typer.scala
+++ b/shared/src/main/scala/effekt/Typer.scala
@@ -436,7 +436,7 @@ class Typer extends Phase[Module, Module] { typer =>
   }
 
   /**
-   * Attempts to check the call to sym, not reporting any errors but returning them instead.
+   * Attempts to check a potentially overladed call, not reporting any errors but returning them instead.
    *
    * This is necessary for overload resolution by trying all alternatives.
    *   - if there is multiple without errors: Report ambiguity
@@ -592,8 +592,6 @@ class Typer extends Phase[Module, Module] { typer =>
       val (tpe2 / exprEffs) = arg checkAgainst tpe1
 
       // Update substitution with new information
-      // TODO Trying to unify here yields the same type error as the previous line, again.
-      // For now we have to live with this duplicated messages
       subst = (subst union Substitution.unify(tpe1, tpe2)).getUnifier
 
       effs = effs ++ exprEffs
@@ -607,7 +605,6 @@ class Typer extends Phase[Module, Module] { typer =>
     def checkBlockArgument(tpe: BlockType, arg: source.BlockArg): Unit = Context.at(arg) {
       val BlockType(Nil, params, tpe1 / handled) = subst substitute tpe
 
-      // TODO make blockargs also take multiple argument sections.
       Context.define {
         checkAgainstDeclaration("block", params, arg.params)
       }

--- a/shared/src/main/scala/effekt/Typer.scala
+++ b/shared/src/main/scala/effekt/Typer.scala
@@ -5,8 +5,8 @@ package typer
  * In this file we fully qualify source types, but use symbols directly
  */
 import effekt.context.{ Annotations, Context, ContextOps }
-import effekt.context.assertions.{ SymbolAssertions }
-import effekt.source.{ AnyPattern, Def, Expr, IgnorePattern, MatchPattern, Stmt, TagPattern, Tree }
+import effekt.context.assertions.SymbolAssertions
+import effekt.source.{ AnyPattern, Def, Expr, IgnorePattern, MatchPattern, ModuleDecl, Stmt, TagPattern, Tree }
 import effekt.subtitutions._
 import effekt.symbols._
 import effekt.symbols.builtins._
@@ -37,11 +37,10 @@ case class TyperState(
   def deepCopy(): TyperState = TyperState(effects, annotations.copy)
 }
 
-class Typer extends Phase[Module, Module] { typer =>
+class Typer extends Phase[ModuleDecl, ModuleDecl] { typer =>
 
-  def run(mod: Module)(implicit C: Context): Option[Module] = try {
-
-    val module = mod.decl
+  def run(module: ModuleDecl)(implicit C: Context): Option[ModuleDecl] = try {
+    val mod = Context.module
 
     // Effects that are lexically in scope at the top level
     val toplevelEffects = mod.imports.foldLeft(mod.effects) { _ ++ _.effects }
@@ -63,7 +62,7 @@ class Typer extends Phase[Module, Module] { typer =>
     if (C.buffer.hasErrors) {
       None
     } else {
-      Some(mod)
+      Some(module)
     }
   } finally {
     // Store the backtrackable annotations into the global DB

--- a/shared/src/main/scala/effekt/Typer.scala
+++ b/shared/src/main/scala/effekt/Typer.scala
@@ -105,6 +105,9 @@ class Typer extends Phase[Module, Module] { typer =>
       case c @ source.Call(fun, targs, args) =>
         checkOverloadedCall(c, targs map { resolveValueType }, args, expected)
 
+      case c @ source.MethodCall(b, fun, targs, args) =>
+        ???
+
       case source.TryHandle(prog, handlers) =>
 
         val (ret / effs) = checkStmt(prog, expected)
@@ -384,6 +387,7 @@ class Typer extends Phase[Module, Module] { typer =>
   def resolveValueType(tpe: source.ValueType)(implicit C: Context): ValueType = tpe match {
     case t @ source.TypeApp(id, args) => TypeApp(t.definition, args.map(resolveValueType))
     case t @ source.TypeVar(id)       => t.definition
+    case source.ValueTypeTree(tpe)    => tpe
   }
 
   /**
@@ -739,7 +743,7 @@ trait TyperOps extends ContextOps { self: Context =>
     assignType(s, t); this
   }
 
-  private[typer] def define(s: Symbol, t: BlockType): Context = {
+  private[typer] def define(s: Symbol, t: InterfaceType): Context = {
     assignType(s, t); this
   }
 

--- a/shared/src/main/scala/effekt/Typer.scala
+++ b/shared/src/main/scala/effekt/Typer.scala
@@ -538,7 +538,9 @@ class Typer extends Phase[Module, Module] { typer =>
 
     // (1) Instantiate blocktype
     // e.g. `[A, B] (A, A) => B` becomes `(?A, ?A) => ?B`
-    val (rigids, BlockType(_, params, ret / retEffs)) = Substitution.instantiate(Context.blockTypeOf(sym))
+    val (rigids, BlockType(_, params, ret / retEffs)) = Substitution.instantiate(Context.blockTypeOption(sym).getOrElse {
+      Context.abort(s"Cannot find type for ${sym.name} -- if it is a recursive definition try to annotate the return type.")
+    })
 
     if (targs.nonEmpty && targs.size != rigids.size)
       Context.abort(s"Wrong number of type arguments ${targs.size}")

--- a/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/shared/src/main/scala/effekt/context/Annotations.scala
@@ -92,7 +92,7 @@ object Annotations {
   /**
    * Block type of symbols like function definitions, block parameters, or continuations
    */
-  val BlockType = Annotation[symbols.BlockSymbol, symbols.BlockType](
+  val BlockType = Annotation[symbols.BlockSymbol, symbols.InterfaceType](
     "BlockType",
     "the type of block symbol"
   )
@@ -183,7 +183,7 @@ trait AnnotationsDB { self: Context =>
 
   // Customized Accessors
   // ====================
-  import symbols.{ Symbol, Type, ValueType, BlockType, ValueSymbol, BlockSymbol, Effectful, Module }
+  import symbols.{ Symbol, Type, ValueType, BlockType, InterfaceType, ValueSymbol, BlockSymbol, Effectful, Module }
 
   // Types
   // -----
@@ -200,7 +200,7 @@ trait AnnotationsDB { self: Context =>
     }
 
   // TODO maybe move to TyperOps
-  def assignType(s: Symbol, tpe: BlockType): Unit = s match {
+  def assignType(s: Symbol, tpe: InterfaceType): Unit = s match {
     case b: BlockSymbol => annotate(Annotations.BlockType, b, tpe)
     case _              => abort(s"Trying to store a block type for non block '${s}'")
   }
@@ -221,8 +221,11 @@ trait AnnotationsDB { self: Context =>
 
   def blockTypeOption(s: Symbol): Option[BlockType] =
     s match {
-      case b: BlockSymbol => annotationOption(Annotations.BlockType, b)
-      case _              => abort(s"Trying to find a block type for non block '${s}'")
+      case b: BlockSymbol => annotationOption(Annotations.BlockType, b) flatMap {
+        case b: BlockType => Some(b)
+        case _            => None
+      }
+      case _ => abort(s"Trying to find a block type for non block '${s}'")
     }
 
   def valueTypeOf(s: Symbol): ValueType =

--- a/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/shared/src/main/scala/effekt/context/Annotations.scala
@@ -188,6 +188,9 @@ trait AnnotationsDB { self: Context =>
   // Types
   // -----
 
+  def typeArguments(c: source.Call): List[symbols.Type] =
+    annotation(Annotations.TypeArguments, c)
+
   def inferredTypeOption(t: source.Tree): Option[Effectful] =
     annotationOption(Annotations.TypeAndEffect, t)
 

--- a/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/shared/src/main/scala/effekt/context/Annotations.scala
@@ -158,6 +158,15 @@ trait AnnotationsDB { self: Context =>
   private def annotationsAt(key: Any): Annotations = annotations.getOrDefault(key, Map.empty)
 
   /**
+   * Copies annotations, keeping existing annotations at `to`
+   */
+  def copyAnnotations(from: Any, to: Any): Unit = {
+    val existing = annotationsAt(to)
+    val source = annotationsAt(from)
+    annotate(to, source ++ existing)
+  }
+
+  /**
    * Bulk annotating the key
    *
    * Used by Annotations.commit to commit all temporary annotations to the DB

--- a/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/shared/src/main/scala/effekt/context/Annotations.scala
@@ -188,8 +188,13 @@ trait AnnotationsDB { self: Context =>
   // Types
   // -----
 
-  def inferredTypeOf(t: source.Tree): Option[Effectful] =
+  def inferredTypeOption(t: source.Tree): Option[Effectful] =
     annotationOption(Annotations.TypeAndEffect, t)
+
+  def inferredTypeOf(t: source.Tree): Effectful =
+    inferredTypeOption(t).getOrElse {
+      abort(s"Internal Error: Missing type of source expression: '${t}'")
+    }
 
   // TODO maybe move to TyperOps
   def assignType(s: Symbol, tpe: BlockType): Unit = s match {

--- a/shared/src/main/scala/effekt/context/Assertions.scala
+++ b/shared/src/main/scala/effekt/context/Assertions.scala
@@ -80,7 +80,11 @@ object assertions {
     }
     def asTermSymbol: TermSymbol = s match {
       case t: TermSymbol => t
-      case _ => reporter.abort("Expected a term symbol")
+      case _ => reporter.panic("Expected a term symbol")
+    }
+    def asBlockSymbol: BlockSymbol = s match {
+      case t: BlockSymbol => t
+      case _ => reporter.panic("Expected a term symbol")
     }
   }
 

--- a/shared/src/main/scala/effekt/context/Context.scala
+++ b/shared/src/main/scala/effekt/context/Context.scala
@@ -1,10 +1,10 @@
 package effekt
 package context
 
-import effekt.core.{ TransformerOps, TransformerState }
+import effekt.core.{ TransformerOps }
 import effekt.namer.{ NamerOps, NamerState }
 import effekt.typer.{ TyperOps, TyperState }
-import effekt.source.Tree
+import effekt.source.{ CapabilityPassingOps, Tree }
 import effekt.util.messages.{ ErrorReporter, MessageBuffer }
 import effekt.symbols.Module
 import org.bitbucket.inkytonik.kiama.util.Messaging.Messages
@@ -45,6 +45,7 @@ abstract class Context(val positions: Positions)
     // Typer
     with TyperOps
     // Transformer
+    with CapabilityPassingOps
     with TransformerOps {
 
   // bring the context itself in scope

--- a/shared/src/main/scala/effekt/context/Context.scala
+++ b/shared/src/main/scala/effekt/context/Context.scala
@@ -1,9 +1,10 @@
 package effekt
 package context
 
-import effekt.core.{ TransformerOps }
-import effekt.namer.{ NamerOps, NamerState }
-import effekt.typer.{ TyperOps, TyperState }
+import effekt.namer.NamerOps
+import effekt.typer.TyperOps
+import effekt.core.TransformerOps
+
 import effekt.source.{ CapabilityPassingOps, Tree }
 import effekt.util.messages.{ ErrorReporter, MessageBuffer }
 import effekt.symbols.Module

--- a/shared/src/main/scala/effekt/context/ModuleDB.scala
+++ b/shared/src/main/scala/effekt/context/ModuleDB.scala
@@ -2,10 +2,7 @@ package effekt
 package context
 
 import effekt.symbols.Module
-import effekt.util.Task
 import org.bitbucket.inkytonik.kiama.util.Source
-
-import scala.collection.mutable
 
 /**
  * The ModuleDB depends on three things:

--- a/shared/src/main/scala/effekt/core/LiftInference.scala
+++ b/shared/src/main/scala/effekt/core/LiftInference.scala
@@ -7,7 +7,11 @@ import effekt.context.Context
 class LiftInference extends Phase[ModuleDecl, ModuleDecl] {
 
   def run(mod: ModuleDecl)(implicit C: Context): Option[ModuleDecl] =
-    Some(transform(mod)(Environment(Map.empty), C))
+    if (C.config.requiresLift()) {
+      Some(transform(mod)(Environment(Map.empty), C))
+    } else {
+      Some(mod)
+    }
 
   // TODO either resolve and bind imports or use the knowledge that they are toplevel!
   def transform(mod: ModuleDecl)(implicit env: Environment, C: Context): ModuleDecl =

--- a/shared/src/main/scala/effekt/core/LiftInference.scala
+++ b/shared/src/main/scala/effekt/core/LiftInference.scala
@@ -22,8 +22,8 @@ class LiftInference extends Phase[ModuleDecl, ModuleDecl] {
 
       // recursive functions need to bind the own id
       val extendedEnv = params.foldLeft(ownBindings.adapt(ScopeVar(id))) {
-        case (env, BlockParam(p)) => env.bind(p)
-        case (env, ValueParam(p)) => env
+        case (env, BlockParam(p, tpe)) => env.bind(p)
+        case (env, ValueParam(p, tpe)) => env
       }
       ScopeAbs(id, BlockLit(params, transform(body)(extendedEnv, C)))
     case Member(body, id) => ??? // Member(transform(body), id)
@@ -31,14 +31,14 @@ class LiftInference extends Phase[ModuleDecl, ModuleDecl] {
   }
 
   def transform(tree: Stmt)(implicit env: Environment, C: Context): Stmt = tree match {
-    case Def(id, block, rest) =>
-      Def(id, transform(block, Some(id)), transform(rest)(env.bind(id), C))
+    case Def(id, tpe, block, rest) =>
+      Def(id, tpe, transform(block, Some(id)), transform(rest)(env.bind(id), C))
 
-    case Val(id, binding, body) =>
-      Val(id, transform(binding), transform(body))
+    case Val(id, tpe, binding, body) =>
+      Val(id, tpe, transform(binding), transform(body))
 
-    case State(id, get, put, init, body) =>
-      State(id, get, put, transform(init), transform(body))
+    case State(id, tpe, get, put, init, body) =>
+      State(id, tpe, get, put, transform(init), transform(body))
 
     case Data(id, ctors, rest) =>
       Data(id, ctors, transform(rest))
@@ -51,14 +51,14 @@ class LiftInference extends Phase[ModuleDecl, ModuleDecl] {
       val transformedHandler = handler.map { transform }
       Handle(transformedBody, transformedHandler)
 
-    case App(b: Block, args: List[Argument]) => b match {
-      case b: Extern => App(b, liftArguments(args))
+    case App(b: Block, targs, args: List[Argument]) => b match {
+      case b: Extern => App(b, targs, liftArguments(args))
       // TODO also for "pure" and "toplevel" functions
-      case b: BlockVar if b.id.builtin => App(b, liftArguments(args))
+      case b: BlockVar if b.id.builtin => App(b, targs, liftArguments(args))
 
       // [[ Eff.op(arg) ]] = Eff(ev).op(arg)
-      case Member(b, field) => App(Member(ScopeApp(transform(b), env.evidenceFor(b)), field), liftArguments(args))
-      case b => App(ScopeApp(transform(b), env.evidenceFor(b)), liftArguments(args))
+      case Member(b, field) => App(Member(ScopeApp(transform(b), env.evidenceFor(b)), field), targs, liftArguments(args))
+      case b => App(ScopeApp(transform(b), env.evidenceFor(b)), targs, liftArguments(args))
     }
 
     // TODO either the implementation of match should provide evidence

--- a/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -42,7 +42,7 @@ class PrettyPrinter extends ParenPrettyPrinter {
     case l: Literal[t] => l.value.toString
     case ValueVar(id)  => id.name.toString
 
-    case PureApp(b, args) => toDoc(b) <> parens(hsep(args map {
+    case PureApp(b, targs, args) => toDoc(b) <> parens(hsep(args map {
       case e: Expr  => toDoc(e)
       case b: Block => toDoc(b)
     }, comma))
@@ -67,11 +67,11 @@ class PrettyPrinter extends ParenPrettyPrinter {
   // pretty print the statement in a javascript expression context
   // not all statement types can be printed in this context!
   def toDocExpr(s: Stmt): Doc = s match {
-    case Val(Wildcard(_), binding, body) =>
+    case Val(Wildcard(_), tpe, binding, body) =>
       toDoc(binding) <> ";" <> line <> toDoc(body)
-    case Val(id, binding, body) =>
+    case Val(id, tpe, binding, body) =>
       "val" <+> toDoc(id.name) <+> "=" <+> toDoc(binding) <> ";" <> line <> toDoc(body)
-    case App(b, args) =>
+    case App(b, targs, args) =>
       toDoc(b) <> parens(hsep(args map argToDoc, comma))
     case If(cond, thn, els) =>
       "if" <+> parens(toDoc(cond)) <+> toDocExpr(thn) <+> "else" <+> toDocExpr(els)
@@ -89,7 +89,7 @@ class PrettyPrinter extends ParenPrettyPrinter {
       }
       val cs = parens("[" <> hsep(handlers, comma) <> "]")
       "handle" <+> braces(nest(line <> toDoc(body)) <> line) <+> "with" <+> cs
-    case State(id, get, put, init, body) =>
+    case State(id, tpe, get, put, init, body) =>
       "state" <+> parens(toDoc(init)) <+> braces(nest(line <> toDoc(body)) <> line)
 
     case Match(sc, clauses) =>
@@ -109,11 +109,11 @@ class PrettyPrinter extends ParenPrettyPrinter {
   }
 
   def toDocStmt(s: Stmt): Doc = s match {
-    case Def(id, Extern(ps, body), rest) =>
+    case Def(id, tpe, Extern(ps, body), rest) =>
       "extern def" <+> toDoc(id.name) <+> "=" <+> parens(hsep(ps map toDoc, comma)) <+> "=>" <+>
         braces(nest(body) <> line) <> emptyline <> toDocStmt(rest)
 
-    case Def(id, b, rest) =>
+    case Def(id, tpe, b, rest) =>
       "def" <+> toDoc(id.name) <+> "=" <+> toDoc(b) <> emptyline <> toDocStmt(rest)
 
     case Data(did, ctors, rest) =>
@@ -133,7 +133,7 @@ class PrettyPrinter extends ParenPrettyPrinter {
 
   def requiresBlock(s: Stmt): Boolean = s match {
     case Data(did, ctors, rest) => true
-    case Def(id, d, rest) => true
+    case Def(id, tpe, d, rest) => true
     case _ => false
   }
 

--- a/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -70,7 +70,7 @@ class PrettyPrinter extends ParenPrettyPrinter {
     case Val(Wildcard(_), tpe, binding, body) =>
       toDoc(binding) <> ";" <> line <> toDoc(body)
     case Val(id, tpe, binding, body) =>
-      "val" <+> toDoc(id.name) <+> "=" <+> toDoc(binding) <> ";" <> line <> toDoc(body)
+      "val" <+> toDoc(id.name) <+> ":" <+> tpe.toString <+> "=" <+> toDoc(binding) <> ";" <> line <> toDoc(body)
     case App(b, targs, args) =>
       toDoc(b) <> parens(hsep(args map argToDoc, comma))
     case If(cond, thn, els) =>

--- a/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -4,7 +4,7 @@ package core
 import org.bitbucket.inkytonik.kiama.output.ParenPrettyPrinter
 
 import scala.language.implicitConversions
-import effekt.symbols.{ builtins, Name }
+import effekt.symbols.{ builtins, Name, Wildcard }
 
 class PrettyPrinter extends ParenPrettyPrinter {
 

--- a/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/shared/src/main/scala/effekt/core/Transformer.scala
@@ -14,10 +14,7 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
   }
 
   def transform(mod: Module)(implicit C: Context): ModuleDecl = {
-    // use capability passing transform
-    val Some(modCPS) = C.capabilityPassing(mod.decl)
-
-    val source.ModuleDecl(path, imports, defs) = modCPS
+    val source.ModuleDecl(path, imports, defs) = mod.ast
     val exports: Stmt = Exports(path, mod.terms.flatMap {
       case (name, syms) => syms.collect {
         // TODO export valuebinders properly

--- a/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/shared/src/main/scala/effekt/core/Transformer.scala
@@ -4,10 +4,8 @@ package core
 import scala.collection.mutable.ListBuffer
 
 import effekt.context.Context
-import effekt.context.assertions.SymbolAssertions
 import effekt.symbols._
-import effekt.util.{ Task, control }
-import effekt.util.control._
+import effekt.util.Task
 
 case class Wildcard(module: Module) extends ValueSymbol { val name = Name("_", module) }
 case class Tmp(module: Module) extends ValueSymbol { val name = Name("tmp" + Symbol.fresh.next(), module) }
@@ -16,7 +14,7 @@ case class TransformerState(
   /**
    * Synthesized state effects for var-definitions
    */
-  stateEffects: Map[VarBinder, StateCapability],
+  stateEffects: Map[VarBinder, StateCapability] = Map.empty,
 
   /**
    * Used to map each lexically scoped capability to its termsymbol
@@ -31,10 +29,12 @@ case class TransformerState(
 
 class Transformer extends Phase[Module, core.ModuleDecl] {
 
-  def run(mod: Module)(implicit C: Context): Option[ModuleDecl] =
-    Some(transform(mod)(TransformerContext(C)))
+  def run(mod: Module)(implicit C: Context): Option[ModuleDecl] = Context in {
+    C.transformerState = TransformerState()
+    Some(transform(mod))
+  }
 
-  def transform(mod: Module)(implicit C: TransformerContext): ModuleDecl = {
+  def transform(mod: Module)(implicit C: Context): ModuleDecl = {
     val source.ModuleDecl(path, imports, defs) = mod.decl
     val exports: Stmt = Exports(path, mod.terms.flatMap {
       case (name, syms) => syms.collect {
@@ -53,7 +53,7 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
   /**
    * the "rest" is a thunk so that traversal of statements takes place in the correct order.
    */
-  def transform(d: source.Def, rest: => Stmt)(implicit C: TransformerContext): Stmt = (d match {
+  def transform(d: source.Def, rest: => Stmt)(implicit C: Context): Stmt = (d match {
     case f @ source.FunDef(id, _, params, _, body) =>
       val sym = f.symbol
 
@@ -117,23 +117,23 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
       core.Record(d.symbol, ops.map { e => e.symbol }, rest)
   }).inheritPosition(d)
 
-  def transform(tree: source.Stmt)(implicit C: TransformerContext): Stmt = (tree match {
+  def transform(tree: source.Stmt)(implicit C: Context): Stmt = (tree match {
     case source.DefStmt(d, rest) =>
       transform(d, transform(rest))
 
     case source.ExprStmt(e, rest) => {
-      Val(freshWildcardFor(tree), ANF { transform(e).map(Ret) }, transform(rest))
+      Val(freshWildcardFor(tree), C.ANF { Ret(transform(e)) }, transform(rest))
     }
 
     case source.Return(e) =>
-      ANF { transform(e).map(Ret) }
+      C.ANF { Ret(transform(e)) }
 
     case source.BlockStmt(b) =>
       transform(b)
 
   }).inheritPosition(tree)
 
-  def transformLit[T](tree: source.Literal[T])(implicit C: TransformerContext): Literal[T] = tree match {
+  def transformLit[T](tree: source.Literal[T])(implicit C: Context): Literal[T] = tree match {
     case source.UnitLit()         => UnitLit()
     case source.IntLit(value)     => IntLit(value)
     case source.BooleanLit(value) => BooleanLit(value)
@@ -141,27 +141,27 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
     case source.StringLit(value)  => StringLit(value)
   }
 
-  def transform(tree: source.Expr)(implicit C: TransformerContext): Control[Expr] = (tree match {
+  def transform(tree: source.Expr)(implicit C: Context): Expr = (tree match {
     case v: source.Var => v.definition match {
       case sym: VarBinder =>
         val state = C.state(sym)
-        bind(C.inferredTypeOf(tree).tpe, App(Member(C.resolveCapability(state.effect), state.get), Nil))
-      case sym => pure { ValueVar(sym) }
+        C.bind(C.inferredTypeOf(tree).tpe, App(Member(C.resolveCapability(state.effect), state.get), Nil))
+      case sym => ValueVar(sym)
     }
 
     case a @ source.Assign(id, expr) =>
-      transform(expr).flatMap { e =>
-        val state = C.state(a.definition)
-        bind(C.inferredTypeOf(tree).tpe, App(Member(C.resolveCapability(state.effect), state.put), List(e)))
-      }
+      val e = transform(expr)
+      val state = C.state(a.definition)
+      C.bind(C.inferredTypeOf(tree).tpe, App(Member(C.resolveCapability(state.effect), state.put), List(e)))
 
-    case l: source.Literal[t] => pure { transformLit(l) }
+    case l: source.Literal[t] => transformLit(l)
 
     case source.If(cond, thn, els) =>
-      transform(cond).flatMap { c => bind(C.inferredTypeOf(tree).tpe, If(c, transform(thn), transform(els))) }
+      val c = transform(cond)
+      C.bind(C.inferredTypeOf(tree).tpe, If(c, transform(thn), transform(els)))
 
     case source.While(cond, body) =>
-      bind(C.inferredTypeOf(tree).tpe, While(ANF { transform(cond) map Ret }, transform(body)))
+      C.bind(C.inferredTypeOf(tree).tpe, While(C.ANF { Ret(transform(cond)) }, transform(body)))
 
     case source.MatchExpr(sc, clauses) =>
 
@@ -170,7 +170,8 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
           val (p, ps) = transform(pattern)
           (p, BlockLit(ps, transform(body)))
       }
-      transform(sc).flatMap { scrutinee => bind(C.inferredTypeOf(tree).tpe, Match(scrutinee, cs)) }
+      val scrutinee = transform(sc)
+      C.bind(C.inferredTypeOf(tree).tpe, Match(scrutinee, cs))
 
     // assumption: typer removed all ambiguous references, so there is exactly one
     case c @ source.Call(fun, _, args) =>
@@ -179,7 +180,7 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
       // we do not want to provide capabilities for the effect itself
       val ownEffect = sym match {
         case e: EffectOp => Effects(List(e.effect))
-        case _           => Pure
+        case _           => symbols.Pure
       }
 
       val BlockType(tparams, params, ret / effs) = C.blockTypeOf(sym)
@@ -189,34 +190,29 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
       val effects = (effs -- ownEffect).userDefined
       val capabilityArgs = effects.toList.map { C.resolveCapability }
 
-      val as: List[Control[List[Argument]]] = (args zip params) map {
-        case (source.ValueArgs(as), _) => sequence(as.map(transform))
+      val as: List[Argument] = (args zip params).flatMap {
+        case (source.ValueArgs(as), _) => as.map(transform)
         case (source.BlockArg(ps, body), List(p: BlockType)) =>
           val params = ps.params.map { v => core.ValueParam(v.symbol) }
-          pure {
-            C.bindingCapabilities(p.ret.effects.userEffects) { caps =>
-              List(BlockLit(params ++ caps, transform(body)))
-            }
+          C.bindingCapabilities(p.ret.effects.userEffects) { caps =>
+            List(BlockLit(params ++ caps, transform(body)))
           }
       }
-
-      val as2: Control[List[Argument]] = sequence(as).map { ls => ls.flatten }
 
       // right now only builtin functions are pure of control effects
       // later we can have effect inference to learn which ones are pure.
       sym match {
         case f: BuiltinFunction if f.pure =>
-          as2.map { args => PureApp(BlockVar(f), args ++ capabilityArgs) }
+          PureApp(BlockVar(f), as ++ capabilityArgs)
         case r: Record =>
-          as2.map { args => PureApp(BlockVar(r), args ++ capabilityArgs) }
+          PureApp(BlockVar(r), as ++ capabilityArgs)
         case f: EffectOp =>
-          as2.flatMap { args =>
-            bind(C.inferredTypeOf(tree).tpe, App(Member(C.resolveCapability(f.effect), f), args ++ capabilityArgs))
-          }
+          C.bind(C.inferredTypeOf(tree).tpe, App(Member(C.resolveCapability(f.effect), f), as ++ capabilityArgs))
         case f: Field =>
-          as2.map { case List(arg: Expr) => Select(arg, f) }
+          val List(arg: Expr) = as
+          Select(arg, f)
         case f: BlockSymbol =>
-          as2.flatMap { args => bind(C.inferredTypeOf(tree).tpe, App(BlockVar(f), args ++ capabilityArgs)) }
+          C.bind(C.inferredTypeOf(tree).tpe, App(BlockVar(f), as ++ capabilityArgs))
       }
 
     case source.TryHandle(prog, handlers) =>
@@ -238,14 +234,14 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
           })
       }
 
-      bind(C.inferredTypeOf(tree).tpe, Handle(body, hs))
+      C.bind(C.inferredTypeOf(tree).tpe, Handle(body, hs))
 
     case source.Hole(stmts) =>
-      bind(C.inferredTypeOf(tree).tpe, Hole)
+      C.bind(C.inferredTypeOf(tree).tpe, Hole)
 
-  }).map { _.inheritPosition(tree) }
+  }).inheritPosition(tree)
 
-  def transform(tree: source.MatchPattern)(implicit C: TransformerContext): (Pattern, List[core.ValueParam]) = tree match {
+  def transform(tree: source.MatchPattern)(implicit C: Context): (Pattern, List[core.ValueParam]) = tree match {
     case source.IgnorePattern()    => (core.IgnorePattern(), Nil)
     case source.LiteralPattern(l)  => (core.LiteralPattern(transformLit(l)), Nil)
     case p @ source.AnyPattern(id) => (core.AnyPattern(), List(core.ValueParam(p.symbol)))
@@ -254,15 +250,10 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
       (core.TagPattern(p.definition, patterns), params.flatten)
   }
 
-  def transform(exprs: List[source.Expr])(implicit C: TransformerContext): Control[List[Expr]] = exprs match {
-    case Nil => pure { Nil }
-    case (e :: rest) => for {
-      ev <- transform(e)
-      rv <- transform(rest)
-    } yield ev :: rv
-  }
+  def transform(exprs: List[source.Expr])(implicit C: Context): List[Expr] =
+    exprs.map(transform)
 
-  def freshWildcardFor(e: source.Tree)(implicit C: TransformerContext): Wildcard = {
+  def freshWildcardFor(e: source.Tree)(implicit C: Context): Wildcard = {
     val x = Wildcard(C.module)
     C.inferredTypeOption(e) match {
       case Some(t / _) => C.assignType(x, t)
@@ -270,71 +261,6 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
     }
     x
   }
-
-  private val delimiter: Cap[Stmt] = new control.Capability { type Res = Stmt }
-
-  def ANF(e: Control[Stmt]): Stmt = control.handle(delimiter)(e).run()
-
-  /**
-   * Introduces a binding for the given statement.
-   *
-   * @param tpe the type of the bound statement
-   * @param s the statement to be bound
-   */
-  def bind(tpe: symbols.ValueType, s: Stmt)(implicit C: TransformerContext): Control[Expr] = control.use(delimiter) { k =>
-
-    // create a fresh symbol and assign the type
-    val x = Tmp(C.module)
-    C.assignType(x, tpe)
-
-    k.apply(ValueVar(x)).map {
-      case Ret(ValueVar(y)) if x == y => s
-      case body => Val(x, s, body)
-    }
-  }
-
-  case class TransformerContext(context: Context) {
-    /**
-     * Synthesized state effects for var-definitions
-     */
-    private var stateEffects = Map.empty[VarBinder, StateCapability]
-    def state(binder: VarBinder): StateCapability = stateEffects.get(binder) match {
-      case Some(v) => v
-      case None =>
-        val cap = StateCapability(binder)(context)
-        stateEffects = stateEffects + (binder -> cap)
-        cap
-    }
-
-    /**
-     * Used to map each lexically scoped capability to its termsymbol
-     */
-    private var capabilities = Map.empty[Effect, symbols.Capability]
-
-    /**
-     * runs the given block, binding the provided capabilities, so that
-     * "resolveCapability" will find them.
-     */
-    def bindingCapabilities[R](effs: List[UserEffect])(block: List[core.BlockParam] => R): R = {
-      val before = capabilities;
-      // create a fresh cabability-symbol for each bound effect
-      val caps = effs.map { UserCapability }
-      // additional block parameters for capabilities
-      val params = caps.map { core.BlockParam }
-
-      capabilities = capabilities ++ caps.map { c => (c.effect -> c) }.toMap
-      val res = block(params)
-      capabilities = before
-      res
-    }
-
-    def resolveCapability(e: Effect) =
-      capabilities.get(e).map { core.BlockVar }.getOrElse(
-        context.abort(s"Compiler error: cannot find capability for ${e}")
-      )
-  }
-  private implicit def asContext(C: TransformerContext): Context = C.context
-  private implicit def getContext(implicit C: TransformerContext): Context = C.context
 }
 trait TransformerOps { Context: Context =>
 

--- a/shared/src/main/scala/effekt/core/Tree.scala
+++ b/shared/src/main/scala/effekt/core/Tree.scala
@@ -2,7 +2,7 @@ package effekt
 package core
 
 import effekt.context.Context
-import effekt.symbols.{ Name, Symbol, TermSymbol, ValueSymbol, BlockSymbol, UserEffect, Effect, EffectOp, Type, ValueType, BlockType }
+import effekt.symbols.{ Name, Symbol, TermSymbol, ValueSymbol, BlockSymbol, UserEffect, Effect, EffectOp, Type, ValueType, BlockType, InterfaceType }
 
 sealed trait Tree extends Product {
   def inheritPosition(from: source.Tree)(implicit C: Context): this.type = {
@@ -44,7 +44,7 @@ case class Select(target: Expr, field: Symbol) extends Expr
  */
 sealed trait Param extends Tree { def id: TermSymbol }
 case class ValueParam(id: ValueSymbol, tpe: ValueType) extends Param
-case class BlockParam(id: BlockSymbol, tpe: BlockType) extends Param
+case class BlockParam(id: BlockSymbol, tpe: InterfaceType) extends Param
 
 sealed trait Block extends Tree with Argument
 case class BlockVar(id: BlockSymbol) extends Block

--- a/shared/src/main/scala/effekt/core/Tree.scala
+++ b/shared/src/main/scala/effekt/core/Tree.scala
@@ -63,7 +63,7 @@ case class Extern(params: List[Param], body: String) extends Block
  * Statements
  */
 sealed trait Stmt extends Tree
-case class Def(id: BlockSymbol, tpe: BlockType, block: Block, rest: Stmt) extends Stmt
+case class Def(id: BlockSymbol, tpe: InterfaceType, block: Block, rest: Stmt) extends Stmt
 case class Val(id: ValueSymbol, tpe: ValueType, binding: Stmt, body: Stmt) extends Stmt
 case class Data(id: Symbol, ctors: List[Symbol], rest: Stmt) extends Stmt
 case class Record(id: Symbol, fields: List[Symbol], rest: Stmt) extends Stmt

--- a/shared/src/main/scala/effekt/generator/ChezSchemeCallCC.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeCallCC.scala
@@ -35,7 +35,7 @@ class ChezSchemeCallCC extends Generator {
     mod <- C.frontend(src)
     _ = C.checkMain(mod)
     deps = mod.dependencies.flatMap(dep => compile(dep))
-    core <- C.lower(src)
+    core <- C.backend(src)
     result = ChezSchemeCallCCPrinter.compilationUnit(mod, core, deps)
     _ = C.saveOutput(result.layout, path(mod))
   } yield result
@@ -44,7 +44,7 @@ class ChezSchemeCallCC extends Generator {
    * Compiles only the given module, does not compile dependencies
    */
   def compile(mod: Module)(implicit C: Context): Option[Document] = for {
-    core <- C.lower(mod.source)
+    core <- C.backend(mod.source)
     doc = ChezSchemeCallCCPrinter.format(core)
   } yield doc
 }

--- a/shared/src/main/scala/effekt/generator/ChezSchemeCallCC.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeCallCC.scala
@@ -3,7 +3,7 @@ package effekt.generator
 import effekt.context.Context
 import effekt.core._
 import effekt.symbols.Module
-import effekt.symbols.{ Name, Symbol }
+import effekt.symbols.{ Name, Symbol, Wildcard }
 
 import org.bitbucket.inkytonik.kiama
 import kiama.output.ParenPrettyPrinter

--- a/shared/src/main/scala/effekt/generator/ChezSchemeCallCC.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeCallCC.scala
@@ -80,7 +80,7 @@ object ChezSchemeCallCCPrinter extends ChezSchemeBase {
   })
 
   override def toDoc(s: Stmt, toplevel: Boolean)(implicit C: Context): Doc = s match {
-    case State(eff, get, put, init, block) =>
+    case State(eff, tpe, get, put, init, block) =>
       defineValue(nameDef(get), "getter") <> line <>
         defineValue(nameDef(put), "setter") <> line <>
         schemeCall("state", toDoc(init, false), toDoc(block))
@@ -133,7 +133,7 @@ trait ChezSchemeBase extends ParenPrettyPrinter {
     case l: Literal[t] => l.value.toString
     case ValueVar(id)  => nameRef(id)
 
-    case PureApp(b, args) => schemeCall(toDoc(b), args map {
+    case PureApp(b, targs, args) => schemeCall(toDoc(b), args map {
       case e: Expr  => toDoc(e)
       case b: Block => toDoc(b)
     })
@@ -156,11 +156,11 @@ trait ChezSchemeBase extends ParenPrettyPrinter {
       parens("while" <+> toDocInBlock(cond) <+> toDoc(body, false))
 
     // definitions can *only* occur at the top of a (begin ...)
-    case Def(id, BlockLit(ps, body), rest) =>
+    case Def(id, tpe, BlockLit(ps, body), rest) =>
       defineFunction(nameDef(id), ps map toDoc, toDoc(body, false)) <> emptyline <> toDoc(rest, toplevel)
 
     // we can't use the unique id here, since we do not know it in the extern string.
-    case Def(id, Extern(ps, body), rest) =>
+    case Def(id, tpe, Extern(ps, body), rest) =>
       defineFunction(nameDef(id), ps.map { p => p.id.name.toString }, body) <> emptyline <> toDoc(rest, toplevel)
 
     case Data(did, ctors, rest) =>
@@ -173,21 +173,21 @@ trait ChezSchemeBase extends ParenPrettyPrinter {
     case Include(contents, rest) =>
       line <> vsep(contents.split('\n').toList.map(c => text(c))) <> emptyline <> toDoc(rest, toplevel)
 
-    case App(b, args) => schemeCall(toDoc(b), args map {
+    case App(b, targs, args) => schemeCall(toDoc(b), args map {
       case e: Expr  => toDoc(e)
       case b: Block => toDoc(b)
     })
 
-    case Val(Wildcard(_), binding, body) if toplevel =>
+    case Val(Wildcard(_), tpe, binding, body) if toplevel =>
       "(run (thunk " <> toDoc(binding, false) <> "))" <> line <> toDoc(body, true)
 
-    case Val(id, binding, body) if toplevel =>
+    case Val(id, tpe, binding, body) if toplevel =>
       defineValue(nameDef(id), "(run (thunk " <> toDocInBlock(binding) <> "))") <> line <> toDoc(body, toplevel)
 
-    case Val(Wildcard(_), binding, body) =>
+    case Val(Wildcard(_), tpe, binding, body) =>
       toDoc(binding, false) <> line <> toDocInBlock(body)
 
-    case Val(id, binding, body) =>
+    case Val(id, tpe, binding, body) =>
       parens("let" <+> parens(brackets(nameDef(id) <+> toDocInBlock(binding))) <+> group(nest(line <> toDoc(body, false))))
 
     case Ret(e) => toDoc(e)

--- a/shared/src/main/scala/effekt/generator/ChezSchemeLift.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeLift.scala
@@ -35,7 +35,7 @@ class ChezSchemeLift extends Generator {
     mod <- C.frontend(src)
     _ = C.checkMain(mod)
     deps = mod.dependencies.flatMap(dep => compile(dep))
-    core <- C.inferLifts(src)
+    core <- C.backend(mod.source)
     result = ChezSchemeLiftPrinter.compilationUnit(mod, core, deps)
     _ = C.saveOutput(result.layout, path(mod))
   } yield result
@@ -44,7 +44,7 @@ class ChezSchemeLift extends Generator {
    * Compiles only the given module, does not compile dependencies
    */
   def compile(mod: Module)(implicit C: Context): Option[Document] = for {
-    core <- C.inferLifts(mod.source)
+    core <- C.backend(mod.source)
     doc = ChezSchemeLiftPrinter.format(core)
   } yield doc
 }

--- a/shared/src/main/scala/effekt/generator/ChezSchemeLift.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeLift.scala
@@ -3,13 +3,11 @@ package effekt.generator
 import effekt.context.Context
 import effekt.core._
 import effekt.symbols.Module
-import effekt.symbols.{ Name, Symbol, Wildcard }
+import effekt.symbols.Wildcard
 
 import org.bitbucket.inkytonik.kiama
-import kiama.output.ParenPrettyPrinter
 import kiama.output.PrettyPrinterTypes.Document
 import kiama.util.Source
-import effekt.context.assertions._
 
 import scala.language.implicitConversions
 

--- a/shared/src/main/scala/effekt/generator/ChezSchemeLift.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeLift.scala
@@ -3,7 +3,7 @@ package effekt.generator
 import effekt.context.Context
 import effekt.core._
 import effekt.symbols.Module
-import effekt.symbols.{ Name, Symbol }
+import effekt.symbols.{ Name, Symbol, Wildcard }
 
 import org.bitbucket.inkytonik.kiama
 import kiama.output.ParenPrettyPrinter

--- a/shared/src/main/scala/effekt/generator/ChezSchemeLift.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeLift.scala
@@ -79,25 +79,25 @@ object ChezSchemeLiftPrinter extends ChezSchemeBase {
   })
 
   override def toDoc(s: Stmt, toplevel: Boolean)(implicit C: Context): Doc = s match {
-    case Val(Wildcard(_), binding, body) if toplevel =>
+    case Val(Wildcard(_), tpe, binding, body) if toplevel =>
       "(run " <> toDoc(binding, false) <> ")" <> emptyline <> toDoc(body, toplevel)
 
-    case Val(id, binding, body) if toplevel =>
+    case Val(id, tpe, binding, body) if toplevel =>
       defineValue(nameDef(id), "(run " <> toDoc(binding, false) <> ")") <> emptyline <> toDoc(body, toplevel)
 
-    case Val(Wildcard(_), binding, body) =>
+    case Val(Wildcard(_), tpe, binding, body) =>
       schemeCall("then", toDoc(binding, false), "_", toDoc(body, false))
 
     case Ret(e) => schemeCall("pure", List(toDoc(e)))
 
-    case Val(id, binding, body) =>
+    case Val(id, tpe, binding, body) =>
       schemeCall("then", toDoc(binding, false), nameDef(id), toDoc(body, false))
 
-    case Def(id, ScopeAbs(sc, BlockLit(ps, body)), rest) =>
+    case Def(id, tpe, ScopeAbs(sc, BlockLit(ps, body)), rest) =>
       defineFunction(nameDef(id), List(nameDef(sc)),
         schemeLambda(ps map toDoc, toDoc(body, false))) <> emptyline <> toDoc(rest, toplevel)
 
-    case State(eff, get, put, init, block) =>
+    case State(eff, tpe, get, put, init, block) =>
       schemeCall("state", nameDef(eff), nameDef(get), nameDef(put), toDoc(init, false), toDoc(block))
 
     case other => super.toDoc(s, toplevel)

--- a/shared/src/main/scala/effekt/generator/ChezSchemeMonadic.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeMonadic.scala
@@ -3,13 +3,11 @@ package effekt.generator
 import effekt.context.Context
 import effekt.core._
 import effekt.symbols.Module
-import effekt.symbols.{ Name, Symbol, Wildcard }
+import effekt.symbols.Wildcard
 
 import org.bitbucket.inkytonik.kiama
-import kiama.output.ParenPrettyPrinter
 import kiama.output.PrettyPrinterTypes.Document
 import kiama.util.Source
-import effekt.context.assertions._
 
 import scala.language.implicitConversions
 

--- a/shared/src/main/scala/effekt/generator/ChezSchemeMonadic.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeMonadic.scala
@@ -77,21 +77,21 @@ object ChezSchemeMonadicPrinter extends ChezSchemeBase {
   })
 
   override def toDoc(s: Stmt, toplevel: Boolean)(implicit C: Context): Doc = s match {
-    case Val(Wildcard(_), binding, body) if toplevel =>
+    case Val(Wildcard(_), tpe, binding, body) if toplevel =>
       "(run " <> toDoc(binding, false) <> ")" <> emptyline <> toDoc(body, toplevel)
 
-    case Val(id, binding, body) if toplevel =>
+    case Val(id, tpe, binding, body) if toplevel =>
       defineValue(nameDef(id), "(run " <> toDoc(binding, false) <> ")") <> emptyline <> toDoc(body, toplevel)
 
-    case Val(Wildcard(_), binding, body) =>
+    case Val(Wildcard(_), tpe, binding, body) =>
       schemeCall("then", toDoc(binding, false), "_", toDoc(body, false))
 
     case Ret(e) => schemeCall("pure", List(toDoc(e)))
 
-    case Val(id, binding, body) =>
+    case Val(id, tpe, binding, body) =>
       schemeCall("then", toDoc(binding, false), nameDef(id), toDoc(body, false))
 
-    case State(eff, get, put, init, block) =>
+    case State(eff, tpe, get, put, init, block) =>
       schemeCall("state", nameDef(eff), nameDef(get), nameDef(put), toDoc(init, false), toDoc(block))
 
     case other => super.toDoc(s, toplevel)

--- a/shared/src/main/scala/effekt/generator/ChezSchemeMonadic.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeMonadic.scala
@@ -3,7 +3,7 @@ package effekt.generator
 import effekt.context.Context
 import effekt.core._
 import effekt.symbols.Module
-import effekt.symbols.{ Name, Symbol }
+import effekt.symbols.{ Name, Symbol, Wildcard }
 
 import org.bitbucket.inkytonik.kiama
 import kiama.output.ParenPrettyPrinter

--- a/shared/src/main/scala/effekt/generator/ChezSchemeMonadic.scala
+++ b/shared/src/main/scala/effekt/generator/ChezSchemeMonadic.scala
@@ -35,7 +35,7 @@ class ChezSchemeMonadic extends Generator {
     mod <- C.frontend(src)
     _ = C.checkMain(mod)
     deps = mod.dependencies.flatMap(dep => compile(dep))
-    core <- C.lower(src)
+    core <- C.backend(src)
     result = ChezSchemeMonadicPrinter.compilationUnit(mod, core, deps)
     _ = C.saveOutput(result.layout, path(mod))
   } yield result
@@ -44,7 +44,7 @@ class ChezSchemeMonadic extends Generator {
    * Compiles only the given module, does not compile dependencies
    */
   def compile(mod: Module)(implicit C: Context): Option[Document] = for {
-    core <- C.lower(mod.source)
+    core <- C.backend(mod.source)
     doc = ChezSchemeMonadicPrinter.format(core)
   } yield doc
 }

--- a/shared/src/main/scala/effekt/generator/JavaScript.scala
+++ b/shared/src/main/scala/effekt/generator/JavaScript.scala
@@ -39,7 +39,7 @@ class JavaScript extends Generator {
    * Compiles only the given module, does not compile dependencies
    */
   def compile(mod: Module)(implicit C: Context): Option[Document] = for {
-    core <- C.lower(mod.source)
+    core <- C.backend(mod.source)
     // setting the scope to mod is important to generate qualified names
     doc = C.using(module = mod) { prettyPrinter.format(core) }
     _ = C.saveOutput(doc.layout, path(mod))

--- a/shared/src/main/scala/effekt/generator/JavaScript.scala
+++ b/shared/src/main/scala/effekt/generator/JavaScript.scala
@@ -3,7 +3,7 @@ package effekt.generator
 import effekt.context.Context
 import effekt.context.assertions._
 import effekt.core._
-import effekt.symbols.{ Module, Name, Symbol }
+import effekt.symbols.{ Module, Name, Symbol, Wildcard }
 import effekt.symbols
 import org.bitbucket.inkytonik.kiama
 import kiama.output.ParenPrettyPrinter

--- a/shared/src/main/scala/effekt/generator/JavaScriptLift.scala
+++ b/shared/src/main/scala/effekt/generator/JavaScriptLift.scala
@@ -1,12 +1,9 @@
 package effekt.generator
 
 import effekt.context.Context
-import effekt.context.assertions._
 import effekt.core._
-import effekt.symbols.{ Module, Name, Symbol, Wildcard }
-import effekt.symbols
+import effekt.symbols.{ Module, Wildcard }
 import org.bitbucket.inkytonik.kiama
-import kiama.output.ParenPrettyPrinter
 import kiama.output.PrettyPrinterTypes.Document
 import kiama.util.Source
 

--- a/shared/src/main/scala/effekt/generator/JavaScriptLift.scala
+++ b/shared/src/main/scala/effekt/generator/JavaScriptLift.scala
@@ -3,7 +3,7 @@ package effekt.generator
 import effekt.context.Context
 import effekt.context.assertions._
 import effekt.core._
-import effekt.symbols.{ Module, Name, Symbol }
+import effekt.symbols.{ Module, Name, Symbol, Wildcard }
 import effekt.symbols
 import org.bitbucket.inkytonik.kiama
 import kiama.output.ParenPrettyPrinter

--- a/shared/src/main/scala/effekt/generator/JavaScriptLift.scala
+++ b/shared/src/main/scala/effekt/generator/JavaScriptLift.scala
@@ -74,13 +74,13 @@ trait JavaScriptLiftPrinter extends JavaScriptBase {
   // not all statement types can be printed in this context!
   def toDocExpr(s: Stmt)(implicit C: Context): Doc = s match {
 
-    case Val(Wildcard(_), binding, body) =>
+    case Val(Wildcard(_), tpe, binding, body) =>
       "$effekt.then" <> parens(toDocExpr(binding)) <> parens(jsLambda(Nil, toDoc(body)))
 
-    case Val(id, binding, body) =>
+    case Val(id, tpe, binding, body) =>
       "$effekt.then" <> parens(toDocExpr(binding)) <> parens(jsLambda(List(nameDef(id)), toDoc(body)))
 
-    case App(b, args) =>
+    case App(b, targs, args) =>
       jsCall(toDoc(b), args map argToDoc)
 
     case If(cond, thn, els) =>
@@ -94,7 +94,7 @@ trait JavaScriptLiftPrinter extends JavaScriptBase {
     case Ret(e) =>
       jsCall("$effekt.pure", toDoc(e))
 
-    case State(id, get, put, init, body) =>
+    case State(id, tpe, get, put, init, body) =>
       "$effekt.state" <> parens(toDocExpr(init)) <> parens(toDoc(body))
 
     case Handle(body, hs) =>
@@ -126,14 +126,14 @@ trait JavaScriptLiftPrinter extends JavaScriptBase {
   }
 
   override def toDocStmt(s: Stmt)(implicit C: Context): Doc = s match {
-    case Def(id, ScopeAbs(sc, BlockLit(ps, body)), rest) =>
+    case Def(id, tpe, ScopeAbs(sc, BlockLit(ps, body)), rest) =>
       jsFunction(nameDef(id), List(nameDef(sc)),
         "return" <+> jsLambda(ps map toDoc, toDoc(body))) <> emptyline <> toDocStmt(rest)
     case _ => super.toDocStmt(s)
   }
 
   override def toDocTopLevel(s: Stmt)(implicit C: Context): Doc = s match {
-    case Def(id, ScopeAbs(sc, BlockLit(ps, body)), rest) =>
+    case Def(id, tpe, ScopeAbs(sc, BlockLit(ps, body)), rest) =>
       jsFunction(nameDef(id), List(nameDef(sc)),
         "return" <+> jsLambda(ps map toDoc, toDoc(body))) <> emptyline <> toDocTopLevel(rest)
     case _ => super.toDocTopLevel(s)

--- a/shared/src/main/scala/effekt/generator/JavaScriptLift.scala
+++ b/shared/src/main/scala/effekt/generator/JavaScriptLift.scala
@@ -38,7 +38,7 @@ class JavaScriptLift extends Generator {
    * Compiles only the given module, does not compile dependencies
    */
   def compile(mod: Module)(implicit C: Context): Option[Document] = for {
-    core <- C.inferLifts(mod.source)
+    core <- C.backend(mod.source)
     // setting the scope to mod is important to generate qualified names
     doc = C.using(module = mod) { prettyPrinter.format(core) }
     _ = C.saveOutput(doc.layout, path(mod))

--- a/shared/src/main/scala/effekt/source/CapabilityPassing.scala
+++ b/shared/src/main/scala/effekt/source/CapabilityPassing.scala
@@ -1,7 +1,6 @@
 package effekt
 package source
 
-import scala.collection.mutable.ListBuffer
 import effekt.context.{ Context, ContextOps }
 import effekt.symbols._
 import effekt.context.assertions.SymbolAssertions

--- a/shared/src/main/scala/effekt/source/CapabilityPassing.scala
+++ b/shared/src/main/scala/effekt/source/CapabilityPassing.scala
@@ -1,0 +1,226 @@
+package effekt
+package source
+
+import scala.collection.mutable.ListBuffer
+import effekt.context.{ Context, ContextOps }
+import effekt.symbols._
+import effekt.context.assertions.SymbolAssertions
+
+/**
+ * Transformation on source trees that translates programs into explicit capability-passing style
+ *
+ * That is, block parameters are introduced to bind capabilities and arguments are introduced at
+ * the call sites.
+ *
+ * TODO also transfer annotations!
+ */
+class CapabilityPassing extends Phase[ModuleDecl, ModuleDecl] {
+
+  def run(mod: ModuleDecl)(implicit C: Context): Option[ModuleDecl] = Context in {
+    Some(transform(mod))
+  }
+
+  def transform(mod: ModuleDecl)(implicit C: Context): ModuleDecl = withAttributes(mod) {
+    case ModuleDecl(path, imports, defs) =>
+      ModuleDecl(path, imports, defs.map { d => transform(d) })
+  }
+
+  // TODO also change the annotated type to include the added capabilities!
+  def transform(d: Def)(implicit C: Context): Def = withAttributes(d) {
+    case f @ FunDef(id, tparams, params, ret, body) =>
+      val sym = f.symbol
+      val effs = sym.effects.userEffects
+
+      C.withCapabilities(effs) { caps =>
+        f.copy(params = params ++ caps, body = transform(body))
+      }
+
+    case v @ ValDef(id, _, binding) =>
+      val annot = ValueTypeTree(C.valueTypeOf(v.symbol))
+      ValDef(id, Some(annot), transform(binding))
+
+    case v @ VarDef(id, _, binding) =>
+      val annot = ValueTypeTree(C.valueTypeOf(v.symbol))
+      VarDef(id, Some(annot), transform(binding))
+
+    case d => d
+  }
+
+  def transform(tree: Expr)(implicit C: Context): Expr = withAttributes(tree) {
+    case v: source.Var =>
+      v
+
+    case a @ source.Assign(id, expr) =>
+      source.Assign(id, transform(expr))
+
+    case l: source.Literal[t] => l
+
+    case source.If(cond, thn, els) =>
+      source.If(transform(cond), transform(thn), transform(els))
+
+    case source.While(cond, body) =>
+      source.While(transform(cond), transform(body))
+
+    case source.MatchExpr(sc, clauses) =>
+      source.MatchExpr(transform(sc), clauses.map { cl =>
+        withAttributes(cl) {
+          case cl @ source.MatchClause(pattern, body) =>
+            source.MatchClause(pattern, transform(body))
+        }
+      })
+
+    // shouldn't exist in source right now
+    case c @ source.MethodCall(block, op, _, args) =>
+      C.panic("Shouldn't exist in source program")
+
+    // an effect call -- translate to method call
+    case c @ source.Call(fun, targs, args) if c.definition.isInstanceOf[EffectOp] =>
+      val op = c.definition.asEffectOp
+
+      // if this is an effect call, we do not want to provide capabilities for the effect itself
+      val ownEffect = Effects(List(op.effect))
+
+      val BlockType(tparams, params, ret / effs) = C.blockTypeOf(op)
+
+      // Do not provide capabilities for builtin effects and also
+      // omit the capability for the effect itself (if it is an effect operation)
+      val effects = (effs -- ownEffect).userDefined
+      val transformedArgs = (args zip params).map { case (a, p) => transform(a, p) }
+      val capabilityArgs = effects.toList.map { e => CapabilityArg(C.capabilityReferenceFor(e)) }
+
+      val receiver = C.capabilityReferenceFor(op.effect)
+
+      source.MethodCall(receiver, fun, targs, transformedArgs ++ capabilityArgs)
+
+    // a "regular" function call
+    // assumption: typer removed all ambiguous references, so there is exactly one
+    case c @ source.Call(fun, targs, args) =>
+
+      val sym: Symbol = c.definition
+      val BlockType(tparams, params, ret / effs) = C.blockTypeOf(sym)
+
+      val effects = effs.userDefined
+      val transformedArgs = (args zip params).map { case (a, p) => transform(a, p) }
+      val capabilityArgs = effects.toList.map { e => CapabilityArg(C.capabilityReferenceFor(e)) }
+
+      source.Call(fun, targs, transformedArgs ++ capabilityArgs)
+
+    case source.TryHandle(prog, handlers) =>
+
+      val effects = handlers.map(_.definition)
+      val (caps, body) = C.withCapabilities(effects) { caps =>
+        (caps, transform(prog))
+      }
+      val hs = (handlers zip caps).map {
+        case (h, cap) => withAttributes(h) {
+          case h @ source.Handler(eff, _, clauses) =>
+            val cls = clauses.map { cl =>
+              withAttributes(cl) {
+                case OpClause(id, params, body, resume: IdDef) =>
+
+                  // OpClause also binds a block parameter for resume, which is not annotated here
+                  OpClause(id, params, transform(body), resume)
+              }
+            }
+
+            // here we annotate the synthesized capability
+            source.Handler(eff, Some(cap), cls)
+        }
+      }
+      source.TryHandle(body, hs)
+
+    case source.Hole(stmts) =>
+      source.Hole(transform(stmts))
+
+  }
+
+  def transform(arg: ArgSection, param: List[symbols.Type])(implicit C: Context): ArgSection = withAttributes(arg) { arg =>
+    (arg, param) match {
+      case (source.ValueArgs(as), _) =>
+        source.ValueArgs(as.map(transform))
+      case (source.BlockArg(ps, body), List(p: BlockType)) =>
+        C.withCapabilities(p.ret.effects.userEffects) { caps =>
+          source.BlockArg(ps ++ caps, transform(body))
+        }
+    }
+  }
+
+  def transform(tree: Stmt)(implicit C: Context): Stmt = withAttributes(tree) {
+    case source.DefStmt(d, rest) =>
+      source.DefStmt(transform(d), transform(rest))
+
+    case source.ExprStmt(e, rest) =>
+      source.ExprStmt(transform(e), transform(rest))
+
+    case source.Return(e) =>
+      source.Return(transform(e))
+
+    case source.BlockStmt(b) =>
+      source.BlockStmt(transform(b))
+  }
+
+  /**
+   * Copies all annotations and position information from source to target
+   */
+  def withAttributes[T <: Tree, R <: Tree](source: T)(block: T => R)(implicit C: Context): R = {
+    val target = block(source)
+    target.inheritPosition(source)
+    C.copyAnnotations(source, target)
+    target
+  }
+}
+trait CapabilityPassingOps extends ContextOps { Context: Context =>
+
+  /**
+   * Used to map each lexically scoped capability to its termsymbol
+   */
+  private var capabilities: Map[Effect, symbols.Capability] = Map.empty
+
+  /**
+   * Override the dynamically scoped `in` to also reset transformer state
+   */
+  override def in[T](block: => T): T = {
+    //    val effectsBefore = stateEffects
+    val capsBefore = capabilities
+    val result = super.in(block)
+    //    stateEffects = effectsBefore
+    capabilities = capsBefore
+    result
+  }
+
+  /**
+   * runs the given block, binding the provided capabilities, so that
+   * "resolveCapability" will find them.
+   */
+  private[source] def withCapabilities[R](effs: List[UserEffect])(block: List[source.CapabilityParam] => R): R = Context in {
+
+    // create a fresh cabability-symbol for each bound effect
+    val caps = effs.map { eff =>
+      val tpe = CapabilityType(eff)
+      val sym = CapabilityParam(eff.name.rename(_ + "$capability"), tpe)
+      assignType(sym, tpe)
+      sym
+    }
+    // additional block parameters for capabilities
+    val params = caps.map { sym =>
+      val id = IdDef(sym.name.localName)
+      assignSymbol(id, sym)
+      source.CapabilityParam(id, source.CapabilityType(sym.effect))
+    }
+    // update state with capabilities
+    capabilities = capabilities ++ caps.map { c => (c.effect -> c) }.toMap
+
+    // run block
+    block(params)
+  }
+
+  private[source] def capabilityReferenceFor(e: Effect): IdRef =
+    capabilities.get(e).map { c =>
+      val id = IdRef(c.name.localName)
+      assignSymbol(id, c)
+      //Var(id)
+      id
+    } getOrElse {
+      Context.abort(s"Compiler error: cannot find capability for ${e}")
+    }
+}

--- a/shared/src/main/scala/effekt/source/CapabilityPassing.scala
+++ b/shared/src/main/scala/effekt/source/CapabilityPassing.scala
@@ -6,7 +6,7 @@ import effekt.context.{ Context, ContextOps }
 import effekt.symbols._
 import effekt.context.assertions.SymbolAssertions
 import effekt.source.Tree.Rewrite
-``
+
 /**
  * Transformation on source trees that translates programs into explicit capability-passing style
  *

--- a/shared/src/main/scala/effekt/source/CapabilityPassing.scala
+++ b/shared/src/main/scala/effekt/source/CapabilityPassing.scala
@@ -6,12 +6,12 @@ import effekt.context.{ Context, ContextOps }
 import effekt.symbols._
 import effekt.context.assertions.SymbolAssertions
 import effekt.source.Tree.Rewrite
-
+``
 /**
  * Transformation on source trees that translates programs into explicit capability-passing style
  *
  * That is, block parameters are introduced to bind capabilities and arguments are introduced at
- * the call sites.
+ * the call sites. Resume is currently _not_ introduced as a block parameter.
  */
 class CapabilityPassing extends Phase[ModuleDecl, ModuleDecl] with Rewrite {
 

--- a/shared/src/main/scala/effekt/source/Tree.scala
+++ b/shared/src/main/scala/effekt/source/Tree.scala
@@ -5,7 +5,7 @@ import effekt.context.Context
 import effekt.symbols.Symbol
 
 /**
- * We extend product to allow reflective copying by Kiama.
+ * We extend product to allow reflective access by Kiama.
  */
 sealed trait Tree extends Product {
   def inheritPosition(from: Tree)(implicit C: Context): this.type = {
@@ -82,14 +82,20 @@ case class Import(path: String) extends Tree
 sealed trait ParamSection extends Tree
 case class ValueParams(params: List[ValueParam]) extends ParamSection
 case class ValueParam(id: IdDef, tpe: Option[ValueType]) extends Definition { type symbol = symbols.ValueParam }
+
+// TODO fuse into one kind of parameter
 case class BlockParam(id: IdDef, tpe: BlockType) extends ParamSection with Definition { type symbol = symbols.BlockParam }
+case class CapabilityParam(id: IdDef, tpe: CapabilityType) extends ParamSection with Definition { type symbol = symbols.CapabilityParam }
 
 sealed trait ArgSection extends Tree
 case class ValueArgs(args: List[Expr]) extends ArgSection
 case class BlockArg(params: ValueParams, body: Stmt) extends ArgSection
+case class CapabilityArg(id: IdRef) extends ArgSection with Reference {
+  type symbol = symbols.CapabilityParam
+}
 
 /**
- * Global (and later, local) definitions
+ * Global and local definitions
  */
 sealed trait Def extends Definition {
   def id: IdDef

--- a/shared/src/main/scala/effekt/source/Tree.scala
+++ b/shared/src/main/scala/effekt/source/Tree.scala
@@ -89,7 +89,7 @@ case class CapabilityParam(id: IdDef, tpe: CapabilityType) extends ParamSection 
 
 sealed trait ArgSection extends Tree
 case class ValueArgs(args: List[Expr]) extends ArgSection
-case class BlockArg(params: ValueParams, body: Stmt) extends ArgSection
+case class BlockArg(params: List[ParamSection], body: Stmt) extends ArgSection
 case class CapabilityArg(id: IdRef) extends ArgSection with Reference {
   type symbol = symbols.CapabilityParam
 }
@@ -197,13 +197,16 @@ case class MethodCall(receiver: IdRef, id: IdRef, targs: List[ValueType], args: 
 case class If(cond: Expr, thn: Stmt, els: Stmt) extends Expr
 case class While(cond: Expr, block: Stmt) extends Expr
 
-// currently, the source language does not allow us to explicitly bind the capabilities
-// the capabilities here are annotated by the capability-passing transformation
-case class TryHandle( /* capabilities: List[CapabilityParam] = Nil, */ prog: Stmt, handlers: List[Handler]) extends Expr
-case class Handler(id: IdRef, clauses: List[OpClause]) extends Reference {
+case class TryHandle(prog: Stmt, handlers: List[Handler]) extends Expr
+
+/**
+ * Currently, the source language does not allow us to explicitly bind the capabilities.
+ * The capability parameter here is annotated by the capability-passing transformation
+ */
+case class Handler(id: IdRef, capability: Option[CapabilityParam] = None, clauses: List[OpClause]) extends Reference {
   type symbol = symbols.UserEffect
 }
-case class OpClause(id: IdRef, params: List[ValueParams], body: Stmt, resume: IdDef) extends Reference {
+case class OpClause(id: IdRef, params: List[ParamSection], body: Stmt, resume: IdDef) extends Reference {
   type symbol = symbols.EffectOp
 }
 

--- a/shared/src/main/scala/effekt/source/Tree.scala
+++ b/shared/src/main/scala/effekt/source/Tree.scala
@@ -163,7 +163,7 @@ case class BlockStmt(stmts: Stmt) extends Stmt
 
 /**
  * In our source language, almost everything is an expression.
- * Effectful calls, if, while,
+ * Effectful calls, if, while, ...
  */
 sealed trait Expr extends Tree
 
@@ -202,6 +202,12 @@ case class TryHandle(prog: Stmt, handlers: List[Handler]) extends Expr
 /**
  * Currently, the source language does not allow us to explicitly bind the capabilities.
  * The capability parameter here is annotated by the capability-passing transformation
+ *
+ *   try {
+ *     <prog>
+ *   } with <eff> : <Effect> { ... }
+ *
+ * Here eff is the capability parameter, as introduced by the transformation.
  */
 case class Handler(id: IdRef, capability: Option[CapabilityParam] = None, clauses: List[OpClause]) extends Reference {
   type symbol = symbols.UserEffect

--- a/shared/src/main/scala/effekt/source/Tree.scala
+++ b/shared/src/main/scala/effekt/source/Tree.scala
@@ -7,7 +7,12 @@ import effekt.symbols.Symbol
 /**
  * We extend product to allow reflective copying by Kiama.
  */
-sealed trait Tree extends Product
+sealed trait Tree extends Product {
+  def inheritPosition(from: Tree)(implicit C: Context): this.type = {
+    C.positions.dupPos(from, this);
+    this
+  }
+}
 
 /**
  * Used for builtin and synthesized trees

--- a/shared/src/main/scala/effekt/source/Tree.scala
+++ b/shared/src/main/scala/effekt/source/Tree.scala
@@ -287,3 +287,128 @@ object Effects {
   def apply(effs: Effect*): Effects = Effects(effs.toSet)
   def apply(effs: Set[Effect]): Effects = Effects(effs.toList)
 }
+
+object Tree {
+
+  // Generic traversal of trees, applying the partial function `f` to every contained
+  // element of type Tree.
+  def visit(obj: Any)(f: PartialFunction[Tree, Unit]): Unit = obj match {
+    case t: Iterable[t] => t.foreach { t => visit(t)(f) }
+    case p: Product => p.productIterator.foreach {
+      case t: Tree => f(t)
+      case other   => ()
+    }
+    case leaf => ()
+  }
+
+  // This solution is between a fine-grained visitor and a untyped and unsafe traversal.
+  trait Rewrite {
+    // Hooks to override
+    def expr(implicit C: Context): PartialFunction[Expr, Expr] = PartialFunction.empty
+    def stmt(implicit C: Context): PartialFunction[Stmt, Stmt] = PartialFunction.empty
+    def defn(implicit C: Context): PartialFunction[Def, Def] = PartialFunction.empty
+
+    /**
+     * Hook that can be overriden to perform an action at every node in the tree
+     */
+    def visit[T <: Tree](t: T)(visitor: T => T)(implicit C: Context): T = visitor(t)
+
+    //
+    // Entrypoints to use the traversal on, defined in terms of the above hooks
+    def rewrite(e: ModuleDecl)(implicit C: Context): ModuleDecl = visit(e) {
+      case ModuleDecl(path, imports, defs) =>
+        ModuleDecl(path, imports, defs.map(rewrite))
+    }
+
+    def rewrite(e: Expr)(implicit C: Context): Expr = visit(e) {
+      case e if expr.isDefinedAt(e) => expr(C)(e)
+      case v: Var                   => v
+      case l: Literal[t]            => l
+
+      case Assign(id, expr) =>
+        Assign(id, rewrite(expr))
+
+      case If(cond, thn, els) =>
+        If(rewrite(cond), rewrite(thn), rewrite(els))
+
+      case While(cond, body) =>
+        While(rewrite(cond), rewrite(body))
+
+      case MatchExpr(sc, clauses) =>
+        MatchExpr(rewrite(sc), clauses.map(rewrite))
+
+      case MethodCall(block, op, targs, args) =>
+        MethodCall(block, op, targs, args.map(rewrite))
+
+      case Call(fun, targs, args) =>
+        Call(fun, targs, args.map(rewrite))
+
+      case TryHandle(prog, handlers) =>
+        TryHandle(rewrite(prog), handlers.map(rewrite))
+
+      case Hole(stmts) =>
+        Hole(rewrite(stmts))
+    }
+
+    def rewrite(t: Def)(implicit C: Context): Def = visit(t) {
+      case t if defn.isDefinedAt(t) => defn(C)(t)
+
+      case FunDef(id, tparams, params, ret, body) =>
+        FunDef(id, tparams, params, ret, rewrite(body))
+
+      case ValDef(id, annot, binding) =>
+        ValDef(id, annot, rewrite(binding))
+
+      case VarDef(id, annot, binding) =>
+        VarDef(id, annot, rewrite(binding))
+
+      case d: EffDef        => d
+      case d: DataDef       => d
+      case d: RecordDef     => d
+      case d: TypeDef       => d
+      case d: EffectDef     => d
+
+      case d: ExternType    => d
+      case d: ExternEffect  => d
+      case d: ExternFun     => d
+      case d: ExternInclude => d
+    }
+
+    def rewrite(t: Stmt)(implicit C: Context): Stmt = visit(t) {
+      case s if stmt.isDefinedAt(s) => stmt(C)(s)
+
+      case DefStmt(d, rest) =>
+        DefStmt(rewrite(d), rewrite(rest))
+
+      case ExprStmt(e, rest) =>
+        ExprStmt(rewrite(e), rewrite(rest))
+
+      case Return(e) =>
+        Return(rewrite(e))
+
+      case BlockStmt(b) =>
+        BlockStmt(rewrite(b))
+    }
+
+    def rewrite(t: ArgSection)(implicit C: Context): ArgSection = visit(t) {
+      case ValueArgs(as)      => ValueArgs(as.map(rewrite))
+      case BlockArg(ps, body) => BlockArg(ps, rewrite(body))
+      case CapabilityArg(id)  => t
+    }
+
+    def rewrite(h: Handler)(implicit C: Context): Handler = visit(h) {
+      case Handler(id, capability, clauses) =>
+        Handler(id, capability, clauses.map(rewrite))
+    }
+
+    def rewrite(h: OpClause)(implicit C: Context): OpClause = visit(h) {
+      case OpClause(id, params, body, resume) =>
+        OpClause(id, params, rewrite(body), resume)
+    }
+
+    def rewrite(c: MatchClause)(implicit C: Context): MatchClause = visit(c) {
+      case MatchClause(pattern, body) =>
+        MatchClause(pattern, rewrite(body))
+    }
+  }
+}

--- a/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -227,6 +227,9 @@ package object symbols {
       if (tparams.isEmpty) { tpe } else { sys error "Cannot delias unapplied type constructor" }
   }
 
+  /**
+   * Types that _can_ be used in type constructor position. e.g. >>>List<<<[T]
+   */
   trait TypeConstructor extends TypeSymbol with ValueType
   object TypeConstructor {
     def unapply(t: ValueType): Option[TypeConstructor] = t match {

--- a/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -54,10 +54,22 @@ package object symbols {
     // this is the order in which the modules need to be compiled / loaded
     lazy val dependencies: List[Module] = imports.flatMap { im => im.dependencies :+ im }.distinct
 
-    // toplevle declared effects
+    // toplevel declared effects
     def effects: Effects = Effects(types.values.collect {
       case e: Effect => e
     })
+
+    // the transformed ast after frontend
+    private var _ast = decl
+    def ast = _ast
+
+    /**
+     * Should be called once after frontend
+     */
+    def setAst(ast: ModuleDecl): this.type = {
+      _ast = ast
+      this
+    }
 
     /**
      * It is actually possible, that exports is invoked on a single module multiple times:

--- a/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -143,6 +143,12 @@ package object symbols {
   case class CallTarget(name: Name, symbols: List[Set[BlockSymbol]]) extends Synthetic with BlockSymbol
 
   /**
+   * Introduced by Transformer
+   */
+  case class Wildcard(module: Module) extends ValueSymbol { val name = Name("_", module) }
+  case class Tmp(module: Module) extends ValueSymbol { val name = Name("tmp" + Symbol.fresh.next(), module) }
+
+  /**
    * A symbol that represents a termlevel capability
    */
   trait Capability extends BlockSymbol {

--- a/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -1,8 +1,7 @@
 package effekt
 
 import effekt.source.{ Def, FunDef, ModuleDecl, ValDef, VarDef }
-import effekt.context.{ Context }
-import effekt.util.messages.{ ErrorReporter }
+import effekt.context.Context
 import org.bitbucket.inkytonik.kiama.util.Source
 import effekt.subtitutions._
 

--- a/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -159,20 +159,6 @@ package object symbols {
     def effect: Effect
   }
 
-  case class StateCapability(effect: UserEffect, get: EffectOp, put: EffectOp) extends Capability {
-    val name = effect.name
-  }
-  object StateCapability {
-    def apply(binder: VarBinder)(implicit C: Context): StateCapability = {
-      val tpe = C.valueTypeOf(binder)
-      val eff = UserEffect(binder.name, Nil)
-      val get = EffectOp(binder.name.rename(name => "get"), Nil, List(Nil), Some(tpe / Pure), eff)
-      val put = EffectOp(binder.name.rename(name => "put"), Nil, List(List(ValueParam(binder.name, Some(tpe)))), Some(builtins.TUnit / Pure), eff)
-      eff.ops = List(get, put)
-      StateCapability(eff, get, put)
-    }
-  }
-
   /**
    * Types
    */

--- a/shared/src/main/scala/effekt/util/Highlight.scala
+++ b/shared/src/main/scala/effekt/util/Highlight.scala
@@ -3,7 +3,6 @@ package util
 
 import org.bitbucket.inkytonik.kiama.util.Positions
 
-import scala.annotation.tailrec
 import scala.util.matching._
 
 object Highlight {

--- a/shared/src/main/scala/effekt/util/Messages.scala
+++ b/shared/src/main/scala/effekt/util/Messages.scala
@@ -3,7 +3,7 @@ package util
 
 import effekt.source.Tree
 
-import org.bitbucket.inkytonik.kiama.util.{ Messaging, Message }
+import org.bitbucket.inkytonik.kiama.util.Messaging
 import org.bitbucket.inkytonik.kiama.util.Messaging.{ Messages, noMessages }
 import org.bitbucket.inkytonik.kiama.util.Severities.Error
 

--- a/shared/src/main/scala/effekt/util/Messages.scala
+++ b/shared/src/main/scala/effekt/util/Messages.scala
@@ -21,7 +21,9 @@ object messages {
    *
    * Should be used for unexpected internal compiler errors
    */
-  case class CompilerPanic(msg: String, position: AnyRef) extends Exception
+  case class CompilerPanic(msg: String, position: AnyRef) extends Exception {
+    override def toString = msg
+  }
 
   /**
    * Stores messages in a mutable field

--- a/shared/src/main/scala/effekt/util/Messages.scala
+++ b/shared/src/main/scala/effekt/util/Messages.scala
@@ -9,7 +9,19 @@ import org.bitbucket.inkytonik.kiama.util.Severities.Error
 
 object messages {
 
+  /**
+   * Error that aborts a compilation phase
+   *
+   * Messages are part of the reporting pipeline and can be backtracked by Typer
+   */
   case class FatalPhaseError(msg: String) extends Exception
+
+  /**
+   * Error that aborts the whole compilation and shows a stack trace
+   *
+   * Should be used for unexpected internal compiler errors
+   */
+  case class CompilerPanic(msg: String, position: AnyRef) extends Exception
 
   /**
    * Stores messages in a mutable field
@@ -41,15 +53,16 @@ object messages {
     def error(msg: String): Unit = error(focus, msg)
     def error(at: AnyRef, msg: String): Unit = buffer append Messaging.error(at, msg)
 
+    def panic(msg: String): Nothing = panic(focus, msg)
+    def panic(at: AnyRef, msg: String): Nothing = throw CompilerPanic(msg, at)
+
     def warning(msg: String): Unit = warning(focus, msg)
     def warning(at: AnyRef, msg: String): Unit = buffer append Messaging.warning(at, msg)
 
     def info(msg: String): Unit = info(focus, msg)
     def info(at: AnyRef, msg: String): Unit = buffer append Messaging.info(at, msg)
 
-    def abort(msg: String): Nothing = {
-      throw FatalPhaseError(msg)
-    }
+    def abort(msg: String): Nothing = throw FatalPhaseError(msg)
 
     def reraise(msg: Messages): Unit = buffer.append(msg)
 

--- a/shared/src/main/scala/effekt/util/PathUtils.scala
+++ b/shared/src/main/scala/effekt/util/PathUtils.scala
@@ -1,7 +1,7 @@
 package effekt
 package util
 
-import org.bitbucket.inkytonik.kiama.util.{ FileSource, Source, StringSource }
+import org.bitbucket.inkytonik.kiama.util.{ FileSource, Source }
 
 /**
  * PathUtils independent of Java as a host platform.

--- a/shared/src/main/scala/effekt/util/Task.scala
+++ b/shared/src/main/scala/effekt/util/Task.scala
@@ -1,11 +1,10 @@
 package effekt.util
 
 import effekt.context.Context
-import effekt.util.messages.FatalPhaseError
 import org.bitbucket.inkytonik.kiama.util.Messaging.Messages
 
 import scala.collection.mutable
-import org.bitbucket.inkytonik.kiama.util.{ FileSource, Source, StringSource }
+import org.bitbucket.inkytonik.kiama.util.Source
 
 trait Task[In, Out] { self =>
 


### PR DESCRIPTION
It is a nice academic trick to use `Control` for ANF. As long as we do not write the Effekt compiler in Effekt, however, it introduces additional complexity, not necessary. 

This PR rewrites `Transformer` to use mutable state instead of control effects. This works in particular, since `Transfomer` does not perform any sorts of backtracking.