### PR TITLE
Require type annotations on value parameters

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -306,7 +306,7 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
    * Parameters
    */
   lazy val params: P[List[ValueParam] ~ List[BlockParam]] =
-    ( valueParamsOpt ~ blockParams
+    ( valueParams ~ blockParams
     | valueParams ~ success(List.empty[BlockParam])
     | success(List.empty[ValueParam]) ~ blockParams
     | failure("Expected a parameter list (multiple value parameters or one block parameter)")
@@ -327,8 +327,13 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
   lazy val valueParamsOptSection: P[List[ValueParam]] =
     `(` ~/> manySep(valueParamOpt, `,`) <~ `)`
 
-  lazy val valueParam: P[ValueParam] =
-    idDef ~ (`:` ~> valueType) ^^ { case id ~ tpe => ValueParam(id, Some(tpe)) }
+  lazy val valueTypeAnnotation : P[ValueType] =
+    ( `:` ~/> valueType
+    | failure("Expected a type annotation")
+    )
+
+  lazy val valueParam : P[ValueParam] =
+    idDef ~ valueTypeAnnotation ^^ { case id ~ tpe => ValueParam(id, Some(tpe)) }
 
   lazy val valueParamOpt: P[ValueParam] =
     idDef ~ (`:` ~> valueType).? ^^ ValueParam.apply

--- a/examples/neg/paramsnotypes.check
+++ b/examples/neg/paramsnotypes.check
@@ -1,0 +1,3 @@
+[error] examples/neg/paramsnotypes.effekt:1:15: Expected a type annotation
+def identity(x) = x
+              ^

--- a/examples/neg/paramsnotypes.effekt
+++ b/examples/neg/paramsnotypes.effekt
@@ -1,0 +1,3 @@
+def identity(x) = x
+
+def main() = ()


### PR DESCRIPTION
As of right now, the implementation presumes that every value parameter has a specified type annotation.
However, the parser does _not_ force the user to specify a type annotation for a parameter provided that there's a block parameter following it.
Altogether, this results in an unseemly internal error:

![Screenshot_20220901_173003](https://user-images.githubusercontent.com/11269173/187953885-f91cfa43-fbfb-4519-a58e-a612f1229b49.png)

The solution entails:
* _always_ requiring type annotations on value parameters, even if they're followed by block parameters
* reporting a more specific error when an annotation is expected, but not provided by the user