### PR TITLE
Feature/pure core

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -41,10 +41,12 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case l: Literal[t] => l.value.toString
     case ValueVar(id)  => id.name.toString
 
-    case PureApp(b, targs, args) => toDoc(b) <> parens(hsep(args map {
+    case DirectApp(b, targs, args) => toDoc(b) <> parens(hsep(args map {
       case e: Expr  => toDoc(e)
       case b: Block => toDoc(b)
     }, comma))
+
+    case PureApp(b, targs, args) => toDoc(b) <> parens(hsep(args map toDoc, comma))
 
     case Select(b, field) =>
       toDoc(b) <> "." <> toDoc(field.name)

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -109,7 +109,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case While(cond, body) =>
       "while" <+> parens(toDoc(cond)) <+> braces(nest(line <> toDoc(body)) <+> line)
 
-    case Ret(e) =>
+    case Return(e) =>
       "return" <+> toDoc(e)
 
     case Handle(body, hs) =>

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -67,10 +67,10 @@ object PrettyPrinter extends ParenPrettyPrinter {
       toDocStmt(s)
 
   def toDoc(p: Pattern): Doc = p match {
-    case IgnorePattern()          => "_"
-    case LiteralPattern(l)        => toDoc(l)
-    case AnyPattern()             => "*"
-    case TagPattern(id, patterns) => toDoc(id.name) <> parens(hsep(patterns map toDoc, comma))
+    case IgnorePattern()           => "_"
+    case Pattern.LiteralPattern(l) => toDoc(l)
+    case AnyPattern()              => "*"
+    case TagPattern(id, patterns)  => toDoc(id.name) <> parens(hsep(patterns map toDoc, comma))
   }
 
   def toDoc(handler: Handler): Doc = braces(nest(line <> vsep(handler.clauses.map { case (id, b) => toDoc(id.name) <> ":" <+> toDoc(b) }, comma)) <> line)

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -146,7 +146,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
         case op @ source.OpClause(id, tparams, vparams, body, resume) =>
           val vps = vparams map transform
           // currently the don't take block params
-          val opBlock = BlockLit(vps, transform(body))
+          val opBlock: BlockLit = BlockLit(vps, transform(body))
           (op.definition, opBlock)
       }))
 
@@ -230,7 +230,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
               // introduce a block parameter for resume
               val resumeParam = BlockParam(resume.symbol.asInstanceOf[BlockSymbol])
 
-              val opBlock = BlockLit(ps :+ resumeParam, transform(body))
+              val opBlock: BlockLit = BlockLit(ps :+ resumeParam, transform(body))
               (op.definition, opBlock)
           })
       }

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -17,7 +17,7 @@ sealed trait Tree extends Product {
 case class ModuleDecl(path: String, imports: List[String], defs: Stmt, exports: List[Symbol]) extends Tree
 
 /**
- * Fine-grain CBV: Arguments can be either pure expressions or blocks
+ * Fine-grain CBV: Arguments can be either pure expressions [[Pure]] or blocks [[Block]]
  */
 sealed trait Argument extends Tree
 
@@ -40,22 +40,25 @@ case class Run(s: Stmt) extends Expr
  * Pure Expressions (no IO effects, or control effects)
  */
 sealed trait Pure extends Expr with Argument
-case class ValueVar(id: ValueSymbol) extends Pure
+object Pure {
+  case class ValueVar(id: ValueSymbol) extends Pure
 
-enum Literal[T](val value: T) extends Pure {
-  case UnitLit() extends Literal(())
-  case IntLit(v: Int) extends Literal(v)
-  case BooleanLit(v: Boolean) extends Literal(v)
-  case DoubleLit(v: Double) extends Literal(v)
-  case StringLit(v: String) extends Literal(v)
+  enum Literal[T](val value: T) extends Pure {
+    case UnitLit() extends Literal(())
+    case IntLit(v: Int) extends Literal(v)
+    case BooleanLit(v: Boolean) extends Literal(v)
+    case DoubleLit(v: Double) extends Literal(v)
+    case StringLit(v: String) extends Literal(v)
+  }
+
+  // invariant, block b is pure.
+  case class PureApp(b: Block, targs: List[Type], args: List[Pure]) extends Pure
+  case class Select(target: Pure, field: Symbol) extends Pure
+
+  case class Box(b: Block) extends Pure
 }
+export Pure.*
 export Literal.*
-
-// invariant, block b is pure.
-case class PureApp(b: Block, targs: List[Type], args: List[Pure]) extends Pure
-case class Select(target: Pure, field: Symbol) extends Pure
-
-case class Box(b: Block) extends Pure
 
 /**
  * Blocks

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -4,12 +4,7 @@ package core
 import effekt.context.Context
 import effekt.symbols.{ Name, Symbol, TermSymbol, ValueSymbol, BlockSymbol, Interface, InterfaceType, Operation, Type, ValueType, FunctionType, BlockType, TrackedParam }
 
-sealed trait Tree extends Product {
-  def inheritPosition(from: source.Tree)(implicit C: Context): this.type = {
-    C.positions.dupPos(from, this);
-    this
-  }
-}
+sealed trait Tree
 
 /**
  * A module declaration, the path should be an Effekt include path, not a system dependent file path

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -99,7 +99,7 @@ enum Stmt extends Tree {
 
   case If(cond: Pure, thn: Stmt, els: Stmt)
   case While(cond: Stmt, body: Stmt)
-  case Ret(e: Pure)
+  case Return(e: Pure)
   case Match(scrutinee: Pure, clauses: List[(Pattern, BlockLit)])
 
   case Include(contents: String, rest: Stmt)
@@ -180,8 +180,8 @@ object Tree {
           If(rewrite(cond), rewrite(thn), rewrite(els))
         case While(cond, body) =>
           While(rewrite(cond), rewrite(body))
-        case Ret(e: Expr) =>
-          Ret(rewrite(e))
+        case Return(e: Expr) =>
+          Return(rewrite(e))
         case Include(contents, rest) =>
           Include(contents, rewrite(rest))
         case State(id, init, reg, body) =>

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -1,8 +1,7 @@
 package effekt
 package core
 
-import effekt.context.Context
-import effekt.symbols.{ Name, Symbol, TermSymbol, ValueSymbol, BlockSymbol, Interface, InterfaceType, Operation, Type, ValueType, FunctionType, BlockType, TrackedParam }
+import effekt.symbols.{ Symbol, TermSymbol, ValueSymbol, BlockSymbol, Interface, Operation, Type, ValueType, BlockType }
 
 sealed trait Tree
 

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -95,7 +95,7 @@ trait ChezScheme {
   }
 
   def toChezExpr(stmt: Stmt): chez.Expr = stmt match {
-    case Ret(e) => pure(toChez(e))
+    case Return(e) => pure(toChez(e))
     case App(b, targs, args) => chez.Call(toChez(b), toChez(args))
     case If(cond, thn, els) => chez.If(toChez(cond), toChezExpr(thn), toChezExpr(els))
     case Val(id, tpe, binding, body) => bind(toChezExpr(binding), nameDef(id), toChez(body))

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -132,19 +132,19 @@ trait ChezScheme {
   def toChez(stmt: Stmt): chez.Block = stmt match {
 
     case Def(id, tpe, block, rest) =>
-      val Block(defs, exprs, result) = toChez(rest)
+      val chez.Block(defs, exprs, result) = toChez(rest)
       val constDef = chez.Constant(nameDef(id), toChez(block))
-      Block(constDef :: defs, exprs, result)
+      chez.Block(constDef :: defs, exprs, result)
 
     case Data(did, ctors, rest) =>
-      val Block(defs, exprs, result) = toChez(rest)
+      val chez.Block(defs, exprs, result) = toChez(rest)
       val constructors = ctors.flatMap(ctor => generateConstructor(ctor.asInstanceOf[effekt.symbols.Record]))
-      Block(constructors ++ defs, exprs, result)
+      chez.Block(constructors ++ defs, exprs, result)
 
     case Record(did, fields, rest) =>
-      val Block(defs, exprs, result) = toChez(rest)
+      val chez.Block(defs, exprs, result) = toChez(rest)
       val constructors = generateConstructor(did, fields)
-      Block(constructors ++ defs, exprs, result)
+      chez.Block(constructors ++ defs, exprs, result)
 
     case Include(contents, rest) =>
       val include = RawDef(contents)

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -199,7 +199,7 @@ trait JavaScript extends Backend {
     case core.While(cond, body) =>
       monadic.While(toJSMonadic(cond), toJSMonadic(body))
 
-    case core.Ret(e) =>
+    case core.Return(e) =>
       monadic.Pure(toJS(e))
 
     case core.Handle(body, hs) =>

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -119,11 +119,6 @@ trait JavaScript extends Backend {
 
   def toJS(p: Param): JSName = nameDef(p.id)
 
-  def toJS(e: core.Argument)(using Context): js.Expr = e match {
-    case e: core.Expr  => toJS(e)
-    case b: core.Block => toJS(b)
-  }
-
   def toJS(b: core.Block)(using Context): js.Expr = b match {
     case BlockVar(v) =>
       nameRef(v)
@@ -150,11 +145,17 @@ trait JavaScript extends Backend {
 
   def builtin(name: String): js.Expr = js.Member($effekt, JSName(name))
 
+  def toJS(args: List[Argument])(using Context): List[js.Expr] = args map {
+    case b: Block => toJS(b)
+    case e: Expr => toJS(e)
+  }
+
   def toJS(expr: core.Expr)(using Context): js.Expr = expr match {
     case UnitLit() => builtin("unit")
     case StringLit(s) => JsString(s)
     case literal: Literal[_] => js.RawExpr(literal.value.toString)
     case ValueVar(id) => nameRef(id)
+    case DirectApp(b, targs, args) => js.Call(toJS(b), toJS(args))
     case PureApp(b, targs, args) => js.Call(toJS(b), args map toJS)
     case Select(target, field) => js.Member(toJS(target), memberNameRef(field))
     case Box(b) => toJS(b)
@@ -190,7 +191,7 @@ trait JavaScript extends Backend {
       monadic.Bind(toJSMonadic(binding), nameDef(id), toJSMonadic(body))
 
     case core.App(b, targs, args) =>
-      monadic.Call(toJS(b), args map toJS)
+      monadic.Call(toJS(b), toJS(args))
 
     case core.If(cond, thn, els) =>
       monadic.If(toJS(cond), toJSMonadic(thn), toJSMonadic(els))

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -105,7 +105,10 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
   def transform(tree: core.Expr)(using Environment, Context): Expr = tree match {
     case l: core.Literal[_] => transform(l)
     case core.ValueVar(sym)   => ValueVar(sym)
-    case core.PureApp(b: core.Block, targs, args: List[core.Argument]) =>
+    case core.DirectApp(b: core.Block, targs, args: List[core.Argument]) =>
+      PureApp(transform(b), targs, liftArguments(args))
+    // TODO also distinguish between pure and io expressions in lift
+    case core.PureApp(b: core.Block, targs, args: List[core.Expr]) =>
       PureApp(transform(b), targs, liftArguments(args))
     case core.Select(target, field) => Select(transform(target), field)
     case core.Box(b)                   => Closure(transform(b))

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -94,7 +94,7 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
     case core.While(cond, body) =>
       While(transform(cond), transform(body))
 
-    case core.Ret(e) =>
+    case core.Return(e) =>
       Ret(transform(e))
 
     case core.Include(contents, rest) => Include(contents, transform(rest))

--- a/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
@@ -4,13 +4,7 @@ package lifted
 import effekt.context.Context
 import effekt.symbols.{ Name, Symbol, TermSymbol, ValueSymbol, BlockSymbol, Interface, InterfaceType, Operation, Type, ValueType, FunctionType, BlockType, TrackedParam }
 
-sealed trait Tree extends Product {
-  def inheritPosition(from: source.Tree)(implicit C: Context): this.type = {
-    C.positions.dupPos(from, this);
-    this
-  }
-}
-
+sealed trait Tree
 /**
  * A module declaration, the path should be an Effekt include path, not a system dependent file path
  */

--- a/libraries/js/monadic/unsafe/cont.effekt
+++ b/libraries/js/monadic/unsafe/cont.effekt
@@ -3,7 +3,8 @@ module unsafe/cont
 // The type of a captured continuation
 extern type Cont[A, B]
 
-extern pure def cont[A, B] { r: A => B / {} }: Cont[A, B] = "r"
+// we mark this as {io} since pure functions should not take block parameters.
+extern io def cont[A, B] { r: A => B / {} }: Cont[A, B] = "r"
 
 // This is unsafe if the continuation left the scope of the
 // capabilities it closed over


### PR DESCRIPTION
@jfrech In order to simplify adding optimizations passes (on core) in the future, I added a distinction between 

- pure (that is side-effect free) expressions (type `Pure`)
- io (that is potentially side-effecting, but not control effectful) expressions (type `Expr`)
- control (that is arbitrary computation) statements (type `Stmt`)

to `core`. We have three constructors for calling functions, accordingly (`PureApp`, `DirectApp`, `App`). Please note that user defined functions always have to be called with `App` at the moment since we do not generate specialized versions of functions for `pure` or `io`. Also a function that looks pure from the outside might use effect handlers internally.

I purposefully did not change lifted core, since this is what you depend on and I didn't want to cause too much breakage. As one can see in this PR, though, the changes are minor.

Please note that the translation in this PR will introduce _less_ `run(stmt)` calls than the original one. This means that less direct style opportunity is exposed. It is always safe to have less; however, I cannot foresee whether this will give less opportunity for optimization later.