### PR TITLE
Avoid having two effekt binaries (deprecate effekt.sh)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,9 @@ jobs:
 
     - name: Assemble fully optimized js file
       run: sbt effektJS/fullOptJS
+
+    - name: Try installing effekt binary
+      run: sbt install
+
+    - name: Run effekt binary
+      run: effekt --help

--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,7 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
       // prepend shebang to make jar file executable
       val binary = (ThisBuild / baseDirectory).value / "bin" / "effekt"
       IO.delete(binary)
-      IO.append(binary, "#! /usr/bin/env java -jar\n")
+      IO.append(binary, "#! /usr/bin/env -S java -jar\n")
       IO.append(binary, IO.readBytes(jarfile))
     },
 


### PR DESCRIPTION
Previously we had to have two commands:

- `effekt` which worked on MacOs
- `effekt.sh` which worked on Ubuntu systems

in #16 @waterlens proposes to use `-S` (which is short for [`--split-string`](https://man7.org/linux/man-pages/man1/env.1.html)).

I am not sure anymore, why I didn't do that in the first place. Maybe `-S` is not available on some implementations?

Could someone with Ubuntu please try whether this works? Simply run

```
sbt assembleBinary
```
and then there should be `bin/effekt` which you probably need to `chmod +x` and then execute. Can you also try executing it with some arguments (like `--help`)?