### PR TITLE
Machine: Fix arity mismatch with effect handlers due to evidence

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -13,13 +13,7 @@ class LLVMTests extends EffektTests {
 
   override lazy val ignored: List[File] = List(
     // computes the wrong results
-    examplesDir / "llvm" / "generator.effekt",
-    examplesDir / "llvm" / "capabilities.effekt",
     examplesDir / "llvm" / "nested.effekt",
-    examplesDir / "llvm" / "stored.effekt",
-
-    // crashes
-    examplesDir / "llvm" / "forking.effekt",
 
     // polymorphic effect operations not supported, yet
     examplesDir / "llvm" / "choice.effekt",

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -312,7 +312,7 @@ object Transformer {
         // TODO we assume that there are no block params in handlers
         // TODO we assume that evidence has to be passed as first param
         // TODO actually use evidence to determine number of stacks popped
-        val ev = Variable("evidence", builtins.Evidence)
+        val ev = Variable(freshName("evidence"), builtins.Evidence)
         List(Clause(ev +: params.map(transform),
           PopStack(Variable(transform(resume).name, Type.Stack()),
             transform(body))))

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -127,7 +127,6 @@ object Transformer {
 
       case lifted.App(lifted.BlockVar(id), List(), args) =>
         // TODO deal with BlockLit
-        // TODO deal with evidence
         id match {
           case symbols.UserFunction(_, _, _, _, _, _, _) =>
             // TODO this is a hack, values is in general shorter than environment
@@ -142,9 +141,10 @@ object Transformer {
             }
           case symbols.ResumeParam(_) =>
             // TODO currently only scoped resumptions are supported
+            // TODO assuming first parameter is evidence TODO actually use evidence?
             transform(args).run { values =>
               PushStack(Variable(transform(id), Type.Stack()),
-                Return(values))
+                Return(values.tail))
             }
           case _ =>
             Context.abort(s"Unsupported blocksymbol: $id")
@@ -183,7 +183,6 @@ object Transformer {
         }
 
       case lifted.Handle(lifted.BlockLit(List(ev, id), body), tpe, List(handler)) =>
-        // TODO deal with evidence
         // TODO more than one handler
         val variable = Variable(freshName("a"), transform(tpe))
         val returnClause = Clause(List(variable), Return(List(variable)))
@@ -311,7 +310,10 @@ object Transformer {
       case lifted.Handler(_, List((operationName, lifted.BlockLit(params :+ resume, body)))) =>
         // TODO we assume here that resume is the last param
         // TODO we assume that there are no block params in handlers
-        List(Clause(params.map(transform),
+        // TODO we assume that evidence has to be passed as first param
+        // TODO actually use evidence to determine number of stacks popped
+        val ev = Variable("evidence", builtins.Evidence)
+        List(Clause(ev +: params.map(transform),
           PopStack(Variable(transform(resume).name, Type.Stack()),
             transform(body))))
       case _ =>

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -143,8 +143,9 @@ object Transformer {
             // TODO currently only scoped resumptions are supported
             // TODO assuming first parameter is evidence TODO actually use evidence?
             transform(args).run { values =>
+              val (evidence :: returnedValues) = values;
               PushStack(Variable(transform(id), Type.Stack()),
-                Return(values.tail))
+                Return(returnedValues))
             }
           case _ =>
             Context.abort(s"Unsupported blocksymbol: $id")


### PR DESCRIPTION
For this code (https://github.com/effekt-lang/effekt/blob/master/examples/llvm/capabilities.effekt):
```
effect Emit(n: Int) : Unit


def loop(n: Int): Unit / Emit = {
  if (n < 0) {
    ()
  } else {
    do Emit(n);
    loop(n - 1)
  }
}

def main() = {
  try {
    loop(10)
  } with Emit { (n: Int) =>
    println(n); resume(())
  }
}
```
the following lifted core is generated:
```
module capabilities

import effekt

record Emit(Emit)

def loop(ev581, ev582, n, Emit$capability) =
  if (infixLt(n, 0)) {
    ()
  } else {
    Emit$capability.Emit(<ev582>, n);
    loop(<ev581>, <ev582>, infixSub(n, 1), Emit$capability)
  }

def main(ev583) =
  try { (ev584, Emit$capability) => 
    loop(<ev584, ev583>, <>, 10, Emit$capability)
  } with Emit {
    def Emit(n, resume) = 
      let _ = println(n);
      resume(<>, ())
  }

()
```
This, with the current machine transformation, leads to an arity mismatch in both the resume and the call of the effect operation.
A hotfix for this part of the issue is to:
- Always ignore the first parameter to `resume` (which is evidence).
- Ignore the first parameter passed into a handler (which is "its" evidence).

This PR implements this Hotfix and un-ignores the tests fixed by this.