### PR TITLE
Machine: Handle evidence

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -1,6 +1,7 @@
 package effekt.llvm
 
 import effekt.context.Context
+import effekt.llvm.Operand.LocalReference
 
 object PrettyPrinter {
 
@@ -80,6 +81,9 @@ ${indentedLines(instructions.map(show).mkString("\n"))}
 
     case Add(result, operand0, ConstantInt(n)) =>
       s"${localName(result)} = add ${show(operand0)}, $n"
+    case Add(result, LocalReference(t1, s1), LocalReference(t2, s2)) =>
+      assert(t1 == t2)
+      s"${localName(result)} = add ${show(t1)} ${localName(s1)}, ${localName(s2)}"
     case Add(_, _, operand1) =>
       C.abort(s"WIP: currently only right-constant additions are supported, not: $operand1")
 

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -81,9 +81,6 @@ ${indentedLines(instructions.map(show).mkString("\n"))}
 
     case Add(result, operand0, ConstantInt(n)) =>
       s"${localName(result)} = add ${show(operand0)}, $n"
-    case Add(result, LocalReference(t1, s1), LocalReference(t2, s2)) =>
-      assert(t1 == t2)
-      s"${localName(result)} = add ${show(t1)} ${localName(s1)}, ${localName(s2)}"
     case Add(_, _, operand1) =>
       C.abort(s"WIP: currently only right-constant additions are supported, not: $operand1")
 

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -81,6 +81,9 @@ ${indentedLines(instructions.map(show).mkString("\n"))}
 
     case Add(result, operand0, ConstantInt(n)) =>
       s"${localName(result)} = add ${show(operand0)}, $n"
+    case Add(result, LocalReference(t1, n1), LocalReference(t2, n2)) =>
+      assert(t1 == t2)
+      s"${localName(result)} = add ${show(t1)} ${localName(n1)}, ${localName(n2)}"
     case Add(_, _, operand1) =>
       C.abort(s"WIP: currently only right-constant additions are supported, not: $operand1")
 

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -292,7 +292,7 @@ object Transformer {
         eraseValues(List(v), freeVariables(rest));
         transform(rest)
 
-      case machine.EviAdd(machine.Variable(name, _), x, y, rest) =>
+      case machine.ComposeEvidence(machine.Variable(name, _), x, y, rest) =>
         emit(Add(name, transform(x), transform(y)));
         transform(rest)
 

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -257,18 +257,6 @@ object Transformer {
         setStackPointer(LocalReference(spType, newStackPointerName));
         transform(rest)
 
-      case machine.PopStack(variable, rest) =>
-        val newStackPointerName = freshName("sp");
-        val tmpName = freshName("tmp");
-        val tmpReference = LocalReference(StructureType(List(stkType, spType)), tmpName);
-        emit(Call(tmpName, StructureType(List(stkType, spType)), popStack, List(getStackPointer())));
-        emit(ExtractValue(variable.name, tmpReference, 0));
-        emit(ExtractValue(newStackPointerName, tmpReference, 1));
-        setStackPointer(LocalReference(spType, newStackPointerName));
-
-        eraseValues(List(variable), freeVariables(rest));
-        transform(rest)
-
       case machine.PopStacks(variable, n, rest) =>
         // TODO Handle n (number of stacks to pop)
         val newStackPointerName = freshName("sp");

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -292,10 +292,6 @@ object Transformer {
         eraseValues(List(v), freeVariables(rest));
         transform(rest)
 
-      case machine.ComposeEvidence(machine.Variable(name, _), x, y, rest) =>
-        emit(Add(name, transform(x), transform(y)));
-        transform(rest)
-
       case machine.ForeignCall(machine.Variable(resultName, resultType), foreign, values, rest) =>
         // TODO careful with calling convention?!?
         val functionType = PointerType(FunctionType(transform(resultType), values.map { case machine.Variable(_, tpe) => transform(tpe) }));

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -12,8 +12,8 @@ object Transformer {
       given BC: BlockContext = BlockContext();
 
       // TODO proper initialization of runtime
-      emit(Call("env", envType, malloc, List(ConstantInt(1024))));
-      emit(Call("sp", spType, malloc, List(ConstantInt(1024))));
+      emit(Call("env", envType, malloc, List(ConstantInt(1024 * 1024))));
+      emit(Call("sp", spType, malloc, List(ConstantInt(1024 * 1024))));
       emit(Store(ConstantGlobal(PointerType(NamedType("Sp")), "base"), LocalReference(spType, "sp")));
       pushReturnAddress("topLevel", "topLevelSharer", "topLevelEraser");
 

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -35,8 +35,6 @@ def freeVariables(statement: Statement): Set[Variable] =
       freeVariables(frame) ++ (freeVariables(rest) -- Set(name))
     case PushStack(value, rest) =>
       Set(value) ++ freeVariables(rest)
-    case PopStack(name, rest) =>
-      freeVariables(rest) -- Set(name)
     case PopStacks(name, n, rest) =>
       freeVariables(rest) -- Set(name) ++ Set(n)
     case LiteralInt(name, value, rest) =>

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -37,6 +37,8 @@ def freeVariables(statement: Statement): Set[Variable] =
       Set(value) ++ freeVariables(rest)
     case PopStack(name, rest) =>
       freeVariables(rest) -- Set(name)
+    case PopStacks(name, n, rest) =>
+      freeVariables(rest) -- Set(name) ++ Set(n)
     case LiteralInt(name, value, rest) =>
       freeVariables(rest) - name
     case LiteralDouble(name, value, rest) =>
@@ -45,4 +47,6 @@ def freeVariables(statement: Statement): Set[Variable] =
       freeVariables(rest) - name
     case ForeignCall(name, builtin, arguments, rest) =>
       arguments.toSet ++ freeVariables(rest) - name
+    case EviAdd(name, x, y, rest) =>
+      freeVariables(rest) -- Set(name) ++ Set(x,y)
   }

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -45,6 +45,6 @@ def freeVariables(statement: Statement): Set[Variable] =
       freeVariables(rest) - name
     case ForeignCall(name, builtin, arguments, rest) =>
       arguments.toSet ++ freeVariables(rest) - name
-    case EviAdd(name, x, y, rest) =>
+    case ComposeEvidence(name, x, y, rest) =>
       freeVariables(rest) -- Set(name) ++ Set(x,y)
   }

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -45,6 +45,4 @@ def freeVariables(statement: Statement): Set[Variable] =
       freeVariables(rest) - name
     case ForeignCall(name, builtin, arguments, rest) =>
       arguments.toSet ++ freeVariables(rest) - name
-    case ComposeEvidence(name, x, y, rest) =>
-      freeVariables(rest) -- Set(name) ++ Set(x,y)
   }

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -37,11 +37,15 @@ def freeVariables(statement: Statement): Set[Variable] =
       Set(value) ++ freeVariables(rest)
     case PopStacks(name, n, rest) =>
       freeVariables(rest) -- Set(name) ++ Set(n)
+    case ComposeEvidence(name, ev1, ev2, rest) =>
+      freeVariables(rest) -- Set(name) ++ Set(ev1, ev2)
     case LiteralInt(name, value, rest) =>
       freeVariables(rest) - name
     case LiteralDouble(name, value, rest) =>
       freeVariables(rest) - name
     case LiteralUTF8String(name, utf8, rest) =>
+      freeVariables(rest) - name
+    case LiteralEvidence(name, ev, rest) =>
       freeVariables(rest) - name
     case ForeignCall(name, builtin, arguments, rest) =>
       arguments.toSet ++ freeVariables(rest) - name

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -12,6 +12,11 @@ object PrettyPrinter extends ParenPrettyPrinter {
 
   def format(stmt: Statement): Document = pretty(toDoc(stmt), 2)
 
+  def evidenceToDoc(value: Evidence): Doc = value match {
+    case builtins.Here => "Here"
+    case builtins.There(ev) => "There(" <> evidenceToDoc(ev) <> ")"
+  }
+
   implicit def toDoc(v: Variable): Doc = string(v.name)
 
   implicit def toDoc(v: Label): Doc = string(v.name)
@@ -72,6 +77,9 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case PopStacks(name, n, rest) =>
       "let" <+> name <+> "=" <+> "shift0" <+> n <> ";" <> line <> toDoc(rest)
 
+    case ComposeEvidence(name, ev1, ev2, rest) =>
+      "let" <+> name <+> "=" <+> ev1 <+> "+" <+> ev2 <> ";" <> line <> toDoc(rest)
+
     case ForeignCall(name, builtin, arguments, rest) =>
       "let" <+> name <+> "=" <+> builtin <> parens(arguments map toDoc) <> ";" <> line <> toDoc(rest)
 
@@ -83,6 +91,9 @@ object PrettyPrinter extends ParenPrettyPrinter {
 
     case LiteralUTF8String(name, utf8, rest) =>
       "let" <+> name <+> "=" <+> ("\"" + (utf8.map { b => "\\" + f"$b%02x" }).mkString + "\"") <> ";" <> line <> toDoc(rest)
+
+    case LiteralEvidence(name, evidence, rest) =>
+      "let" <+> name <+> "=" <+> evidenceToDoc(evidence) <> ";" <> line <> toDoc(rest)
   }
 
   def nested(content: Doc): Doc = group(nest(line <> content))

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -14,7 +14,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
 
   def evidenceToDoc(value: Evidence): Doc = value match {
     case builtins.Here => "Here"
-    case builtins.There(ev) => "There(" <> evidenceToDoc(ev) <> ")"
+    case builtins.There => "There"
+    case n => "There + " + evidenceToDoc(n)
   }
 
   implicit def toDoc(v: Variable): Doc = string(v.name)

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -72,6 +72,9 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case PopStack(name, rest) =>
       "let" <+> name <+> "=" <+> "shift0" <> ";" <> line <> toDoc(rest)
 
+    case PopStacks(name, n, rest) =>
+      "let" <+> name <+> "=" <+> "shift0" <+> n <> ";" <> line <> toDoc(rest)
+
     case ForeignCall(name, builtin, arguments, rest) =>
       "let" <+> name <+> "=" <+> builtin <> parens(arguments map toDoc) <> ";" <> line <> toDoc(rest)
 
@@ -83,6 +86,9 @@ object PrettyPrinter extends ParenPrettyPrinter {
 
     case LiteralUTF8String(name, utf8, rest) =>
       "let" <+> name <+> "=" <+> ("\"" + (utf8.map { b => "\\" + f"$b%02x" }).mkString + "\"") <> ";" <> line <> toDoc(rest)
+
+    case EviAdd(name, x, y, rest) =>
+      "let" <+> name <+> "=" <+> x <+> "+" <+> y <> ";" <> line <> toDoc(rest)
   }
 
   def nested(content: Doc): Doc = group(nest(line <> content))

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -84,7 +84,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case LiteralUTF8String(name, utf8, rest) =>
       "let" <+> name <+> "=" <+> ("\"" + (utf8.map { b => "\\" + f"$b%02x" }).mkString + "\"") <> ";" <> line <> toDoc(rest)
 
-    case EviAdd(name, x, y, rest) =>
+    case ComposeEvidence(name, x, y, rest) =>
       "let" <+> name <+> "=" <+> x <+> "+" <+> y <> ";" <> line <> toDoc(rest)
   }
 

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -83,9 +83,6 @@ object PrettyPrinter extends ParenPrettyPrinter {
 
     case LiteralUTF8String(name, utf8, rest) =>
       "let" <+> name <+> "=" <+> ("\"" + (utf8.map { b => "\\" + f"$b%02x" }).mkString + "\"") <> ";" <> line <> toDoc(rest)
-
-    case ComposeEvidence(name, x, y, rest) =>
-      "let" <+> name <+> "=" <+> x <+> "+" <+> y <> ";" <> line <> toDoc(rest)
   }
 
   def nested(content: Doc): Doc = group(nest(line <> content))

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -69,9 +69,6 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case PushStack(stack, rest) =>
       "push stack" <+> stack <> ";" <> line <> toDoc(rest)
 
-    case PopStack(name, rest) =>
-      "let" <+> name <+> "=" <+> "shift0" <> ";" <> line <> toDoc(rest)
-
     case PopStacks(name, n, rest) =>
       "let" <+> name <+> "=" <+> "shift0" <+> n <> ";" <> line <> toDoc(rest)
 

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -60,7 +60,7 @@ object Transformer {
         val transformedParams = params.map {
           case lifted.ValueParam(id, tpe) => Variable(id.name.name, transform(tpe))
           case lifted.BlockParam(id, tpe) => Context.abort("Foreign functions currently cannot take block arguments.")
-          case lifted.EvidenceParam(_) => ???
+          case lifted.EvidenceParam(id) => Variable(id.name.name, builtins.Evidence)
         }
         emitDeclaration(Extern(transform(name), transformedParams, transform(functionType.result), body))
         transformToplevel(rest, entryPoint)

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -187,7 +187,7 @@ object Transformer {
         val returnClause = Clause(List(variable), Return(List(variable)))
         val delimiter = Variable(freshName("returnClause"), Type.Stack())
 
-        LiteralEvidence(transform(ev), builtins.There(builtins.Here),
+        LiteralEvidence(transform(ev), builtins.There,
           NewStack(delimiter, returnClause,
             PushStack(delimiter,
               New(transform(id), transform(handler),

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -66,8 +66,6 @@ object Transformer {
         transformToplevel(rest, entryPoint)
 
       case lifted.Def(id, _, lifted.BlockLit(params, body), rest) =>
-        // TODO top-level definitions don't need evidence, or do they?
-        // some of the params are now evidence params... TODO handle evidence.
         Def(Label(transform(id), params.map(transform)), transform(body), transformToplevel(rest, entryPoint))
 
       case lifted.Include(content, rest) =>
@@ -110,7 +108,6 @@ object Transformer {
         }
 
       case lifted.Def(id, tpe, block @ lifted.BlockLit(params, body), rest) =>
-        // TODO deal with evidence
         // TODO does not work for mutually recursive local definitions
         val freeParams = lifted.freeVariables(block).toList.collect {
           case id: symbols.ValueSymbol => Variable(transform(id), transform(Context.valueTypeOf(id)))
@@ -226,7 +223,6 @@ object Transformer {
       pure(Variable(transform(id), transform(tpe)))
 
     case lifted.BlockLit(params, body) =>
-      // TODO deal with evidence
       val parameters = params.map(transform);
       val variable = Variable(freshName("g"), Negative("<function>"))
       Binding { k =>
@@ -333,7 +329,6 @@ object Transformer {
         // TODO we assume here that resume is the last param
         // TODO we assume that there are no block params in handlers
         // TODO we assume that evidence has to be passed as first param
-        // TODO actually use evidence to determine number of stacks popped
         val ev = Variable(freshName("evidence"), builtins.Evidence)
         List(Clause(ev +: params.map(transform),
           PopStacks(Variable(transform(resume).name, Type.Stack()), ev,
@@ -386,7 +381,6 @@ object Transformer {
         findToplevelBlocksParams(rest)
 
       case lifted.Def(blockName, _, lifted.BlockLit(params, body), rest) =>
-        // TODO add evidence param
         noteBlockParams(blockName, params.map(transform));
         findToplevelBlocksParams(rest)
 

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -209,7 +209,7 @@ object Transformer {
       }).foldRight(transform(lifted.IntLit(builtins.Here)))({(evi, acc) =>
         val res = Variable(freshName("ev_acc"), builtins.Evidence)
         acc.flatMap({acc => Binding { k =>
-          EviAdd(res, evi, acc, k(res));
+          ComposeEvidence(res, evi, acc, k(res));
         }})
       })
     }

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -204,7 +204,7 @@ object Transformer {
     case expr: lifted.Expr => transform(expr)
     case block: lifted.Block => transform(block)
     case lifted.Evidence(scopes) => {
-      val addSymbol = Context.module.dependencies.find(_.name.name == "effekt").get.terms("infixAdd").find({
+      val addSymbol = Context.module.findPrelude.terms("infixAdd").find({
         s =>
           import symbols.builtins.TInt
           Context.typeOf(s) == FunctionType(List(), List(), List(TInt, TInt), List(), TInt, symbols.Effects.Pure)

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -330,9 +330,18 @@ object Transformer {
         // TODO we assume that there are no block params in handlers
         // TODO we assume that evidence has to be passed as first param
         val ev = Variable(freshName("evidence"), builtins.Evidence)
+        val one = Variable(freshName("one"), builtins.Evidence)
+        val shiftBy = Variable(freshName("shiftby"), builtins.Evidence)
+        val addSymbol = Context.module.findPrelude.terms("infixAdd").find({
+          s =>
+            import symbols.builtins.TInt
+            Context.typeOf(s) == FunctionType(List(), List(), List(TInt, TInt), List(), TInt, symbols.Effects.Pure)
+        }).get
         List(Clause(ev +: params.map(transform),
-          PopStacks(Variable(transform(resume).name, Type.Stack()), ev,
-            transform(body))))
+          LiteralInt(one, 1,
+            ForeignCall(shiftBy, transform(addSymbol), List(ev, one),
+              PopStacks(Variable(transform(resume).name, Type.Stack()), shiftBy,
+                transform(body))))))
       case _ =>
         Context.abort(s"Unsupported handler $handler")
     }

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -190,7 +190,7 @@ object Transformer {
         val returnClause = Clause(List(variable), Return(List(variable)))
         val delimiter = Variable(freshName("returnClause"), Type.Stack())
 
-        LiteralInt(transform(ev), builtins.Here,
+        LiteralInt(transform(ev), 1,
           NewStack(delimiter, returnClause,
             PushStack(delimiter,
               New(transform(id), transform(handler),

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -144,7 +144,7 @@ enum Statement {
   case LiteralDouble(name: Variable, value: Double, rest: Statement)
   case LiteralUTF8String(name: Variable, utf8: Array[Byte], rest: Statement)
 
-  case EviAdd(name: Variable, s1: Variable, s2: Variable, rest: Statement)
+  case ComposeEvidence(name: Variable, s1: Variable, s2: Variable, rest: Statement)
 }
 export Statement.*
 

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -143,8 +143,6 @@ enum Statement {
 
   case LiteralDouble(name: Variable, value: Double, rest: Statement)
   case LiteralUTF8String(name: Variable, utf8: Array[Byte], rest: Statement)
-
-  case ComposeEvidence(name: Variable, s1: Variable, s2: Variable, rest: Statement)
 }
 export Statement.*
 

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -127,11 +127,6 @@ enum Statement {
   case PushStack(stack: Variable, rest: Statement)
 
   /**
-   * e.g. let k = shift0; s
-   */
-  case PopStack(name: Variable, rest: Statement)
-
-  /**
    * e.g. let k = shift0 n; s
    */
   case PopStacks(name: Variable, n: Variable, rest: Statement)

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -173,12 +173,7 @@ object builtins {
 
   val Evidence = Type.Int()
   val Here: Evidence = 0
-  object There {
-    def apply(v: Evidence): Evidence = v+1
-    def unapply(v: Evidence): Option[Evidence] = {
-      if v > 0 then Some(v-1) else None
-    }
-  }
+  val There: Evidence = 1
 
   /**
    * Blocks types are interfaces with a single operation.

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -132,6 +132,11 @@ enum Statement {
   case PopStack(name: Variable, rest: Statement)
 
   /**
+   * e.g. let k = shift0 n; s
+   */
+  case PopStacks(name: Variable, n: Variable, rest: Statement)
+
+  /**
    * let x = #infix_add(v1, ...); s
    */
   case ForeignCall(name: Variable, builtin: String, arguments: Environment, rest: Statement)
@@ -143,6 +148,8 @@ enum Statement {
 
   case LiteralDouble(name: Variable, value: Double, rest: Statement)
   case LiteralUTF8String(name: Variable, utf8: Array[Byte], rest: Statement)
+
+  case EviAdd(name: Variable, s1: Variable, s2: Variable, rest: Statement)
 }
 export Statement.*
 

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -171,6 +171,7 @@ export Type.{ Positive, Negative }
 object builtins {
 
   val Evidence = Type.Int()
+  val Here = 0
 
   /**
    * Blocks types are interfaces with a single operation.

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -127,7 +127,8 @@ enum Statement {
   case PushStack(stack: Variable, rest: Statement)
 
   /**
-   * e.g. let k = shift0 n; s
+   * e.g. let k = shift0 (n+1); s
+   * NOTE: Pops the stacks until the nth, i.e. the first n+1 ones
    */
   case PopStacks(name: Variable, n: Variable, rest: Statement)
 
@@ -137,12 +138,19 @@ enum Statement {
   case ForeignCall(name: Variable, builtin: String, arguments: Environment, rest: Statement)
 
   /**
+   * Evidence composition, i.e. currently:
+   * let x = ev1 + ev2; s
+   */
+  case ComposeEvidence(name: Variable, ev1: Variable, ev2: Variable, rest: Statement)
+
+  /**
    * let x = 42; s
    */
   case LiteralInt(name: Variable, value: Int, rest: Statement)
 
   case LiteralDouble(name: Variable, value: Double, rest: Statement)
   case LiteralUTF8String(name: Variable, utf8: Array[Byte], rest: Statement)
+  case LiteralEvidence(name: Variable, value: Evidence, rest: Statement)
 }
 export Statement.*
 
@@ -160,11 +168,17 @@ enum Type {
 }
 export Type.{ Positive, Negative }
 
-
+type Evidence = Int
 object builtins {
 
   val Evidence = Type.Int()
-  val Here = 0
+  val Here: Evidence = 0
+  object There {
+    def apply(v: Evidence): Evidence = v+1
+    def unapply(v: Evidence): Option[Evidence] = {
+      if v > 0 then Some(v-1) else None
+    }
+  }
 
   /**
    * Blocks types are interfaces with a single operation.


### PR DESCRIPTION
Handle evidence and use it to execute effect operations in the correct context.

Is not yet correctly implemented in the llvm backend (number of stacks to pop is ignored),
so widely untested.