### PR TITLE
Recognize when def is used in the place of val

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -408,7 +408,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
                 // Since this `unbox` was synthesized by the compiler from `def foo = E`,
                 // it's possible that the user simply doesn't know that they should have used the `val` keyword to specify a value
                 // instead of using `def`; see [issue #130](https://github.com/effekt-lang/effekt/issues/130) for more details
-                Context.abort(pretty"Unbox requires a boxed type, but got $vtpe. Maybe try `val` if you're defining a value")
+                Context.abort(pretty"Expected the right-hand side of a `def` binding to be a block, but got a value of type $vtpe.\nMaybe try `val` if you're defining a value.")
               case _ =>
                 Context.abort(pretty"Unbox requires a boxed type, but got $vtpe.")
             }

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -403,7 +403,15 @@ object Typer extends Phase[NameResolved, Typechecked] {
             usingCapture(capt2)
             Result(btpe, eff1)
           case _ =>
-            Context.abort(pretty"Unbox requires a boxed type, but got $vtpe")
+            Context.annotationOption(Annotations.UnboxParentDef, u) match {
+              case Some(source.DefDef(id, annot, block)) =>
+                // Since this `unbox` was synthesized by the compiler from `def foo = E`,
+                // it's possible that the user simply doesn't know that they should have used the `val` keyword to specify a value
+                // instead of using `def`; see [issue #130](https://github.com/effekt-lang/effekt/issues/130) for more details
+                Context.abort(pretty"Unbox requires a boxed type, but got $vtpe. Maybe try `val` if you're defining a value")
+              case _ =>
+                Context.abort(pretty"Unbox requires a boxed type, but got $vtpe.")
+            }
         }
 
       case source.Var(id) => id.symbol match {

--- a/effekt/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Annotations.scala
@@ -263,6 +263,18 @@ object Annotations {
     "SelfRegion",
     "the region corresponding to a lexical scope"
   )
+
+  /**
+   * The [[source.Def]] which is a parent of this [[source.Unbox]] node
+   * provided that the [[source.Unbox]] was synthesized by the compiler.
+   *
+   * Introduced by the pretyper.
+   * Used by typer in order to display a more precise error message.
+   */
+  val UnboxParentDef = Annotation[source.Unbox, source.Def](
+    "UnboxParentDef",
+    "the parent definition of an Unbox if it was synthesized"
+  )
 }
 
 

--- a/examples/neg/def_instead_of_val.check
+++ b/examples/neg/def_instead_of_val.check
@@ -1,3 +1,4 @@
-[error] examples/neg/def_instead_of_val.effekt:3:13: Unbox requires a boxed type, but got Int. Maybe try `val` if you're defining a value
+[error] examples/neg/def_instead_of_val.effekt:3:13: Expected the right-hand side of a `def` binding to be a block, but got a value of type Int.
+Maybe try `val` if you're defining a value.
 def three = addOne(2)
             ^

--- a/examples/neg/def_instead_of_val.check
+++ b/examples/neg/def_instead_of_val.check
@@ -1,0 +1,3 @@
+[error] examples/neg/def_instead_of_val.effekt:3:13: Unbox requires a boxed type, but got Int. Maybe try `val` if you're defining a value
+def three = addOne(2)
+            ^

--- a/examples/neg/def_instead_of_val.effekt
+++ b/examples/neg/def_instead_of_val.effekt
@@ -1,0 +1,5 @@
+def addOne(x: Int) = x + 1
+
+def three = addOne(2)
+
+def main() = ()


### PR DESCRIPTION
Resolves #130 by distinguishing a case where the user wrote `def foo = <value>` when they meant `val foo = <value>`.

Internally, it adds a new `UnboxParentDef` annotation which is applied to synthezised `Unbox` nodes
that have a `Def` as a parent.

<img width="649" alt="image" src="https://user-images.githubusercontent.com/11269173/188886433-1b2c8224-fa8c-4495-b9ff-5ca7354b0f38.png">
