### PR TITLE
Fix block parameter type pretty-printing

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -150,7 +150,7 @@ trait Intelligence {
       SymbolInfo(c, s"Constructor of data type `${c.tpe}`", Some(DeclPrinter(c)), Some(ex))
 
     case c: BlockParam =>
-      val signature = C.functionTypeOption(c).map { tpe => s"{ ${c.name}: ${tpe} }" }
+      val signature = C.functionTypeOption(c).map { tpe => pp"{ ${c.name}: ${tpe} }" }
 
       val ex =
         s"""|Blocks, like `${c.name}`, are similar to functions in other languages.


### PR DESCRIPTION
Resolves issue #151 with a one-line change -- using pretty-printing instead of plain string interpolation.

Before (on the website):
<img width="715" alt="Screenshot 2022-09-26 at 10 27 37" src="https://user-images.githubusercontent.com/11269173/192489202-0873b5b3-0199-494c-a681-d246c53f83f6.png">

After (on my machine with VSCode):
<img width="669" alt="Screenshot 2022-09-27 at 11 26 04" src="https://user-images.githubusercontent.com/11269173/192489148-2cd2a697-d72c-4afd-9bc2-1249d78fa904.png">
