### PR TITLE
Fix fatal error formatting in JS LanguageServer

### DIFF
--- a/effekt/js/src/main/scala/effekt/LanguageServer.scala
+++ b/effekt/js/src/main/scala/effekt/LanguageServer.scala
@@ -109,7 +109,8 @@ class LanguageServer extends Intelligence {
       mainOutputPath
     } catch {
       case FatalPhaseError(msg) =>
-        throw js.JavaScriptException(msg)
+        val formattedError = context.messaging.formatMessage(msg)
+        throw js.JavaScriptException(formattedError)
     }
   }
 


### PR DESCRIPTION
Previously, the JS language server did not format fatal error messages which resulted in unfriendly messages on the website.

Before:
![Screenshot_20220902_100501](https://user-images.githubusercontent.com/11269173/188096731-ab40b09f-34c9-4a20-b2e9-6fb4105234e9.png)

After:
![image](https://user-images.githubusercontent.com/11269173/188661404-d45f75c8-9a89-4b14-8302-5d22a65acbe1.png)

See issue #120 for more details.