### PR TITLE
JIT: Find the JIT binary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -182,6 +182,7 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
 
     install := {
       assembleBinary.value
+      downloadJITBinary.value
       Process("npm pack").!!
       Process(s"npm install -g effekt-${effektVersion}.tgz").!!
     },

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -159,7 +159,9 @@ trait Driver extends kiama.util.Compiler[Tree, ModuleDecl, EffektConfig, EffektE
       C.error(s"Unsupported platform ${platform}. Currently supported platforms: ${platforms.mkString(", ")}");
       return
     }
-    val runCommand = Process(Seq(s"./bin/${platform}/rpyeffect-jit", jitPath)) // TODO use path independent of cwd
+    val jitBinary = C.config.findJITBinary(platform)
+
+    val runCommand = Process(Seq(jitBinary.unixPath, jitPath)) // TODO use path independent of cwd
     C.config.output().emit(runCommand.!!)
   }
 


### PR DESCRIPTION
Search for the JIT binary in the following places:

1. specified as part of the settings arg `--jit-binary`
2. specified in environment variable `EFFEKT_JIT_BIN`
3. in `./bin/${platform}/rpyeffect-jit` relative to PWD
4. in `./bin/${platform}/rpyeffect-jit` relative to the jar