### PR TITLE
Refactor/scala3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
   )
   .settings(commonSettings)
   .dependsOn(kiama)
-  .enablePlugins(NativeImagePlugin)
+  // .enablePlugins(NativeImagePlugin)
   .jvmSettings(
     libraryDependencies ++= (replDependencies ++ lspDependencies ++ testingDependencies),
 
@@ -102,15 +102,15 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
 
     // Options to compile Effekt with native-image
     // -------------------------------------------
-    nativeImageOptions ++= Seq(
-      "--no-fallback",
-      "--initialize-at-build-time",
-      "--report-unsupported-elements-at-runtime",
-      "-H:+ReportExceptionStackTraces",
-      "-H:IncludeResourceBundles=jline.console.completer.CandidateListCompletionHandler",
-      "-H:ReflectionConfigurationFiles=../../native-image/reflect-config.json",
-      "-H:DynamicProxyConfigurationFiles=../../native-image/dynamic-proxies.json"
-    ),
+    //    nativeImageOptions ++= Seq(
+    //      "--no-fallback",
+    //      "--initialize-at-build-time",
+    //      "--report-unsupported-elements-at-runtime",
+    //      "-H:+ReportExceptionStackTraces",
+    //      "-H:IncludeResourceBundles=jline.console.completer.CandidateListCompletionHandler",
+    //      "-H:ReflectionConfigurationFiles=../../native-image/reflect-config.json",
+    //      "-H:DynamicProxyConfigurationFiles=../../native-image/dynamic-proxies.json"
+    //    ),
 
 
     // Assembling one big jar-file and packaging it

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val commonSettings = Seq(
     "-deprecation",
     "-unchecked",
     // "-Xlint",
-    //"-Xfatal-warnings",
+    "-Xfatal-warnings",
     "-feature",
     "-language:existentials",
     "-language:higherKinds",

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val commonSettings = Seq(
     "-deprecation",
     "-unchecked",
     // "-Xlint",
-    "-Xfatal-warnings",
+    //"-Xfatal-warnings",
     "-feature",
     "-language:existentials",
     "-language:higherKinds",

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val lspDependencies = Seq(
 
 lazy val testingDependencies = Seq(
   "org.scala-sbt" %% "io" % "1.6.0" % "test",
-  "org.scalatest" % "scalatest_2.13" % "3.1.1" % "test"
+  "org.scalatest" %% "scalatest" % "3.2.9" % "test"
 )
 
 lazy val kiama: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("kiama"))

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val noPublishSettings = Seq(
 )
 
 lazy val commonSettings = Seq(
-  scalaVersion := "2.13.3",
+  scalaVersion := "3.1.0",
   scalacOptions ++= Seq(
     "-encoding", "utf8",
     "-deprecation",
@@ -30,8 +30,7 @@ lazy val commonSettings = Seq(
     "-feature",
     "-language:existentials",
     "-language:higherKinds",
-    "-language:implicitConversions",
-    "-Ypatmat-exhaust-depth", "40"
+    "-language:implicitConversions"
   ),
   scalariformPreferences := scalariformPreferences.value
     .setPreference(AlignSingleLineCaseStatements, true)
@@ -45,7 +44,7 @@ enablePlugins(ScalaJSPlugin)
 
 lazy val replDependencies = Seq(
   "jline" % "jline" % "2.14.6",
-  "org.rogach" %% "scallop" % "3.4.0",
+  "org.rogach" %% "scallop" % "4.1.0",
 )
 
 lazy val lspDependencies = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val noPublishSettings = Seq(
 )
 
 lazy val commonSettings = Seq(
-  scalaVersion := "3.1.0",
+  scalaVersion := "3.1.2",
   scalacOptions ++= Seq(
     "-encoding", "utf8",
     "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -94,10 +94,10 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
     Test / watchTriggers += baseDirectory.value.toGlob / "libraries" / "**" / "*.effekt",
 
     // show duration of the tests
-    testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oD"),
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oD"),
 
     // disable tests for assembly to speed up build
-    test in assembly := {},
+    assembly / test := {},
 
 
     // Options to compile Effekt with native-image
@@ -115,21 +115,21 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
 
     // Assembling one big jar-file and packaging it
     // --------------------------------------------
-    mainClass in assembly := Some("effekt.Server"),
+    assembly / mainClass := Some("effekt.Server"),
 
-    assemblyJarName in assembly := "effekt.jar",
+    assembly / assemblyJarName := "effekt.jar",
 
     // we use the lib folder as resource directory to include it in the JAR
-    Compile / unmanagedResourceDirectories += (baseDirectory in ThisBuild).value / "libraries",
+    Compile / unmanagedResourceDirectories += (ThisBuild / baseDirectory).value / "libraries",
 
-    Compile / unmanagedResourceDirectories += (baseDirectory in ThisBuild).value / "licenses",
+    Compile / unmanagedResourceDirectories += (ThisBuild / baseDirectory).value / "licenses",
 
 
     assembleBinary := {
       val jarfile = assembly.value
 
       // prepend shebang to make jar file executable
-      val binary = (baseDirectory in ThisBuild).value / "bin" / "effekt"
+      val binary = (ThisBuild / baseDirectory).value / "bin" / "effekt"
       IO.delete(binary)
       IO.append(binary, "#! /usr/bin/env java -jar\n")
       IO.append(binary, IO.readBytes(jarfile))
@@ -174,7 +174,7 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
   )
 
 lazy val versionGenerator = Def.task {
-  val sourceDir = (sourceManaged in Compile).value
+  val sourceDir = (Compile / sourceManaged).value
   val sourceFile = sourceDir / "effekt" / "util" / "Version.scala"
 
   IO.write(sourceFile,
@@ -194,10 +194,10 @@ lazy val versionGenerator = Def.task {
  */
 lazy val stdLibGenerator = Def.task {
 
-  val baseDir = (baseDirectory in ThisBuild).value / "libraries" / "js" / "monadic"
+  val baseDir = (ThisBuild / baseDirectory).value / "libraries" / "js" / "monadic"
   val resources = baseDir ** "*.*"
 
-  val sourceDir = (sourceManaged in Compile).value
+  val sourceDir = (Compile / sourceManaged).value
   val sourceFile = sourceDir / "Resources.scala"
 
   if (!sourceFile.exists() || sourceFile.lastModified() < baseDir.lastModified()) {

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val lspDependencies = Seq(
 )
 
 lazy val testingDependencies = Seq(
-  "org.scala-sbt" %% "io" % "1.3.1" % "test",
+  "org.scala-sbt" %% "io" % "1.6.0" % "test",
   "org.scalatest" % "scalatest_2.13" % "3.1.1" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -164,9 +164,6 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
     Compile / sourceGenerators += versionGenerator.taskValue
   )
   .jsSettings(
-    libraryDependencies ++= Seq(
-      //"org.bitbucket.inkytonik.kiama" %%% "kiama-scalajs" % "2.4.0-SNAPSHOT"
-    ),
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
 
     // include all resource files in the virtual file system

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -4,7 +4,9 @@ import java.io.File
 
 import effekt.util.paths.file
 import kiama.util.REPLConfig
+
 import org.rogach.scallop.ScallopOption
+import org.rogach.scallop.{ fileConverter, fileListConverter }
 
 class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
 

--- a/effekt/jvm/src/main/scala/effekt/Repl.scala
+++ b/effekt/jvm/src/main/scala/effekt/Repl.scala
@@ -1,17 +1,17 @@
 package effekt
 
 import effekt.source._
+import effekt.context.{ Context, IOModuleDB }
 import effekt.symbols.{ BlockSymbol, DeclPrinter, Module, ValueSymbol }
 import effekt.util.{ ColoredMessaging, Highlight, VirtualSource }
 import effekt.util.Version.effektVersion
-
 import kiama.util.Messaging.{ Messages, message }
 import kiama.util.{ Console, REPL, Source, StringSource }
 import kiama.parsing.{ NoSuccess, ParseResult, Success }
 
 class Repl(driver: Driver) extends REPL[Tree, EffektConfig] {
 
-  private implicit lazy val context = driver.context
+  private implicit lazy val context: Context with IOModuleDB = driver.context
 
   override val messaging = new ColoredMessaging(positions)
 

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -53,7 +53,7 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
 
     resolveGeneric(decl)
 
-    Context.module.export(imports, scope.terms.toMap, scope.types.toMap)
+    Context.module.exports(imports, scope.terms.toMap, scope.types.toMap)
     decl
   }
 

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -103,8 +103,8 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     }
       | failure("Expected an identifier"))
 
-  lazy val idDef: P[IdDef] = ident ^^ IdDef
-  lazy val idRef: P[IdRef] = ident ^^ IdRef
+  lazy val idDef: P[IdDef] = ident ^^ IdDef.apply
+  lazy val idRef: P[IdRef] = ident ^^ IdRef.apply
 
   lazy val path = someSep(ident, `/`)
 
@@ -207,7 +207,7 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     )
 
   lazy val importDecl: P[Import] =
-    `import` ~/> moduleName ^^ Import
+    `import` ~/> moduleName ^^ Import.apply
 
 
   /**
@@ -234,7 +234,7 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     )
 
   lazy val funDef: P[Def] =
-    `def` ~/> idDef ~ maybeTypeParams ~ some(params) ~ (`:` ~> effectful).? ~ ( `=` ~/> stmt) ^^ FunDef
+    `def` ~/> idDef ~ maybeTypeParams ~ some(params) ~ (`:` ~> effectful).? ~ ( `=` ~/> stmt) ^^ FunDef.apply
 
   lazy val maybePure: P[Boolean] =
     `pure`.? ^^ { _.isDefined }
@@ -244,17 +244,17 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
         case op =>
           EffDef(IdDef(op.id.name) withPositionOf op.id, Nil, List(op))
       }
-    | `effect` ~> idDef ~ maybeTypeParams ~ (`{` ~/> some(`def` ~> effectOp)  <~ `}`) ^^ EffDef
+    | `effect` ~> idDef ~ maybeTypeParams ~ (`{` ~/> some(`def` ~> effectOp)  <~ `}`) ^^ EffDef.apply
     )
 
   lazy val effectOp: P[Operation] =
-    idDef ~ maybeTypeParams ~ some(valueParams) ~/ (`:` ~/> effectful) ^^ Operation
+    idDef ~ maybeTypeParams ~ some(valueParams) ~/ (`:` ~/> effectful) ^^ Operation.apply
 
   lazy val externType: P[Def] =
-    `extern` ~> `type` ~/> idDef ~ maybeTypeParams ^^ ExternType
+    `extern` ~> `type` ~/> idDef ~ maybeTypeParams ^^ ExternType.apply
 
   lazy val externEffect: P[Def] =
-    `extern` ~> `effect` ~/> idDef ~ maybeTypeParams ^^ ExternEffect
+    `extern` ~> `effect` ~/> idDef ~ maybeTypeParams ^^ ExternEffect.apply
 
   lazy val externFun: P[Def] =
     `extern` ~> (maybePure <~ `def`) ~/ idDef ~ maybeTypeParams ~ some(params) ~ (`:` ~> effectful) ~ ( `=` ~/> """\"([^\"]*)\"""".r) ^^ {
@@ -275,19 +275,19 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     )
 
   lazy val valueParams: P[ValueParams] =
-    `(` ~/> manySep(valueParam, `,`) <~ `)` ^^ ValueParams
+    `(` ~/> manySep(valueParam, `,`) <~ `)` ^^ ValueParams.apply
 
   lazy val valueParamsOpt: P[ValueParams] =
-    `(` ~/> manySep(valueParamOpt, `,`) <~ `)` ^^ ValueParams
+    `(` ~/> manySep(valueParamOpt, `,`) <~ `)` ^^ ValueParams.apply
 
   lazy val valueParam: P[ValueParam] =
     idDef ~ (`:` ~> valueType) ^^ { case id ~ tpe => ValueParam(id, Some(tpe)) }
 
   lazy val valueParamOpt: P[ValueParam] =
-    idDef ~ (`:` ~> valueType).? ^^ ValueParam
+    idDef ~ (`:` ~> valueType).? ^^ ValueParam.apply
 
   lazy val blockParam: P[BlockParam] =
-    idDef ~ (`:` ~> blockType) ^^ BlockParam
+    idDef ~ (`:` ~> blockType) ^^ BlockParam.apply
 
   lazy val typeParams: P[List[Id]] =
     `[` ~/> manySep(idDef, `,`) <~ `]`
@@ -322,7 +322,7 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     valueParamsOpt | (idDef ^^ { id => ValueParams(List(ValueParam(id, None))) })
 
   lazy val valueArgs: P[ValueArgs] =
-    `(` ~/> manySep(expr, `,`) <~ `)` ^^ ValueArgs | failure("Expected a value argument list")
+    `(` ~/> manySep(expr, `,`) <~ `)` ^^ ValueArgs.apply | failure("Expected a value argument list")
 
   lazy val typeArgs: P[List[ValueType]] =
     `[` ~/> manySep(valueType, `,`) <~ `]`
@@ -331,8 +331,8 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     typeArgs.? ^^ { o => o.getOrElse(Nil) }
 
   lazy val stmt: P[Stmt] =
-    ( expr ^^ Return
-    | `{` ~/> stmts <~ `}` ^^ BlockStmt
+    ( expr ^^ Return.apply
+    | `{` ~/> stmts <~ `}` ^^ BlockStmt.apply
     | failure("Expected a statement")
     )
 
@@ -341,10 +341,10 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
    */
   lazy val stmts: P[Stmt] =
     ( withStmt
-    | (expr <~ `;`) ~ stmts ^^ ExprStmt
-    | (definition <~ `;`) ~ stmts ^^ DefStmt
-    | (varDef  <~ `;`) ~ stmts ^^ DefStmt
-    | (expr <~ `;`) ^^ Return
+    | (expr <~ `;`) ~ stmts ^^ ExprStmt.apply
+    | (definition <~ `;`) ~ stmts ^^ DefStmt.apply
+    | (varDef  <~ `;`) ~ stmts ^^ DefStmt.apply
+    | (expr <~ `;`) ^^ Return.apply
     | matchDef
     | failure("Expected a statement")
     )
@@ -364,10 +364,10 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     )
 
   lazy val valDef: P[ValDef] =
-     `val` ~> idDef ~ (`:` ~/> valueType).? ~ (`=` ~/> stmt) ^^ ValDef
+     `val` ~> idDef ~ (`:` ~/> valueType).? ~ (`=` ~/> stmt) ^^ ValDef.apply
 
   lazy val varDef: P[VarDef] =
-     `var` ~/> idDef ~ (`:` ~/> valueType).? ~ (`=` ~/> stmt) ^^ VarDef
+     `var` ~/> idDef ~ (`:` ~/> valueType).? ~ (`=` ~/> stmt) ^^ VarDef.apply
 
   // TODO make the scrutinee a statement
   lazy val matchDef: P[Stmt] =
@@ -377,19 +377,19 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
      }
 
   lazy val typeDef: P[TypeDef] =
-    `type` ~> idDef ~ maybeTypeParams ~ (`=` ~/> valueType) ^^ TypeDef
+    `type` ~> idDef ~ maybeTypeParams ~ (`=` ~/> valueType) ^^ TypeDef.apply
 
   lazy val effectAliasDef: P[EffectDef] =
-    `effect` ~> idDef ~ (`=` ~/> effects) ^^ EffectDef
+    `effect` ~> idDef ~ (`=` ~/> effects) ^^ EffectDef.apply
 
   lazy val dataDef: P[DataDef] =
-    `type` ~> idDef ~ maybeTypeParams ~ (`{` ~/> manySep(constructor, `;`) <~ `}`) ^^ DataDef
+    `type` ~> idDef ~ maybeTypeParams ~ (`{` ~/> manySep(constructor, `;`) <~ `}`) ^^ DataDef.apply
 
   lazy val recordDef: P[RecordDef] =
-    `record` ~/> idDef ~ maybeTypeParams ~ valueParams ^^ RecordDef
+    `record` ~/> idDef ~ maybeTypeParams ~ valueParams ^^ RecordDef.apply
 
   lazy val constructor: P[Constructor] =
-    idDef ~ valueParams ^^ Constructor
+    idDef ~ valueParams ^^ Constructor.apply
 
   /**
    * Expressions
@@ -422,22 +422,22 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     )
 
   lazy val callTarget: P[CallTarget] =
-    ( idRef ^^ IdTarget
-    | `(` ~> expr <~ `)` ^^ ExprTarget
+    ( idRef ^^ IdTarget.apply
+    | `(` ~> expr <~ `)` ^^ ExprTarget.apply
     )
 
   lazy val funCall: P[Expr] =
-    callTarget ~ maybeTypeArgs ~ some(args) ^^ Call
+    callTarget ~ maybeTypeArgs ~ some(args) ^^ Call.apply
 
   lazy val matchExpr: P[Expr] =
-    (accessExpr <~ `match` ~/ `{`) ~/ (some(clause) <~ `}`) ^^ MatchExpr
+    (accessExpr <~ `match` ~/ `{`) ~/ (some(clause) <~ `}`) ^^ MatchExpr.apply
 
   // TODO deprecate doExpr
   lazy val doExpr: P[Expr] =
-    `do` ~/> callTarget ~ maybeTypeArgs ~ some(valueArgs) ^^ Call
+    `do` ~/> callTarget ~ maybeTypeArgs ~ some(valueArgs) ^^ Call.apply
 
   lazy val handleExpr: P[Expr] =
-    `try` ~/> stmt ~ some(handler) ^^ TryHandle
+    `try` ~/> stmt ~ some(handler) ^^ TryHandle.apply
 
   lazy val handler: P[Handler] =
     ( `with` ~> effectType ~ (`{` ~> some(defClause) <~ `}`) ^^ {
@@ -457,13 +457,13 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     }
 
   lazy val clause: P[MatchClause] =
-    `case` ~/> pattern ~ (`=>` ~/> stmts) ^^ MatchClause
+    `case` ~/> pattern ~ (`=>` ~/> stmts) ^^ MatchClause.apply
 
   lazy val pattern: P[MatchPattern] =
     ( "_" ^^^ IgnorePattern()
     | literals ^^ { l => LiteralPattern(l) }
-    | idRef ~ (`(` ~> manySep(pattern, `,`)  <~ `)`) ^^ TagPattern
-    | idDef ^^ AnyPattern
+    | idRef ~ (`(` ~> manySep(pattern, `,`)  <~ `)`) ^^ TagPattern.apply
+    | idDef ^^ AnyPattern.apply
     | `(` ~> pattern ~ (`,` ~> some(pattern) <~ `)`) ^^ { case f ~ r =>
         TagPattern(IdRef(s"Tuple${r.size + 1}") withPositionOf f, f :: r)
       }
@@ -473,23 +473,23 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
 
 
   lazy val assignExpr: P[Expr] =
-    idRef ~ (`=` ~> expr) ^^ Assign
+    idRef ~ (`=` ~> expr) ^^ Assign.apply
 
   lazy val ifExpr: P[Expr] =
-    `if` ~/> (`(` ~/> expr <~ `)`) ~/ stmt ~ (`else` ~/> stmt | success(Return(UnitLit()))) ^^ If
+    `if` ~/> (`(` ~/> expr <~ `)`) ~/ stmt ~ (`else` ~/> stmt | success(Return(UnitLit()))) ^^ If.apply
 
   lazy val whileExpr: P[Expr] =
-    `while` ~/> (`(` ~/> expr <~ `)`) ~/ stmt ^^ While
+    `while` ~/> (`(` ~/> expr <~ `)`) ~/ stmt ^^ While.apply
 
   lazy val primExpr: P[Expr] =
     variable | literals | tupleLiteral | listLiteral | hole | `(` ~/> expr <~ `)`
 
   lazy val variable: P[Expr] =
-    idRef ^^ Var
+    idRef ^^ Var.apply
 
   lazy val hole: P[Expr] =
     ( `<>` ^^^ Hole(Return(UnitLit()))
-    | `<{` ~> stmts <~ `}>` ^^ Hole
+    | `<{` ~> stmts <~ `}>` ^^ Hole.apply
     )
 
   lazy val literals: P[Literal[_]] =
@@ -521,8 +521,8 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     ( funType
     | `(` ~> valueType <~ `)`
     | `(` ~> valueType ~ (`,` ~/> some(valueType) <~ `)`) ^^ { case f ~ r => TupleTypeTree(f :: r) }
-    | idRef ~ typeArgs ^^ TypeApp
-    | idRef ^^ TypeVar
+    | idRef ~ typeArgs ^^ TypeApp.apply
+    | idRef ^^ TypeVar.apply
     | failure("Expected a type")
     )
 
@@ -533,7 +533,7 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     }
 
   lazy val blockType: P[BlockType] =
-    ( (`(` ~> manySep(valueType, `,`) <~ `)`) ~ (`=>` ~/> effectful) ^^ BlockType
+    ( (`(` ~> manySep(valueType, `,`) <~ `)`) ~ (`=>` ~/> effectful) ^^ BlockType.apply
     | valueType ~ (`=>` ~/> effectful) ^^ { case t ~ e => BlockType(List(t), e) }
     | effectful ^^ { e => BlockType(Nil, e) }
     )
@@ -551,7 +551,7 @@ class Parser(positions: Positions) extends Parsers(positions) with Phase[Source,
     )
 
   lazy val effectType: P[Effect] =
-    (idRef ~ maybeTypeArgs) ^^ Effect | failure("Expected a single effect")
+    (idRef ~ maybeTypeArgs) ^^ Effect.apply | failure("Expected a single effect")
 
 
   // === AST Helpers ===

--- a/effekt/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Annotations.scala
@@ -312,7 +312,6 @@ trait AnnotationsDB { self: Context =>
     s match {
       case b: BlockSymbol => annotationOption(Annotations.BlockType, b) flatMap {
         case b: InterfaceType => Some(b)
-        case _                => None
       }
       case _ => panic(s"Trying to find a interface type for non block '${s}'")
     }

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -97,7 +97,7 @@ class Transformer extends Phase[Module, core.ModuleDecl] {
       transform(b)
   }
 
-  def transformLit[T](tree: source.Literal[T])(implicit C: Context): Literal[T] = withPosition(tree) {
+  def transformLit[T](tree: source.Literal[T])(implicit C: Context): Literal[T] = withPosition[source.Literal[T], Literal[T]](tree) {
     case source.UnitLit()         => UnitLit()
     case source.IntLit(value)     => IntLit(value)
     case source.BooleanLit(value) => BooleanLit(value)

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -136,6 +136,7 @@ object Tree {
         PureApp(rewrite(b), targs, args map rewrite)
       case Select(target, field) =>
         Select(rewrite(target), field)
+      case Closure(b)    => Closure(rewrite(b))
       case v: ValueVar   => v
       case l: Literal[_] => l
     }
@@ -188,6 +189,8 @@ object Tree {
         Member(rewrite(b), field)
       case Extern(params, body) =>
         Extern(params map rewrite, body)
+      case Unbox(e) =>
+        Unbox(rewrite(e))
       case b: BlockVar => b
     }
     def rewrite(e: Pattern): Pattern = e match {

--- a/effekt/shared/src/main/scala/effekt/generator/ChezSchemeCallCC.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/ChezSchemeCallCC.scala
@@ -219,8 +219,6 @@ trait ChezSchemeBase extends ParenPrettyPrinter {
           brackets(toDoc(pattern) <+> b.params.foldRight(schemeLambda(Nil, toDoc(b.body, false))) {
             case (p, body) => schemeLambda(List(nameDef(p.id)), body)
           })
-
-        case (pattern, b) => sys error "Right hand side of a matcher needs to be a block definition"
       }
       schemeCall("pattern-match", toDoc(sc) :: parens(vsep(clauses, line)) :: Nil)
 

--- a/effekt/shared/src/main/scala/effekt/source/CapabilityPassing.scala
+++ b/effekt/shared/src/main/scala/effekt/source/CapabilityPassing.scala
@@ -145,6 +145,7 @@ class CapabilityPassing extends Phase[ModuleDecl, ModuleDecl] with Rewrite {
           C.withCapabilities(effs) { caps =>
             source.BlockArg(ps ++ caps, rewrite(body))
           }
+        case _ => Context.panic("Invalid combination of arguments and parameter types")
       }
     }
 

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -468,6 +468,9 @@ object Tree {
 
       case Hole(stmts) =>
         Hole(rewrite(stmts))
+
+      case Lambda(id, params, body) =>
+        Lambda(id, params, rewrite(body))
     }
 
     def rewrite(t: Def)(implicit C: Context): Def = visit(t) {

--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -68,6 +68,7 @@ object DeclPrinter extends ParenPrettyPrinter {
       case l: List[ValueParam @unchecked] =>
         val vps = l.map { p => s"${p.name}: ${p.tpe.get}" }.mkString(", ")
         s"($vps)"
+      case _ => sys error "Parameter lists are either singleton block params or a list of value params."
     }.mkString
 
     s"$kw ${f.name}$tps$ps${ret.map { tpe => s": $tpe" }.getOrElse("")}"

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -76,7 +76,7 @@ package object symbols {
      * The dependencies of a module might change, which triggers frontend on the same module
      * again. It is the same, since the source and AST did not change.
      */
-    def export(
+    def exports(
       imports: List[Module],
       terms: Map[String, Set[TermSymbol]],
       types: Map[String, TypeSymbol]

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -218,8 +218,9 @@ package object symbols {
       val BlockType(_, params, Effectful(ret, effs)) = tpe
       // copy and paste from BlockType.toString
       val ps = params.map {
-        case List(b: BlockType)             => s"{${b.toString}}"
+        case List(b: BlockType) => s"{${b.toString}}"
         case ps: List[ValueType @unchecked] => s"(${ps.map { _.toString }.mkString(", ")})"
+        case _ => sys error "Parameter lists are either singleton block params or a list of value params."
       }.mkString("")
 
       val effects = effs.toList
@@ -266,8 +267,9 @@ package object symbols {
   case class BlockType(tparams: List[TypeVar], params: Sections, ret: Effectful) extends InterfaceType {
     override def toString: String = {
       val ps = params.map {
-        case List(b: BlockType)             => s"{${b.toString}}"
+        case List(b: BlockType) => s"{${b.toString}}"
         case ps: List[ValueType @unchecked] => s"(${ps.map { _.toString }.mkString(", ")})"
+        case _ => sys error "Parameter lists are either singleton block params or a list of value params."
       }.mkString("")
 
       tparams match {

--- a/kiama/jvm/src/main/scala/kiama/util/Config.scala
+++ b/kiama/jvm/src/main/scala/kiama/util/Config.scala
@@ -12,6 +12,7 @@ package kiama
 package util
 
 import org.rogach.scallop.ScallopConf
+import org.rogach.scallop.intConverter
 
 /**
  * Configurations for Kiama programs. `args` gives the command-line

--- a/kiama/shared/src/main/scala/kiama/util/Trampoline.scala
+++ b/kiama/shared/src/main/scala/kiama/util/Trampoline.scala
@@ -47,14 +47,14 @@ object Trampolines {
           a match {
             case Done(v)       => f(v).resume
             case More(k)       => Left(() => k() flatMap f)
-            case FlatMap(b, g) => b.flatMap((x: Any) => g(x) flatMap f).resume
+            case FlatMap(b, g) => b.flatMap(x => g(x) flatMap f).resume
           }
       }
 
     def flatMap[B](f: A => Trampoline[B]): Trampoline[B] =
       this match {
         case FlatMap(a, g) =>
-          FlatMap(a, (x: Any) => g(x) flatMap f)
+          FlatMap(a, x => g(x) flatMap f)
         case x =>
           FlatMap(x, f)
       }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 // build native images using GraalVM
-addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.1.2")
+// addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.1.2")


### PR DESCRIPTION
This PR migrates the code base to Scala 3.

The migration should be performed in two steps:

1.  fix compilation issues to compile it _at all_ again.
2. move to Scala 3 idioms

This PR only targets (1).  Things to do:

- [x] enable `-Xfatal-warnings` again and fix the exhaustivity checks