### PR TITLE
JIT backend: Add sbt target to download jit binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
       with:
         node-version: '10.x'
 
+    - name: Download JIT binary
+      env:
+        GH_TOKEN: ${{ secrets.JITTING_EFFECTS_GH_TOKEN }}
+      run: sbt effektJVM/downloadJITBinary
+
     - name: Run tests
       run: sbt clean test
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,11 @@ jobs:
       with:
         node-version: '10.x'
 
+    - name: Download JIT binary
+      env:
+        GH_TOKEN: ${{ secrets.JITTING_EFFECTS_GH_TOKEN }}
+      run: sbt effektJVM/downloadJITBinary
+
     - name: Install Chez Scheme
       run: sudo apt-get install chezscheme
 

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -151,11 +151,12 @@ trait Driver extends kiama.util.Compiler[Tree, ModuleDecl, EffektConfig, EffektE
   }
 
   def evalJIT(jitPath: String)(implicit C: Context): Unit = {
-    val arch = Process(Seq(s"uname", "-m"));
-    val platform = (arch.!!).trim;
-    val platforms = List("x86_64");
+    val arch = Process(Seq(s"uname", "-m")).!!.trim;
+    val os = Process(Seq(s"uname", "-s")).!!.trim;
+    val platform = "%s-%s".format(arch,os);
+    val platforms = List("x86_64-Linux", "arm64-Darwin");
     if (!platforms.contains(platform)) {
-      C.error(s"Unsupported platform ${platform}. Currently supported platforms; ${platforms.mkString(", ")}");
+      C.error(s"Unsupported platform ${platform}. Currently supported platforms: ${platforms.mkString(", ")}");
       return
     }
     val runCommand = Process(Seq(s"./bin/${platform}/rpyeffect-jit", jitPath)) // TODO use path independent of cwd


### PR DESCRIPTION
Currently, this has to be done manually and requires either a GH_TOKEN
environment variable or running `gh auth login` first.

This is a possible (temporary) solution to #121.