### PR TITLE
Port back the names refactoring from System C

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -79,7 +79,7 @@ trait LSPServer extends kiama.util.Server[Tree, ModuleDecl, EffektConfig] with D
     decl = id // TODO for now we use id as the declaration. This should be improved in SymbolsDB
     kind <- getSymbolKind(sym)
     detail <- getInfoOf(sym)(context)
-  } yield new DocumentSymbol(sym.name.localName, kind, rangeOfNode(decl), rangeOfNode(id), detail.header))
+  } yield new DocumentSymbol(sym.name.name, kind, rangeOfNode(decl), rangeOfNode(id), detail.header))
 
   override def getReferences(position: Position, includeDecl: Boolean): Option[Vector[Tree]] =
     for {

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -5,9 +5,9 @@ package namer
  * In this file we fully qualify source types, but use symbols directly
  */
 import effekt.context.{ Context, ContextOps }
-import effekt.context.assertions.SymbolAssertions
+import effekt.context.assertions._
 import effekt.regions.Region
-import effekt.source.{ Def, Id, IdDef, IdRef, ModuleDecl, Named, Tree }
+import effekt.source.{ Def, Id, IdDef, IdRef, ModuleDecl, Named, Tree, ValueParams }
 import effekt.symbols._
 import scopes._
 
@@ -47,7 +47,7 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
     }
 
     // create new scope for the current module
-    scope = scope.enter
+    scope = scope.enterGlobal
 
     Context.initNamerstate(scope)
 
@@ -55,6 +55,111 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
 
     Context.module.exports(imports, scope.terms.toMap, scope.types.toMap)
     decl
+  }
+
+  /**
+   * To allow mutually recursive definitions, here we only resolve the declarations,
+   * not the bodies of functions.
+   */
+  def preresolve(d: Def)(implicit C: Context): Unit = Context.focusing(d) {
+
+    case d @ source.ValDef(id, annot, binding) =>
+      ()
+
+    case d @ source.VarDef(id, annot, binding) =>
+      ()
+
+    case f @ source.FunDef(id, tparams, params, annot, body) =>
+      val uniqueId = Context.freshNameFor(id)
+      // we create a new scope, since resolving type params introduces them in this scope
+      val sym = Context scoped {
+        val tps = tparams map resolve
+        // TODO resolve(ParamSection) loses structural information about value params and block params.
+        //   we should refactor!
+        val ps = params map resolve
+        val ret = Context scoped {
+          C.bindParams(ps)
+          annot map resolve
+        }
+        UserFunction(uniqueId, tps, ps, ret, f)
+      }
+      Context.define(id, sym)
+
+    case source.EffDef(id, tparams, ops) =>
+      val effectName = Name.qualified(id)
+      // we use the localName for effects, since they will be bound as capabilities
+      val effectSym = Context scoped {
+        val tps = tparams map resolve
+        // we do not resolve the effect operations here to allow them to refer to types that are defined
+        // later in the file
+        UserEffect(effectName, tps)
+      }
+      Context.define(id, effectSym)
+
+    case source.TypeDef(id, tparams, tpe) =>
+      val tps = Context scoped { tparams map resolve }
+      val alias = Context scoped {
+        tps.foreach { t => Context.bind(t) }
+        TypeAlias(Name.qualified(id), tps, resolve(tpe))
+      }
+      Context.define(id, alias)
+
+    case source.EffectDef(id, effs) =>
+      val alias = Context scoped {
+        EffectAlias(Name.qualified(id), Nil, resolve(effs))
+      }
+      Context.define(id, alias)
+
+    case source.DataDef(id, tparams, ctors) =>
+      val typ = Context scoped {
+        val tps = tparams map resolve
+        // we do not resolve the constructors here to allow them to refer to types that are defined
+        // later in the file
+        DataType(C.nameFor(id), tps)
+      }
+      Context.define(id, typ)
+
+    case source.RecordDef(id, tparams, fields) =>
+      lazy val sym: Record = {
+        val tps = Context scoped { tparams map resolve }
+        // we do not resolve the fields here to allow them to refer to types that are defined
+        // later in the file
+        Record(C.nameFor(id), tps, null)
+      }
+      sym.tpe = if (sym.tparams.isEmpty) sym else TypeApp(sym, sym.tparams)
+
+      // define constructor
+      Context.define(id, sym: TermSymbol)
+      // define record type
+      Context.define(id, sym: TypeSymbol)
+
+    case source.ExternType(id, tparams) =>
+      Context.define(id, Context scoped {
+        val tps = tparams map resolve
+        BuiltinType(C.nameFor(id), tps)
+      })
+
+    case source.ExternEffect(id, tparams) =>
+      Context.define(id, Context scoped {
+        val tps = tparams map resolve
+        BuiltinEffect(C.nameFor(id), tps)
+      })
+
+    case source.ExternFun(pure, id, tparams, params, ret, body) => {
+      val name = Context.freshNameFor(id)
+      Context.define(id, Context scoped {
+        val tps = tparams map resolve
+        val ps: Params = params map resolve
+        val tpe = resolve(ret)
+        BuiltinFunction(name, tps, ps, Some(tpe), pure, body)
+      })
+    }
+
+    case d @ source.ExternInclude(path) =>
+      d.contents = Context.contentsOf(path).getOrElse {
+        C.abort(s"Missing include: ${path}")
+      }
+      ()
   }
 
   /**
@@ -66,40 +171,40 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
 
     // (1) === Binding Occurrences ===
     case source.ModuleDecl(path, imports, decls) =>
-      decls foreach { resolve }
+      decls foreach { preresolve }
       resolveAll(decls)
 
     case source.DefStmt(d, rest) =>
       // resolve declarations but do not resolve bodies
-      resolve(d)
+      preresolve(d)
       // resolve bodies
       resolveGeneric(d)
       resolveGeneric(rest)
 
     case source.ValueParam(id, tpe) =>
-      Context.define(id, ValueParam(Name(id), tpe.map(resolve)))
+      Context.define(id, ValueParam(Name.local(id), tpe.map(resolve)))
 
     case source.BlockParam(id, tpe) =>
-      Context.define(id, BlockParam(Name(id), resolve(tpe)))
+      Context.define(id, BlockParam(Name.local(id), resolve(tpe)))
 
     case d @ source.ValDef(id, annot, binding) =>
       val tpe = annot.map(resolve)
       resolveGeneric(binding)
-      Context.define(id, ValBinder(Name(id), tpe, d))
+      Context.define(id, ValBinder(Name.local(id), tpe, d))
 
     case d @ source.VarDef(id, annot, binding) =>
       val tpe = annot.map(resolve)
       resolveGeneric(binding)
-      Context.define(id, VarBinder(Name(id), tpe, d))
+      Context.define(id, VarBinder(Name.local(id), tpe, d))
 
     // FunDef and EffDef have already been resolved as part of the module declaration
-    case f @ source.FunDef(id, tparams, params, ret, body) =>
+    case f @ source.FunDef(id, tparams, vparams, ret, body) =>
       val sym = Context.symbolOf(f)
       Context scoped {
         sym.tparams.foreach { p =>
           Context.bind(p)
         }
-        Context.bind(sym.params)
+        Context.bindParams(sym.params)
         resolveGeneric(body)
       }
 
@@ -107,7 +212,9 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
       val effectSym = Context.resolveType(id).asUserEffect
       effectSym.ops = ops.map {
         case source.Operation(id, tparams, params, ret) =>
-          val name = Context.freshTermName(id)
+          // effect operations are always selected, no functions are generated, so we use a local name here
+          val name = Name.local(id)
+
           Context scoped {
             // the parameters of the effect are in scope
             effectSym.tparams.foreach { p => Context.bind(p) }
@@ -117,7 +224,7 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
             // The type parameters of an effect op are:
             //   1) all type parameters on the effect, followed by
             //   2) the annotated type parameters on the concrete operation
-            val op = EffectOp(Name(id), effectSym.tparams ++ tps, params map resolve, resolve(ret), effectSym)
+            val op = EffectOp(name, effectSym.tparams ++ tps, params map resolve, resolve(ret), effectSym)
             Context.define(id, op)
             op
           }
@@ -132,7 +239,7 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
       val typ = d.symbol
       typ.variants = ctors map {
         case source.Constructor(id, ps) =>
-          val name = Context.freshTermName(id)
+          val name = Context.freshNameFor(id)
           val ctorRet = if (typ.tparams.isEmpty) typ else TypeApp(typ, typ.tparams)
           val record = Record(name, typ.tparams, ctorRet)
           // define constructor
@@ -196,7 +303,7 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
 
           val ps = params.map(resolve)
           Context scoped {
-            Context.bind(ps)
+            Context.bindParams(ps)
             Context.define(resumeId, ResumeParam(C.module))
             resolveGeneric(body)
           }
@@ -212,14 +319,14 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
     case source.BlockArg(params, stmt) =>
       val ps = params.map(resolve)
       Context scoped {
-        Context.bind(ps)
+        Context.bindParams(ps)
         resolveGeneric(stmt)
       }
 
     case l @ source.Lambda(id, params, stmt) =>
       val ps = params.map(resolve)
       Context scoped {
-        Context.bind(ps)
+        Context.bindParams(ps)
         resolveGeneric(stmt)
       }
       val sym = Lambda(ps, l)
@@ -256,7 +363,7 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
       (paramSyms zip params) map {
         case (paramSym, paramTree) =>
           val fieldId = paramTree.id.clone
-          val name = Context.freshTermName(fieldId)
+          val name = Context.freshNameFor(fieldId)
           val fieldSym = Field(name, paramSym, record)
           Context.define(fieldId, fieldSym)
           fieldSym
@@ -284,17 +391,17 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
   def resolve(params: source.ParamSection)(implicit C: Context): List[Param] = Context.focusing(params) {
     case ps: source.ValueParams => resolve(ps)
     case source.BlockParam(id, tpe) =>
-      val sym = BlockParam(Name(id), resolve(tpe))
+      val sym = BlockParam(Name.local(id), resolve(tpe))
       Context.assignSymbol(id, sym)
       List(sym)
     case source.CapabilityParam(id, tpe) =>
-      val sym = CapabilityParam(Name(id), resolve(tpe))
+      val sym = CapabilityParam(Name.local(id), resolve(tpe))
       Context.assignSymbol(id, sym)
       List(sym)
   }
   def resolve(ps: source.ValueParams)(implicit C: Context): List[ValueParam] =
     ps.params map { p =>
-      val sym = ValueParam(Name(p.id), p.tpe.map(resolve))
+      val sym = ValueParam(Name.local(p.id), p.tpe.map(resolve))
       Context.assignSymbol(p.id, sym)
       sym
     }
@@ -308,108 +415,6 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
   }
 
   /**
-   * To allow mutually recursive definitions, here we only resolve the declarations,
-   * not the bodies of functions.
-   */
-  def resolve(d: Def)(implicit C: Context): Unit = Context.focusing(d) {
-
-    case d @ source.ValDef(id, annot, binding) =>
-      ()
-
-    case d @ source.VarDef(id, annot, binding) =>
-      ()
-
-    case f @ source.FunDef(id, tparams, params, annot, body) =>
-      val uniqueId = Context.freshTermName(id)
-      // we create a new scope, since resolving type params introduces them in this scope
-      val sym = Context scoped {
-        val tps = tparams map resolve
-        val ps = params map resolve
-        val ret = Context scoped {
-          Context.bind(ps)
-          annot map resolve
-        }
-        UserFunction(uniqueId, tps, ps, ret, f)
-      }
-      Context.define(id, sym)
-
-    case source.EffDef(id, tparams, ops) =>
-      // we use the localName for effects, since they will be bound as capabilities
-      val effectSym = Context scoped {
-        val tps = tparams map resolve
-        // we do not resolve the effect operations here to allow them to refer to types that are defined
-        // later in the file
-        UserEffect(Name(id), tps)
-      }
-      Context.define(id, effectSym)
-
-    case source.TypeDef(id, tparams, tpe) =>
-      val tps = Context scoped { tparams map resolve }
-      val alias = Context scoped {
-        tps.foreach { t => Context.bind(t) }
-        TypeAlias(Name(id), tps, resolve(tpe))
-      }
-      Context.define(id, alias)
-
-    case source.EffectDef(id, effs) =>
-      val alias = Context scoped {
-        EffectAlias(Name(id), Nil, resolve(effs))
-      }
-      Context.define(id, alias)
-
-    case source.DataDef(id, tparams, ctors) =>
-      val typ = Context scoped {
-        val tps = tparams map resolve
-        // we do not resolve the constructors here to allow them to refer to types that are defined
-        // later in the file
-        DataType(Name(id), tps)
-      }
-      Context.define(id, typ)
-
-    case source.RecordDef(id, tparams, fields) =>
-      lazy val sym: Record = {
-        val tps = Context scoped { tparams map resolve }
-        // we do not resolve the fields here to allow them to refer to types that are defined
-        // later in the file
-        Record(Name(id), tps, null)
-      }
-      sym.tpe = if (sym.tparams.isEmpty) sym else TypeApp(sym, sym.tparams)
-
-      // define constructor
-      Context.define(id, sym: TermSymbol)
-      // define record type
-      Context.define(id, sym: TypeSymbol)
-
-    case source.ExternType(id, tparams) =>
-      Context.define(id, Context scoped {
-        val tps = tparams map resolve
-        BuiltinType(Name(id), tps)
-      })
-
-    case source.ExternEffect(id, tparams) =>
-      Context.define(id, Context scoped {
-        val tps = tparams map resolve
-        BuiltinEffect(Name(id), tps)
-      })
-
-    case source.ExternFun(pure, id, tparams, params, ret, body) => {
-      val name = Context.freshTermName(id)
-      Context.define(id, Context scoped {
-        val tps = tparams map resolve
-        val ps: Params = params map resolve
-        val tpe = resolve(ret)
-        BuiltinFunction(name, tps, ps, Some(tpe), pure, body)
-      })
-    }
-
-    case d @ source.ExternInclude(path) =>
-      d.contents = Context.contentsOf(path).getOrElse {
-        C.abort(s"Missing include: ${path}")
-      }
-      ()
-  }
-
-  /**
    * Resolve pattern matching
    *
    * Returns the value params it binds
@@ -418,7 +423,7 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
     case source.IgnorePattern()     => Nil
     case source.LiteralPattern(lit) => Nil
     case source.AnyPattern(id) =>
-      val p = ValueParam(Name(id), None)
+      val p = ValueParam(Name.local(id), None)
       Context.assignSymbol(id, p)
       List(p)
     case source.TagPattern(id, patterns) =>
@@ -505,7 +510,7 @@ class Namer extends Phase[ModuleDecl, ModuleDecl] {
    * Resolves type variables, term vars are resolved as part of resolve(tree: Tree)
    */
   def resolve(id: Id)(implicit C: Context): TypeVar = {
-    val sym = TypeVar(Name(id))
+    val sym = TypeVar(Name.local(id))
     Context.define(id, sym)
     sym
   }
@@ -533,14 +538,25 @@ trait NamerOps extends ContextOps { Context: Context =>
     result
   }
 
+  private[namer] def nameFor(id: Id): Name = nameFor(id.name)
+
+  private[namer] def nameFor(id: String): Name = {
+    if (scope.isGlobal) Name.qualified(id, module)
+    else LocalName(id)
+  }
+
   // TODO we only want to add a seed to a name under the following conditions:
   // - there is already another instance of that name in the same
   //   namespace.
   // - if it is not already fully qualified
-  private[namer] def freshTermName(id: Id): Name = {
+  private[namer] def freshLocalName(id: Id): LocalName = LocalName(freshTermName(id))
+
+  private[namer] def freshNameFor(id: Id): Name = nameFor(freshTermName(id))
+
+  private[namer] def freshTermName(id: Id): String = {
     val alreadyBound = scope.currentTermsFor(id.name).size
     val seed = if (alreadyBound > 0) "$" + alreadyBound else ""
-    Name(id.name + seed, module)
+    id.name + seed
   }
 
   // Name Binding and Resolution
@@ -555,12 +571,25 @@ trait NamerOps extends ContextOps { Context: Context =>
     scope.define(id.name, s)
   }
 
-  private[namer] def bind(s: TermSymbol): Unit = scope.define(s.name.localName, s)
+  private[namer] def bind(s: TermSymbol): Unit = scope.define(s.name.name, s)
 
-  private[namer] def bind(s: TypeSymbol): Unit = scope.define(s.name.localName, s)
+  private[namer] def bind(s: TypeSymbol): Unit = scope.define(s.name.name, s)
 
-  private[namer] def bind(params: List[List[Param]]): Context = {
+  private[namer] def bindParams(params: Params): Context = {
     params.flatten.foreach { p => bind(p) }
+    this
+  }
+
+  private[namer] def bindValue(params: List[ValueParam]): Context = {
+    params.foreach { p => bind(p) }
+    this
+  }
+
+  private[namer] def bindBlock(params: List[BlockParam]): Context = {
+    params.foreach { p =>
+      // bind the block parameter as a term
+      bind(p)
+    }
     this
   }
 
@@ -591,7 +620,8 @@ trait NamerOps extends ContextOps { Context: Context =>
       abort(s"Cannot resolve function ${id.name}")
     }
 
-    assignSymbol(id, new CallTarget(Name(id), syms))
+    // TODO does local name make sense here?
+    assignSymbol(id, new CallTarget(Name.local(id), syms))
   }
 
   /**
@@ -609,7 +639,7 @@ trait NamerOps extends ContextOps { Context: Context =>
   }
 
   private[namer] def scoped[R](block: => R): R = Context in {
-    scope = scope.enter
+    scope = scope.enterLocal
     block
   }
 }

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -567,7 +567,7 @@ class Typer extends Phase[ModuleDecl, ModuleDecl] {
               Context.abort(s"Cannot find type for ${sym.name} -- if it is a recursive definition try to annotate the return type.")
             }
           }
-          val r = checkCallTo(call, sym.name.localName, tpe, targs, args, expected)
+          val r = checkCallTo(call, sym.name.name, tpe, targs, args, expected)
           (r, C.backupTyperstate())
         }
       }
@@ -622,7 +622,12 @@ class Typer extends Phase[ModuleDecl, ModuleDecl] {
         // reraise all and abort
         val msgs = failed.flatMap {
           // TODO also print signature!
-          case (block, msgs) => msgs.map { m => m.copy(label = s"Possible overload ${block.name.qualifiedName}: ${m.label}") }
+          case (block, msgs) =>
+            val fullname = block.name match {
+              case q: QualifiedName => q.qualifiedName
+              case n                => n.name
+            }
+            msgs.map { m => m.copy(label = s"Possible overload ${fullname}: ${m.label}") }
         }.toVector
 
         C.reraise(msgs)

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -104,7 +104,7 @@ case class Here() extends Scope
 case class Nested(list: List[Scope]) extends Scope
 case class ScopeVar(id: Symbol) extends Scope
 
-case class ScopeId() extends Symbol { val name = Name(s"ev${id}", effekt.symbols.builtins.prelude) }
+case class ScopeId() extends Symbol { val name = Name.local(s"ev${id}") }
 
 object Tree {
 

--- a/effekt/shared/src/main/scala/effekt/source/CapabilityPassing.scala
+++ b/effekt/shared/src/main/scala/effekt/source/CapabilityPassing.scala
@@ -191,7 +191,7 @@ trait CapabilityPassingOps extends ContextOps { Context: Context =>
     }
     // additional block parameters for capabilities
     val params = caps.map { sym =>
-      val id = IdDef(sym.name.localName)
+      val id = IdDef(sym.name.name)
       assignSymbol(id, sym)
       source.CapabilityParam(id, source.CapabilityType(sym.effect))
     }
@@ -204,7 +204,7 @@ trait CapabilityPassingOps extends ContextOps { Context: Context =>
 
   private[source] def capabilityReferenceFor(e: Effect): IdRef =
     capabilities.get(e).map { c =>
-      val id = IdRef(c.name.localName)
+      val id = IdRef(c.name.name)
       assignSymbol(id, c)
       //Var(id)
       id

--- a/effekt/shared/src/main/scala/effekt/symbols/Name.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/Name.scala
@@ -3,83 +3,48 @@ package effekt.symbols
 import effekt.source.Id
 import effekt.context.Context
 
-trait Name {
+sealed trait Name {
   /**
-   * The local part of the name relative to its potential parent.
-   *
-   * @example The local part of the name `"foo.baz.bar"` is `"bar"`.
+   * The local part of the name
    */
-  val localName: String
+  def name: String
 
   /**
-   * Computes the qualified version of this name.
-   * @return a String containing the local part of this name prefixed by their parent name. Components are separated by the point character (`.`).
-   *
-   * @note this should only be used for reporting errors, not for code generation.
-   */
-  def qualifiedName: String
-
-  /**
-   * @return The parent of this name or [[None]] if this name represents a top-level name.
-   */
-  def parentOption: Option[Name]
-
-  /**
-   * @return The qualified name of the parent or `None` if this name doesn't have a parent.
-   */
-  def qualifiedParentOption: Option[String] = parentOption.map((parent) => parent.qualifiedName)
-
-  /**
-   * Creates a new name with the same parent as this name and the changed local name.
-   * @param f rename function.
-   * @return A Name with local name equal to `f(this.localName)`.
+   * Renames the local part of the name
    */
   def rename(f: String => String): Name
 
-  /**
-   * Creates a new [[NestedName]] with this name as the parent.
-   * @param name the local name of the nested name.
-   * @return A [[NestedName]] with this Name as parent.
-   */
-  def nested(name: String) = NestedName(this, name)
+  override def toString = name
+}
 
-  override def toString = localName
+case object NoName extends Name {
+  def name = "<anon>"
+  def rename(f: String => String): NoName.type = this
 }
 
 /**
- * A Name without a parent, e.g. the name of a global symbol.
- * @param localName the local name which is also the qualified name.
- * The local name should not contain point characters (`'.'`). This could lead to unexpected behavior.
- *
- * @note Don't use the constructor of this type directly. Instead use [[Name(qualifiedName)]] to safely convert strings to names.
+ * Names of local variables, local definitions, and members like fields
  */
-case class ToplevelName(localName: String) extends Name {
-  def parentOption: Option[Name] = None
-
-  def qualifiedName: String = localName
-
-  def rename(f: String => String): Name = ToplevelName(f(localName))
+case class LocalName(name: String) extends Name {
+  def rename(f: String => String): LocalName = LocalName(f(name))
 }
 
 /**
- * A Name which is a child of a other name, e.g. the name of a nested module.
- *
- * @param parent The parent of this name.
- * @param localName The local name relative to the parent.
- * The local name should not contain point characters (`'.'`). This could lead to unexpected behavior.
- *
- * @note Creation of [[NestedName]] via the [[Name.nested()]] method is prefered.
+ * Names of definitions that are globally reachable via a stable path
  */
-case class NestedName(parent: Name, localName: String) extends Name {
-  def parentOption: Some[Name] = Some(parent)
-
-  def qualifiedName: String = s"${parent.qualifiedName}.$localName"
-
-  def rename(f: String => String): Name = NestedName(parent, f(localName))
+case class QualifiedName(prefix: List[String], name: String) extends Name {
+  val localName = name
+  val qualifiedName = (prefix :+ name).mkString(".")
+  def rename(f: String => String): QualifiedName = QualifiedName(prefix, f(name))
 }
 
 // Pseudo-constructors to safely convert ids and strings into names.
 object Name {
+
+  def local(id: Id): LocalName = local(id.name)
+
+  def local(id: String): LocalName = LocalName(id)
+
   /**
    * Creates a name for the ID inside the module of the current context.
    *
@@ -87,7 +52,7 @@ object Name {
    * @param C The implicit context used to find the current module.
    * @return A qualified name inside the module.
    */
-  def apply(id: Id)(implicit C: Context): Name = Name.apply(id.name, C.module)
+  def qualified(id: Id)(implicit C: Context): Name = Name.qualified(id.name, C.module)
 
   /**
    * Creates a qualified name for a symbol inside the given module.
@@ -98,32 +63,6 @@ object Name {
    *
    * @example The name `"baz"` inside the module with the path `"foo/bar"` is parsed as qualified name `"foo.bar.baz"`
    */
-  def apply(name: String, module: Module): Name = module.name.nested(name)
+  def qualified(name: String, module: Module): QualifiedName = QualifiedName(module.path.split("/").toList, name)
 
-  /**
-   * Parses a [[Name]] from a String which might be a qualified name.
-   * @param name A non-empty String which might be a qualified or local name.
-   * @return A Name where [[Name.qualifiedName]] is equal to the input name.
-   *
-   * @example `Name("foo") == ToplevelName("foo")`
-   * @example `Name("foo.bar.baz") == NestedName(NestedName(ToplevelName("foo"), "bar"), "baz")`
-   */
-  def apply(name: String): Name = {
-    assert(name.nonEmpty, "Name cannot be empty.")
-
-    val segments = name.split('.')
-    val top: Name = ToplevelName(segments.head)
-    segments.drop(1).foldLeft(top)((parent, segment) => parent.nested(segment))
-  }
-
-  /**
-   * Convert a module path into a valid name.
-   *
-   * @param path the module path where each segment is separated by a slash character (`'/'`).
-   * @return a qualified name with the same name components as the input path.
-   *
-   * @example `module("foo/bar/baz") == Name("foo.bar.baz")`
-   * @note this method might be removed in the future because module paths don't exists in the new module-system.
-   */
-  def module(path: String): Name = Name(path.replace("/", "."))
 }

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -12,7 +12,7 @@ object builtins {
   // defined in the prelude
   lazy val prelude = Module(ModuleDecl("effekt", Nil, Nil), StringSource("", "effekt.effekt"))
 
-  private def name(s: String) = Name(s, prelude)
+  private def name(s: String) = Name.qualified(s, prelude)
 
   val TInt = BuiltinType(name("Int"), Nil)
   val TBoolean = BuiltinType(name("Boolean"), Nil)

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -37,7 +37,11 @@ package object symbols {
     decl: ModuleDecl,
     source: Source
   ) extends Symbol {
-    val name = Name.module(decl.path)
+
+    val name = {
+      val segments = decl.path.split("/")
+      QualifiedName(segments.tail.toList, segments.head)
+    }
 
     def path = decl.path
 
@@ -99,7 +103,7 @@ package object symbols {
     override def toString = s"@${tpe.eff.name}"
   }
 
-  case class ResumeParam(module: Module) extends TrackedParam with BlockSymbol { val name = Name("resume", module) }
+  case class ResumeParam(module: Module) extends TrackedParam with BlockSymbol { val name = Name.local("resume") }
 
   /**
    * Right now, parameters are a union type of a list of value params and one block param.
@@ -148,7 +152,7 @@ package object symbols {
    * Anonymous symbols used to represent scopes / regions in the region checker
    */
   sealed trait Anon extends TermSymbol {
-    val name = Name("<anon>")
+    val name = NoName
     def decl: source.Tree
   }
 
@@ -184,8 +188,8 @@ package object symbols {
   /**
    * Introduced by Transformer
    */
-  case class Wildcard(module: Module) extends ValueSymbol { val name = Name("_", module) }
-  case class Tmp(module: Module) extends ValueSymbol { val name = Name("tmp" + Symbol.fresh.next(), module) }
+  case class Wildcard(module: Module) extends ValueSymbol { val name = Name.local("_") }
+  case class Tmp(module: Module) extends ValueSymbol { val name = Name.local("tmp" + Symbol.fresh.next()) }
 
   /**
    * A symbol that represents a termlevel capability

--- a/libraries/js/monadic/effekt_runtime.js
+++ b/libraries/js/monadic/effekt_runtime.js
@@ -46,10 +46,10 @@ const $runtime = (function() {
   function Cell(init) {
     var _value = init;
     return {
-      "op$get": function() {
+      "$get": function() {
         return $effekt.pure(_value)
       },
-      "op$put": function(v) {
+      "put": function(v) {
         _value = v;
         return $effekt.pure($effekt.unit)
       },

--- a/libraries/js/monadic/effekt_runtime.js
+++ b/libraries/js/monadic/effekt_runtime.js
@@ -46,10 +46,10 @@ const $runtime = (function() {
   function Cell(init) {
     var _value = init;
     return {
-      "$get": function() {
+      "op$get": function() {
         return $effekt.pure(_value)
       },
-      "put": function(v) {
+      "op$put": function(v) {
         _value = v;
         return $effekt.pure($effekt.unit)
       },


### PR DESCRIPTION
In the System C implementation, we slightly changed the representation of names. This PR brings those changes to the Effekt compiler.

In particular, we distinguish between names in source that are
- _local_, that is, local variables, function parameters, etc.
- _global_ (or static), that are reachable by a FQN (like toplevel definitions, etc.)

The JavaScript Monadic backend is the only one that is rather fragile in its treatment of names, since it doesn't perform whole program generation (scrambling names), but instead generates node modules.