### PR TITLE
Simplify Syntax

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -159,7 +159,7 @@ trait LSPServer extends kiama.util.Server[Tree, ModuleDecl, EffektConfig, Effekt
     sym match {
       case _: Module =>
         Some(SymbolKind.Class)
-      case _: Fun =>
+      case _: Callable =>
         Some(SymbolKind.Method)
       case _: Param | _: ValBinder | _: VarBinder =>
         Some(SymbolKind.Variable)

--- a/effekt/jvm/src/test/scala/effekt/ConstraintTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ConstraintTests.scala
@@ -27,16 +27,16 @@ abstract class ConstraintTests extends munit.FunSuite {
   lazy val C = freshCaptVar("C")
   lazy val D = freshCaptVar("D")
 
-  lazy val x = CaptureParameter(Name.local("x"))
-  lazy val y = CaptureParameter(Name.local("y"))
-  lazy val z = CaptureParameter(Name.local("z"))
+  lazy val x = CaptureParam(Name.local("x"))
+  lazy val y = CaptureParam(Name.local("y"))
+  lazy val z = CaptureParam(Name.local("z"))
 
 
   def freshTypeVar(name: String) =
     scope.fresh(UnificationVar.TypeVariableInstantiation(TypeParam(Name.local(name)), NoSource))
 
   def freshCaptVar(name: String) =
-    scope.freshCaptVar(CaptUnificationVar.VariableInstantiation(CaptureParameter(Name.local(name)), NoSource))
+    scope.freshCaptVar(CaptUnificationVar.VariableInstantiation(CaptureParam(Name.local(name)), NoSource))
 
   def freshGraph() = {
     messages.clear()

--- a/effekt/jvm/src/test/scala/effekt/ConstraintTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ConstraintTests.scala
@@ -33,7 +33,7 @@ abstract class ConstraintTests extends munit.FunSuite {
 
 
   def freshTypeVar(name: String) =
-    scope.fresh(UnificationVar.TypeVariableInstantiation(TypeVar(Name.local(name)), NoSource))
+    scope.fresh(UnificationVar.TypeVariableInstantiation(TypeParam(Name.local(name)), NoSource))
 
   def freshCaptVar(name: String) =
     scope.freshCaptVar(CaptUnificationVar.VariableInstantiation(CaptureParameter(Name.local(name)), NoSource))

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -133,7 +133,7 @@ trait Intelligence {
     case t: TypeAlias =>
       SymbolInfo(t, "Type alias", Some(DeclPrinter(t)), None)
 
-    case c: Record =>
+    case c: Constructor =>
       val ex = pp"""|Instances of data types like `${c.tpe}` can only store
                     |_values_, not _blocks_. Hence, constructors like `${c.name}` only have
                     |value parameter lists, not block parameters.

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -105,14 +105,6 @@ trait Intelligence {
     case f: UserFunction if C.functionTypeOption(f).isDefined =>
       SymbolInfo(f, "Function", Some(DeclPrinter(f)), None)
 
-    case f: BuiltinEffect =>
-      val ex = s"""|Builtin effects like `${f.name}` are tracked by the effect system,
-                   |but cannot be handled with `try { ... } with ${f.name} { ... }`. The return type
-                   |of the main function can still have unhandled builtin effects.
-                   |""".stripMargin
-
-      SymbolInfo(f, "Builtin Effect", None, Some(ex))
-
     case f: Operation =>
       val ex =
         pp"""|Effect operations, like `${f.name}` allow to express non-local control flow.

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -569,7 +569,7 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
 
       val effs = resolve(effects).distinct
-      effs.controlEffects.foreach { eff =>
+      effs.canonical.foreach { eff =>
         val cap = CaptureParameter(eff.name)
         cps = cps :+ cap
       }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -599,7 +599,7 @@ object Namer extends Phase[Parsed, NameResolved] {
   /**
    * Resolves an interface type, potentially with effect aliases on the top level
    */
-  def resolveAsEffect(tpe: source.BlockTypeRef)(using Context): List[InterfaceType] = Context.at(tpe) {
+  def resolveAsInterfaceType(tpe: source.BlockTypeRef)(using Context): List[InterfaceType] = Context.at(tpe) {
     tpe match {
       case source.BlockTypeRef(id, args) => Context.resolveType(id) match {
         case EffectAlias(name, tparams, effs) =>
@@ -615,7 +615,7 @@ object Namer extends Phase[Parsed, NameResolved] {
   }
 
   def resolve(tpe: source.Effects)(using Context): Effects =
-    Effects(tpe.effs.flatMap(resolveAsEffect).toSeq: _*) // TODO this otherwise is calling the wrong apply
+    Effects(tpe.effs.flatMap(resolveAsInterfaceType).toSeq: _*) // TODO this otherwise is calling the wrong apply
 
   def resolve(e: source.Effectful)(using Context): (ValueType, Effects) =
     (resolve(e.tpe), resolve(e.eff))

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -556,14 +556,14 @@ object Namer extends Phase[Parsed, NameResolved] {
       val bps = bparams.map {
         case (id, tpe) =>
           val name = id.map(Name.local).getOrElse(NoName)
-          val cap = CaptureParameter(name)
+          val cap = CaptureParam(name)
           cps = cps :+ cap
           resolve(tpe)
       }
 
       val effs = resolve(effects).distinct
       effs.canonical.foreach { eff =>
-        val cap = CaptureParameter(eff.name)
+        val cap = CaptureParam(eff.name)
         cps = cps :+ cap
       }
 

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -326,15 +326,9 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
     some(`{` ~/> blockParam <~ `}`)
 
   lazy val valueParams: P[List[ValueParam]] =
-    some(valueParamSection) ^^ { _.flatten }
-
-  lazy val valueParamsOpt: P[List[ValueParam]] =
-    some(valueParamsOptSection) ^^ { _.flatten }
-
-  lazy val valueParamSection: P[List[ValueParam]] =
     `(` ~/> manySep(valueParam, `,`) <~ `)`
 
-  lazy val valueParamsOptSection: P[List[ValueParam]] =
+  lazy val valueParamsOpt: P[List[ValueParam]] =
     `(` ~/> manySep(valueParamOpt, `,`) <~ `)`
 
   lazy val valueTypeAnnotation : P[ValueType] =

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -548,10 +548,11 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
       case effect ~ clauses =>
         Implementation(effect, clauses)
       }
-    | (idRef ^^ InterfaceVar.apply) ~ maybeTypeParams ~ implicitResume ~ functionArg ^^ {
-      case effect ~ tparams ~ resume ~ BlockLiteral(_, vparams, _, body) =>
-        val synthesizedId = IdRef(effect.id.name)
-        Implementation(effect, List(OpClause(synthesizedId, tparams, vparams, None, body, resume) withPositionOf effect))
+    | idRef ~ maybeTypeParams ~ implicitResume ~ functionArg ^^ {
+      case id ~ tparams ~ resume ~ BlockLiteral(_, vparams, _, body) =>
+        val synthesizedId = IdRef(id.name)
+        val interface = BlockTypeRef(id, Nil) withPositionOf id
+        Implementation(interface, List(OpClause(synthesizedId, tparams, vparams, None, body, resume) withPositionOf id))
       }
     )
 
@@ -630,8 +631,7 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
     )
 
   lazy val primValueType: P[ValueType] =
-    ( idRef ~ typeArgs ^^ ValueTypeApp.apply
-    | idRef ^^ TypeVar.apply
+    ( idRef ~ maybeTypeArgs ^^ ValueTypeRef.apply
     | `(` ~> valueType <~ `)`
     | `(` ~> valueType ~ (`,` ~/> some(valueType) <~ `)`) ^^ { case f ~ r => TupleTypeTree(f :: r) }
     | failure("Expected a type")
@@ -647,9 +647,8 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
     | `=>` ~/> primValueType ~ maybeEffects ^^ { case ret ~ eff => FunctionType(Nil, ret, eff) }
     )
 
-  lazy val interfaceType: P[InterfaceType] =
-    ( idRef ~ typeArgs ^^ BlockTypeApp.apply
-    | idRef ^^ InterfaceVar.apply
+  lazy val interfaceType: P[BlockTypeRef] =
+    ( idRef ~ maybeTypeArgs ^^ BlockTypeRef.apply
     | failure("Expected an interface / effect")
     )
 
@@ -691,7 +690,7 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
   }
 
   private def TupleTypeTree(tps: List[ValueType]): ValueType =
-    ValueTypeApp(IdRef(s"Tuple${tps.size}"), tps)
+    ValueTypeRef(IdRef(s"Tuple${tps.size}"), tps)
 
   // === Utils ===
   def many[T](p: => Parser[T]): Parser[List[T]] =

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -249,7 +249,6 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
     | dataDef
     | recordDef
     | externType
-    | externEffect
     | externFun
     | externInclude
     | failure("Expected a definition")
@@ -280,9 +279,6 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
 
   lazy val externType: P[Def] =
     `extern` ~> `type` ~/> idDef ~ maybeTypeParams ^^ ExternType.apply
-
-  lazy val externEffect: P[Def] =
-    `extern` ~> `effect` ~/> idDef ~ maybeTypeParams ^^ ExternEffect.apply
 
   lazy val externFun: P[Def] =
     `extern` ~> ((externFlag | success(ExternFlag.IO)) <~ `def`) ~/ idDef ~ maybeTypeParams ~ params ~ (`:` ~> effectful) ~ ( `=` ~/> externBody) ^^ {

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -178,7 +178,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
           case _ => Context.abort("Cannot infer function type for callee.")
         }
 
-        val Result(t, eff) = checkCallTo(c, "function", tpe, targs map { _.resolve }, vargs, bargs, expected, None)
+        val Result(t, eff) = checkCallTo(c, "function", tpe, targs map { _.resolve }, vargs, bargs, expected)
         Result(t, eff ++ funEffs)
 
       // precondition: PreTyper translates all uniform-function calls to `Call`.

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -246,7 +246,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
 
         // TODO only issue warning if they are not bound to capabilities in source
         if (unusedEffects.nonEmpty)
-          Context.warning("Handling effects that are not used: " + unusedEffects)
+          Context.warning(pp"Handling effects that are not used: ${unusedEffects}")
 
         // The captures of the handler continue flowing into the outer scope
         usingCapture(continuationCapt)

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -326,7 +326,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
 
           // create the capture parameters for bidirectional effects -- this is necessary for a correct interaction
           // of bidirectional effects and capture polymorphism (still has to be tested).
-          val cparams = declaredType.effects.canonical.map { tpe => CaptureParameter(tpe.name) }
+          val cparams = declaredType.effects.canonical.map { tpe => CaptureParam(tpe.name) }
 
           // (1) Instantiate block type of effect operation
           // Bidirectional example:
@@ -379,7 +379,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
               val resumeType = if (otherEffs.nonEmpty) {
                 // resume { e }
                 val resumeType = FunctionType(Nil, cparams, Nil, Nil, tpe, otherEffs)
-                val resumeCapt = CaptureParameter(Name.local("resumeBlock"))
+                val resumeCapt = CaptureParam(Name.local("resumeBlock"))
                 FunctionType(Nil, List(resumeCapt), Nil, List(resumeType), ret, Effects.Pure)
               } else {
                 // resume(v)
@@ -1207,7 +1207,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
         effects = effs.distinct
         // TODO currently the return type cannot refer to the annotated effects, so we can make up capabilities
         //   in the future namer needs to annotate the function with the capture parameters it introduced.
-        capt = effects.canonical.map { tpe => CaptureParameter(tpe.name) }
+        capt = effects.canonical.map { tpe => CaptureParam(tpe.name) }
       } yield toType(ret, effects, capt)
   }
   //</editor-fold>

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -297,8 +297,6 @@ object Typer extends Phase[NameResolved, Typechecked] {
       val (effectSymbol, targs) = tpe match {
         case BlockTypeApp(eff: Interface, args) => (eff, args)
         case eff: Interface => (eff, Nil)
-        case BlockTypeApp(b: BuiltinEffect, args) => Context.abort("Cannot implement builtin effect")
-        case b: BuiltinEffect => Context.abort("Cannot implement builtin effect")
       }
 
       // (3) check all operations are covered

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -1192,7 +1192,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
    * Helper methods on function symbols to retreive its type
    * either from being annotated or by looking it up (if already typechecked...)
    */
-  extension (fun: Fun)(using Context) {
+  extension (fun: Callable)(using Context) {
     // invariant: only works if ret is defined!
     def toType: FunctionType =
       annotatedType.get

--- a/effekt/shared/src/main/scala/effekt/context/Assertions.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Assertions.scala
@@ -77,8 +77,8 @@ object assertions {
       case t: Interface => t
       case t => reporter.abort("Expected an interface")
     }
-    def asFun: Fun = s match {
-      case t: Fun => t
+    def asFun: Callable = s match {
+      case t: Callable => t
       case _ => reporter.abort("Expected a function")
     }
     def asCallTarget: CallTarget = s match {

--- a/effekt/shared/src/main/scala/effekt/context/Assertions.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Assertions.scala
@@ -73,10 +73,6 @@ object assertions {
       case t: Type => t
       case _ => reporter.abort("Expected a type")
     }
-    def asEffect: InterfaceType = s match {
-      case t: InterfaceType => t
-      case t => reporter.abort("Expected an effect")
-    }
     def asInterface: Interface = s match {
       case t: Interface => t
       case t => reporter.abort("Expected an interface")

--- a/effekt/shared/src/main/scala/effekt/context/Assertions.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Assertions.scala
@@ -13,9 +13,9 @@ object assertions {
    * in one place
    */
   extension(s: Symbol)(using reporter: ErrorReporter) {
-    def asTypeVar: TypeVar = s match {
-      case t: TypeVar => t
-      case _ => reporter.abort("Expected a type variable")
+    def asTypeParam: TypeParam = s match {
+      case t: TypeParam => t
+      case _ => reporter.abort("Expected a type parameter")
     }
     def asValueParam: ValueParam = s match {
       case t: ValueParam => t
@@ -41,8 +41,8 @@ object assertions {
       case t: BuiltinFunction => t
       case _ => reporter.abort("Expected a builtin function")
     }
-    def asConstructor: Record = s match {
-      case t: Record => t
+    def asConstructor: Constructor = s match {
+      case t: Constructor => t
       case _ => reporter.abort("Expected a constructor")
     }
     def asDataType: DataType = s match {

--- a/effekt/shared/src/main/scala/effekt/context/ModuleDB.scala
+++ b/effekt/shared/src/main/scala/effekt/context/ModuleDB.scala
@@ -76,9 +76,9 @@ trait ModuleDB { self: Context =>
     }
 
     val tpe = C.functionTypeOf(main)
-    val controlEffects = tpe.effects.toList.controlEffects
+    val controlEffects = tpe.effects
     if (controlEffects.nonEmpty) {
-      C.abort(pp"Main cannot have user defined effects, but includes effects: ${tpe.effects}")
+      C.abort(pp"Main cannot have user defined effects, but includes effects: ${controlEffects}")
     }
 
     main

--- a/effekt/shared/src/main/scala/effekt/context/ModuleDB.scala
+++ b/effekt/shared/src/main/scala/effekt/context/ModuleDB.scala
@@ -78,7 +78,7 @@ trait ModuleDB { self: Context =>
     val tpe = C.functionTypeOf(main)
     val controlEffects = tpe.effects.toList.controlEffects
     if (controlEffects.nonEmpty) {
-      C.abort(s"Main cannot have user defined effects, but includes effects: ${controlEffects.mkString(", ")}")
+      C.abort(pp"Main cannot have user defined effects, but includes effects: ${tpe.effects}")
     }
 
     main

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -51,7 +51,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
 
     case d @ source.RecordDef(id, _, _) =>
       val rec = d.symbol
-      core.Record(rec, rec.fields, rest())
+      core.Record(rec, rec.constructor.fields, rest())
 
     case v @ source.ValDef(id, _, binding) if pureOrIO(binding) =>
       Let(v.symbol, Run(transform(binding), Context.inferredTypeOf(binding)), rest())
@@ -306,7 +306,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
         PureApp(BlockVar(f), targs, vargsT)
       case f: BuiltinFunction if f.purity == ExternFlag.IO =>
         DirectApp(BlockVar(f), targs, as)
-      case r: Record =>
+      case r: Constructor =>
         if (bargs.nonEmpty) Context.abort("Constructors cannot take block arguments.")
         PureApp(BlockVar(r), targs, vargsT)
       case f: Operation =>

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -81,8 +81,6 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     case e @ source.ExternInclude(path) =>
       Include(e.contents, rest())
 
-    case d: source.ExternEffect => rest()
-
     case d: source.ExternType => rest()
 
     case d : source.TypeDef => rest()

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -22,7 +22,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     val exports = mod.terms.flatMap {
       case (name, syms) => syms.collect {
         // TODO export valuebinders properly
-        case sym: Fun if !sym.isInstanceOf[Operation] && !sym.isInstanceOf[Field] => sym
+        case sym: Callable if !sym.isInstanceOf[Operation] && !sym.isInstanceOf[Field] => sym
         case sym: ValBinder => sym
       }
     }.toList

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -137,8 +137,9 @@ trait ChezScheme {
 
     case Data(did, ctors, rest) =>
       val chez.Block(defs, exprs, result) = toChez(rest)
-      val constructors = ctors.flatMap { ctor =>
-        generateConstructor(ctor.asInstanceOf[effekt.symbols.Record])
+      val constructors = ctors.flatMap {
+        case ctor: symbols.Constructor => generateConstructor(ctor, ctor.fields)
+        case other => sys error s"Wrong type, expected constructor but got: ${other}"
       }
       chez.Block(constructors ++ defs, exprs, result)
 

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -137,7 +137,9 @@ trait ChezScheme {
 
     case Data(did, ctors, rest) =>
       val chez.Block(defs, exprs, result) = toChez(rest)
-      val constructors = ctors.flatMap(ctor => generateConstructor(ctor.asInstanceOf[effekt.symbols.Record]))
+      val constructors = ctors.flatMap { ctor =>
+        generateConstructor(ctor.asInstanceOf[effekt.symbols.Record])
+      }
       chez.Block(constructors ++ defs, exprs, result)
 
     case Record(did, fields, rest) =>

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
@@ -123,7 +123,10 @@ object ChezSchemeLift extends Backend {
 
     case Data(did, ctors, rest) =>
       val Block(defs, exprs, result) = toChez(rest)
-      val constructors = ctors.flatMap(ctor => generateConstructor(ctor.asInstanceOf[effekt.symbols.Record]))
+      val constructors = ctors.flatMap {
+        case ctor: symbols.Constructor => generateConstructor(ctor, ctor.fields)
+        case other => sys error s"Wrong type, expected constructor but got: ${ other }"
+      }
       Block(constructors ++ defs, exprs, result)
 
     case Record(did, fields, rest) =>

--- a/effekt/shared/src/main/scala/effekt/generator/chez/package.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/package.scala
@@ -32,7 +32,7 @@ case class RecordNames(sym: Symbol) {
   val typeName = ChezName(basename + "$Type" + id)
   val predicate = ChezName(name + "?")
   val constructor = sym match {
-    case _: effekt.symbols.InterfaceType => ChezName(s"make-${name}")
+    case _: effekt.symbols.Interface => ChezName(s"make-${name}")
     case _ => uid
   }
 }

--- a/effekt/shared/src/main/scala/effekt/generator/chez/package.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/package.scala
@@ -37,12 +37,17 @@ case class RecordNames(sym: Symbol) {
   }
 }
 
-def generateConstructor(ctor: effekt.symbols.Record): List[chez.Def] =
-  generateConstructor(ctor, ctor.fields)
-
 // https://www.scheme.com/csug8/objects.html
 // https://scheme.com/tspl4/records.html
-def generateConstructor(did: Symbol, fields: List[Symbol]): List[chez.Def] = {
+def generateConstructor(id: Symbol, fields: List[Symbol]): List[chez.Def] = {
+
+  val did = id match {
+    case c: symbols.Constructor => c
+    case r: symbols.Record => r.constructor
+    // right now, we also use core.Records to represent capabilities
+    case i: symbols.Interface => i
+    case other => sys error s"Compiler error: cannot generate a scheme record for internal symbol ${other}"
+  }
 
   val names = RecordNames(did)
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -302,7 +302,7 @@ trait JavaScript extends Backend {
       (Nil, toJSMonadic(other))
   }
 
-  def generateConstructor(ctor: symbols.Record): js.Stmt =
+  def generateConstructor(ctor: symbols.Constructor): js.Stmt =
     generateConstructor(ctor, ctor.fields)
 
   def generateConstructor(ctor: Symbol, fields: List[Symbol]): js.Stmt =

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -111,7 +111,7 @@ trait JavaScript extends Backend {
     id match {
       case b: symbols.BlockParam if b.tpe.isInstanceOf[symbols.InterfaceType] => ref(id.name.toString + "_" + id.id)
       case _: symbols.Operation => ref("op$" + id.name.toString)
-      case _: symbols.InterfaceType => ref(id.name.name)
+      case _: symbols.Interface => ref(id.name.name)
       case _: symbols.Field => ref(id.name.name)
       case _ => id.name match {
         case LocalName(name) => ref(name)

--- a/effekt/shared/src/main/scala/effekt/source/Elaborator.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Elaborator.scala
@@ -5,7 +5,6 @@ import effekt.context.{ Annotations, Context, ContextOps }
 import effekt.symbols.*
 import effekt.context.assertions.*
 import effekt.source.Tree.{ Query, Rewrite }
-import effekt.typer.typeMapToSubstitution
 
 /**
  * Transformation on source trees that translates programs into explicit capability-passing style

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -31,7 +31,6 @@ import effekt.symbols.Symbol
  *   |  |- TypeDef
  *   |  |- EffectDef
  *   |  |- ExternType
- *   |  |- ExternEffect
  *   |  |- ExternFun
  *   |  |- ExternInclude
  *   |
@@ -210,9 +209,6 @@ case class EffectDef(id: IdDef, tparams: List[Id], effs: Effects) extends Def {
 // only valid on the toplevel!
 case class ExternType(id: IdDef, tparams: List[Id]) extends Def {
   type symbol = symbols.BuiltinType
-}
-case class ExternEffect(id: IdDef, tparams: List[Id]) extends Def {
-  type symbol = symbols.BuiltinEffect
 }
 
 object ExternFlag extends Enumeration {
@@ -610,7 +606,6 @@ object Tree {
       case d: EffectDef     => d
 
       case d: ExternType    => d
-      case d: ExternEffect  => d
       case d: ExternFun     => d
       case d: ExternInclude => d
     }
@@ -762,7 +757,6 @@ object Tree {
       case d: EffectDef     => empty
 
       case d: ExternType    => empty
-      case d: ExternEffect  => empty
       case d: ExternFun     => empty
       case d: ExternInclude => empty
     }

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -186,7 +186,7 @@ case class DataDef(id: IdDef, tparams: List[Id], ctors: List[Constructor]) exten
   type symbol = symbols.DataType
 }
 case class Constructor(id: IdDef, params: List[ValueParam]) extends Definition {
-  type symbol = symbols.Record
+  type symbol = symbols.Constructor
 }
 case class RecordDef(id: IdDef, tparams: List[Id], fields: List[ValueParam]) extends Def {
   type symbol = symbols.Record
@@ -385,7 +385,7 @@ case class AnyPattern(id: IdDef) extends MatchPattern with Definition { type sym
  *   case Cons(a, as) => ...
  */
 case class TagPattern(id: IdRef, patterns: List[MatchPattern]) extends MatchPattern with Reference {
-  type symbol = symbols.Record
+  type symbol = symbols.Constructor
 }
 
 /**

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -282,7 +282,7 @@ case class Select(receiver: Term, id: IdRef) extends Term, Reference {
  * The [[effect]] is the optionally annotated effect type (not possible in source ATM). In the future, this could
  * look like `do Exc.raise()`, or `do[Exc] raise()`, or do[Exc].raise(), or simply Exc.raise() where Exc is a type.
  */
-case class Do(effect: Option[InterfaceType], id: IdRef, targs: List[ValueType], vargs: List[Term]) extends Term, Reference {
+case class Do(effect: Option[BlockTypeRef], id: IdRef, targs: List[ValueType], vargs: List[Term]) extends Term, Reference {
   type symbol = symbols.Operation
 }
 
@@ -335,7 +335,7 @@ case class TryHandle(prog: Stmt, handlers: List[Handler]) extends Term
  *
  * Called "template" or "class" in other languages.
  */
-case class Implementation(interface: InterfaceType, clauses: List[OpClause]) extends Reference {
+case class Implementation(interface: BlockTypeRef, clauses: List[OpClause]) extends Reference {
   def id = interface.id
   type symbol = symbols.Interface
 }
@@ -415,7 +415,7 @@ sealed trait Resolvable extends Tree {
  *
  * TODO generalize to blocks that can take blocks
  */
-sealed trait Type extends Tree with Resolvable {
+sealed trait Type extends Tree, Resolvable {
   type resolved <: symbols.Type
   def resolve(implicit C: Context) = C.resolvedType(this)
 }
@@ -428,7 +428,7 @@ sealed trait ValueType extends Type {
 }
 
 /**
- * Trees that represent inferred or synthesized types
+ * Trees that represent inferred or synthesized types (not present in the source)
  */
 case class ValueTypeTree(tpe: symbols.ValueType) extends ValueType
 
@@ -437,11 +437,12 @@ case class ValueTypeTree(tpe: symbols.ValueType) extends ValueType
  */
 case class BoxedType(tpe: BlockType, capt: CaptureSet) extends ValueType
 
-// Used for both binding and bound vars
-case class TypeVar(id: IdRef) extends ValueType with Reference {
+// Used for bindings
+case class TypeVar(id: IdDef) extends ValueType, Definition {
   type symbol = symbols.Symbol with symbols.ValueType
 }
-case class ValueTypeApp(id: IdRef, args: List[ValueType]) extends ValueType with Reference {
+// Bound occurrences (args can be empty)
+case class ValueTypeRef(id: IdRef, args: List[ValueType]) extends ValueType, Reference {
   // can be applied to type aliases or data types
   type symbol = symbols.TypeSymbol
 }
@@ -451,7 +452,9 @@ case class ValueTypeApp(id: IdRef, args: List[ValueType]) extends ValueType with
  */
 sealed trait BlockType extends Type
 
-// not userdefinable, only for inferred type arguments
+/**
+ * Trees that represent inferred or synthesized types (not present in the source)
+ */
 case class BlockTypeTree(eff: symbols.BlockType) extends BlockType {
   type resolved = symbols.BlockType
 }
@@ -460,30 +463,23 @@ case class FunctionType(vparams: List[ValueType], result: ValueType, effects: Ef
   type resolved = symbols.FunctionType
 }
 
-sealed trait InterfaceType extends BlockType {
-  def id: IdRef
-  type resolved <: symbols.InterfaceType
-}
-
-case class BlockTypeApp(id: IdRef, args: List[ValueType]) extends InterfaceType with Reference {
+case class BlockTypeRef(id: IdRef, args: List[ValueType]) extends BlockType, Reference {
   type symbol = symbols.TypeSymbol
-}
-
-/**
- * **Reference** to an interface type (like an effect)
- */
-case class InterfaceVar(id: IdRef) extends InterfaceType with Resolvable {
-  type resolved = symbols.Interface
+  type resolved <: symbols.InterfaceType
 }
 
 // We have Effectful as a tree in order to apply code actions on it (see Server.inferEffectsAction)
 case class Effectful(tpe: ValueType, eff: Effects) extends Tree
 
-case class Effects(effs: List[InterfaceType]) extends Tree
+/**
+ * Represents an annotated set of effects. Before name resolution, we cannot know
+ * the concrete nature of its elements (so it is generic [[BlockTypeRef]]).
+ */
+case class Effects(effs: List[BlockTypeRef]) extends Tree
 object Effects {
   val Pure: Effects = Effects()
-  def apply(effs: InterfaceType*): Effects = Effects(effs.toSet)
-  def apply(effs: Set[InterfaceType]): Effects = Effects(effs.toList)
+  def apply(effs: BlockTypeRef*): Effects = Effects(effs.toSet)
+  def apply(effs: Set[BlockTypeRef]): Effects = Effects(effs.toList)
 }
 
 case class CaptureSet(captures: List[IdRef]) extends Resolvable {

--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -49,10 +49,6 @@ object DeclPrinter extends ParenPrettyPrinter {
     case f: BuiltinFunction =>
       format("extern def", f, f.annotatedResult, f.annotatedEffects)
 
-    case BuiltinEffect(name, tparams) =>
-      val tps = if (tparams.isEmpty) "" else s"[${tparams.mkString(", ")}]"
-      s"extern effect ${name}$tps"
-
     case BuiltinType(name, tparams) =>
       val tps = if (tparams.isEmpty) "" else s"[${tparams.mkString(", ")}]"
       s"extern type ${name}$tps"

--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -53,7 +53,7 @@ object DeclPrinter extends ParenPrettyPrinter {
       val tps = if (tparams.isEmpty) "" else s"[${tparams.mkString(", ")}]"
       s"extern type ${name}$tps"
 
-    case c: Fun =>
+    case c: Callable =>
       val tpe = context.functionTypeOption(c)
       format("def", c, tpe.map { _.result }, tpe.map { _.effects })
 
@@ -62,7 +62,7 @@ object DeclPrinter extends ParenPrettyPrinter {
       pp"def ${ d.name }: ${ tpe }"
   }
 
-  def format(kw: String, f: Fun, result: Option[ValueType], effects: Option[Effects]): Doc = {
+  def format(kw: String, f: Callable, result: Option[ValueType], effects: Option[Effects]): Doc = {
     val tps = if (f.tparams.isEmpty) "" else s"[${f.tparams.mkString(", ")}]"
 
     val valueParams = f.vparams.map { p => pp"${p.name}: ${p.tpe.get}" }.mkString(", ")

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -59,8 +59,8 @@ object TypePrinter extends ParenPrettyPrinter {
   def toDoc(interface: Interface): Doc = interface.name
 
   def toDoc(t: TypeConstructor): Doc = t match {
-    case DataType(name, tparams, variants)  => name <> typeParams(tparams)
-    case Record(name, tparams, tpe, fields) => name <> typeParams(tparams)
+    case DataType(name, tparams, constructors)  => name <> typeParams(tparams)
+    case Record(name, tparams, constructor) => name <> typeParams(tparams)
     case BuiltinType(name, tparams) => name
   }
 

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -26,8 +26,8 @@ object TypePrinter extends ParenPrettyPrinter {
 
   def toDoc(tpe: ValueType): Doc = tpe match {
     case BoxedType(tpe, capture)    => toDoc(tpe) <+> "at" <+> toDoc(capture)
-    case ValueTypeApp(tpe, Nil)     => toDoc(tpe)
-    case ValueTypeApp(tpe, args)    => toDoc(tpe) <> brackets(hsep(args.map(toDoc), comma))
+    case ValueTypeApp(tpe, Nil)     => tpe.name
+    case ValueTypeApp(tpe, args)    => tpe.name <> brackets(hsep(args.map(toDoc), comma))
     case ValueTypeRef(x)            => toDoc(x)
   }
 
@@ -63,7 +63,9 @@ object TypePrinter extends ParenPrettyPrinter {
     case BuiltinType(name, tparams) => name
   }
 
-  def toDoc(eff: Effects): Doc = if (eff.isEmpty) "{}" else braces(space <> hsep(eff.effects.map(toDoc), comma) <> space)
+  def toDoc(eff: Effects): Doc =
+    if (eff.isEmpty) "{}" else
+    braces(space <> hsep(eff.effects.map(toDoc), comma) <> space)
 
   def toDoc(c: Captures): Doc = c match {
     case CaptureSet(captures)  => braces { hsep(captures.toList.map(toDoc), comma) }

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -50,7 +50,6 @@ object TypePrinter extends ParenPrettyPrinter {
 
     case BlockTypeApp(tpe, args)       => toDoc(tpe) <> typeParams(args)
     case Interface(name, tparams, ops) => name
-    case BuiltinEffect(name, tparams)  => name
   }
 
   def toDoc(t: TypeConstructor): Doc = t match {

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -2,6 +2,7 @@ package effekt
 package symbols
 
 import effekt.symbols.builtins.*
+import effekt.typer.ConcreteEffects
 import kiama.output.ParenPrettyPrinter
 
 import scala.language.implicitConversions
@@ -91,6 +92,7 @@ implicit class ErrorMessageInterpolator(private val sc: StringContext) extends A
     case t: Capture      => TypePrinter.show(t)
     case t: Captures     => TypePrinter.show(t)
     case t: Effects      => TypePrinter.show(t)
+    case t: ConcreteEffects => TypePrinter.show(t.toEffects)
     case other           => other.toString
   }: _*)
 }

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -26,6 +26,7 @@ object TypePrinter extends ParenPrettyPrinter {
 
   def toDoc(tpe: ValueType): Doc = tpe match {
     case BoxedType(tpe, capture)    => toDoc(tpe) <+> "at" <+> toDoc(capture)
+    case ValueTypeApp(tpe, Nil)     => toDoc(tpe)
     case ValueTypeApp(tpe, args)    => toDoc(tpe) <> brackets(hsep(args.map(toDoc), comma))
     case ValueTypeRef(x)            => toDoc(x)
   }
@@ -50,6 +51,7 @@ object TypePrinter extends ParenPrettyPrinter {
       val eff = if (effects.isEmpty) emptyDoc else space <> "/" <+> toDoc(effects)
       tps <> ps <+> "=>" <+> ret <> eff
 
+    case InterfaceType(tpe, Nil)  => toDoc(tpe)
     case InterfaceType(tpe, args) => toDoc(tpe) <> typeParams(args)
   }
 

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -28,10 +28,10 @@ object builtins {
   val TTop = BuiltinType(name("⊤"), Nil)
   val TBottom = BuiltinType(name("⊥"), Nil)
 
-  val IOEffect = BuiltinEffect(name("IO"), Nil)
+  val IOEffect = Interface(Name.local("IO"), Nil, Nil)
   val IOCapability = BlockParam(name("io"), IOEffect)
 
-  val ControlEffect = BuiltinEffect(name("Control"), Nil)
+  val ControlEffect = Interface(Name.local("Control"), Nil, Nil)
   val ControlCapability = BlockParam(name("control"), ControlEffect)
 
   object TState {

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -19,45 +19,60 @@ object builtins {
 
   private def name(s: String) = Name.qualified(s, prelude)
 
-  val TUnit = BuiltinType(name("Unit"), Nil)
-  val TBoolean = BuiltinType(name("Boolean"), Nil)
-  val TInt = BuiltinType(name("Int"), Nil)
-  val TDouble = BuiltinType(name("Double"), Nil)
-  val TString = BuiltinType(name("String"), Nil)
+  val UnitSymbol = BuiltinType(name("Unit"), Nil)
+  val TUnit = ValueTypeApp(UnitSymbol, Nil)
 
-  val TTop = BuiltinType(name("⊤"), Nil)
-  val TBottom = BuiltinType(name("⊥"), Nil)
+  val BooleanSymbol = BuiltinType(name("Boolean"), Nil)
+  val TBoolean = ValueTypeApp(BooleanSymbol, Nil)
 
-  val IOEffect = Interface(Name.local("IO"), Nil, Nil)
-  val IOCapability = BlockParam(name("io"), IOEffect)
+  val IntSymbol = BuiltinType(name("Int"), Nil)
+  val TInt = ValueTypeApp(IntSymbol, Nil)
 
-  val ControlEffect = Interface(Name.local("Control"), Nil, Nil)
-  val ControlCapability = BlockParam(name("control"), ControlEffect)
+  val DoubleSymbol = BuiltinType(name("Double"), Nil)
+  val TDouble = ValueTypeApp(DoubleSymbol, Nil)
+
+  val StringSymbol = BuiltinType(name("String"), Nil)
+  val TString = ValueTypeApp(StringSymbol, Nil)
+
+  val TopSymbol = BuiltinType(name("⊤"), Nil)
+  val TTop = ValueTypeApp(TopSymbol, Nil)
+
+  val BottomSymbol = BuiltinType(name("⊥"), Nil)
+  val TBottom = ValueTypeApp(BottomSymbol, Nil)
+
+  val IOSymbol = Interface(Name.local("IO"), Nil, Nil)
+  val IOCapability = BlockParam(name("io"), InterfaceType(IOSymbol, Nil))
+
+  val ControlSymbol = Interface(Name.local("Control"), Nil, Nil)
+  val ControlCapability = BlockParam(name("control"), InterfaceType(ControlSymbol, Nil))
 
   object TState {
-    val S = TypeVar(Name.local("S"))
+    val S = TypeParam(Name.local("S"))
     val interface = Interface(Name.local("$State"), List(S), Nil)
-    val get = Operation(name("get"), Nil, Nil, S, Effects.Pure, interface)
-    val put = Operation(name("put"), Nil, List(ValueParam(Name.local("s"), Some(S))), TUnit, Effects.Pure, interface)
+    val get = Operation(name("get"), Nil, Nil, ValueTypeRef(S), Effects.Pure, interface)
+    val put = Operation(name("put"), Nil, List(ValueParam(Name.local("s"), Some(ValueTypeRef(S)))), TUnit, Effects.Pure, interface)
     interface.ops = List(get, put)
+
+    def apply(stateType: ValueType) = InterfaceType(interface, List(stateType))
 
     def extractType(state: BlockType)(using C: Context): ValueType =
       state match {
-        case BlockTypeApp(i, List(tpe)) => tpe
+        case InterfaceType(i, List(tpe)) if i == interface => tpe
         case tpe => C.panic(pretty"Expected builtin state, but got $tpe")
       }
   }
 
-  val TRegion = Interface(Name.local("Region"), Nil, Nil)
+  val RegionSymbol = Interface(Name.local("Region"), Nil, Nil)
+  val TRegion = InterfaceType(RegionSymbol, Nil)
 
   val rootTypes: Map[String, TypeSymbol] = Map(
-    "Unit" -> TUnit,
-    "Boolean" -> TBoolean,
-    "Int" -> TInt,
-    "Double" -> TDouble,
-    "String" -> TString,
-    "IO" -> IOEffect,
-    "Region" -> TRegion
+    "Unit" -> UnitSymbol,
+    "Boolean" -> BooleanSymbol,
+    "Int" -> IntSymbol,
+    "Double" -> DoubleSymbol,
+    "String" -> StringSymbol,
+    "IO" -> IOSymbol,
+    "Region" -> RegionSymbol
   )
 
   lazy val globalRegion = BlockParam(name("global"), TRegion)

--- a/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
@@ -55,7 +55,7 @@ package object kinds {
 
   private def wellformedTypeConstructor(tpe: TypeConstructor)(using C: Context): Kind.Fun = tpe match {
     case DataType(_, tparams, _)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
-    case Record(_, tparams, _, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
+    case Record(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
     case BuiltinType(_, tparams)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
   }
 

--- a/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
@@ -5,40 +5,36 @@ import effekt.context.Context
 
 package object kinds {
 
-  def wellformed(tpe: Type)(implicit C: Context): Unit = tpe match {
+  def wellformed(tpe: Type)(using Context): Unit = tpe match {
     case t: ValueType => wellformed(t)
     case t: BlockType => wellformed(t)
   }
 
-  def wellformed(effs: Effects)(implicit C: Context): Unit =
+  def wellformed(effs: Effects)(using C: Context): Unit =
     val effects = effs.toList
     if (effects.size != effects.distinct.size) {
       C.panic("Compiler invariant violated: duplicate effects.")
     }
-    effs.toList foreach { wellformedEffect }
+    effs.toList foreach { wellformed }
 
-  def wellformed(tpe: ValueType)(implicit C: Context): Unit = wellformedType(tpe) match {
+  def wellformed(tpe: ValueType)(using C: Context): Unit = wellformedType(tpe) match {
     case Kind.VType => ()
     case Kind.Fun(args, Kind.VType) => C.abort(s"${tpe} needs to be applied to ${args.size} type arguments")
     case _ => C.abort(s"Expected a value type but got ${tpe}")
   }
 
-  def wellformed(tpe: BlockType)(implicit C: Context): Unit = tpe match {
+  def wellformed(tpe: BlockType)(using Context): Unit = tpe match {
     case b: FunctionType  => wellformed(b)
     case c: InterfaceType => wellformed(c)
   }
 
-  def wellformedEffect(eff: InterfaceType)(implicit C: Context): Unit = eff match {
-    case i: InterfaceType          => wellformed(i)
-  }
-
-  def wellformed(eff: InterfaceType)(implicit C: Context): Unit = wellformedInterfaceType(eff) match {
+  def wellformed(eff: InterfaceType)(using C: Context): Unit = wellformedInterfaceType(eff) match {
     case Kind.BType => ()
     case Kind.Fun(args, Kind.BType) => C.abort(s"${eff} needs to be applied to ${args.size} type arguments")
     case o => C.abort(s"Expected a block type but got a type ${eff} of kind ${o}")
   }
 
-  def wellformed(b: FunctionType)(implicit C: Context): Unit = b match {
+  def wellformed(b: FunctionType)(using C: Context): Unit = b match {
     case FunctionType(tps, cps, vps, bps, res, effs) =>
       // TODO we could also check whether the same type variable shows up twice
       if (cps.size != (bps.size + effs.controlEffects.size)) {
@@ -55,63 +51,41 @@ package object kinds {
     case object VType extends Kind
     case object BType extends Kind
     case class Fun(params: List[Kind], res: Kind) extends Kind
-    def VFun(params: List[Kind]): Kind =
-      if (params.isEmpty) Kind.VType else Kind.Fun(params, Kind.VType)
-    def BFun(params: List[Kind]): Kind =
-      if (params.isEmpty) Kind.BType else Kind.Fun(params, Kind.BType)
   }
 
-  private def wellformedType(tpe: ValueType)(implicit C: Context): Kind = tpe match {
-    case BoxedType(tpe, region) =>
-      wellformed(tpe); Kind.VType
-    case _: TypeVar => Kind.VType
-    case ValueTypeApp(tpe, args) =>
-      val Kind.Fun(params, res) = wellformedType(tpe) match {
-        case t: Kind.Fun => t
-        case _           => C.abort(s"Expected a type constructor, but got: ${tpe}")
-      }
-      if (args.size != params.size) {
+  private def wellformedTypeConstructor(tpe: TypeConstructor)(using C: Context): Kind.Fun = tpe match {
+    case DataType(_, tparams, _)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
+    case Record(_, tparams, _, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
+    case BuiltinType(_, tparams)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
+  }
+
+  private def wellformedType(tpe: ValueType)(using C: Context): Kind = tpe match {
+    case BoxedType(tpe, region) => wellformed(tpe); Kind.VType
+    case _: ValueTypeRef => Kind.VType
+    case ValueTypeApp(tpe, args) => wellformedTypeConstructor(tpe) match {
+      case Kind.Fun(params, res) if params.isEmpty && args.nonEmpty =>
+        C.abort(s"Cannot apply type ${tpe}. Type ${ tpe } does not expect any arguments, but is applied to ${ args.size }.")
+      case Kind.Fun(params, res) if (args.size != params.size) =>
         C.abort(s"Wrong type constructor arity. Type constructor ${tpe} expects ${params.size} parameters, but got ${args.size} arguments.")
-      }
-      args foreach { a => wellformedType(a) }
-      res
-
-    case DataType(_, tparams, _)  => Kind.VFun(tparams map { p => Kind.VType })
-    case Record(_, tparams, _, _) => Kind.VFun(tparams map { p => Kind.VType })
-    case BuiltinType(_, tparams)  => Kind.VFun(tparams map { p => Kind.VType })
-  }
-
-  private def wellformedInterfaceType(e: InterfaceType)(implicit C: Context): Kind = e match {
-    case BlockTypeApp(eff, args) =>
-      val Kind.Fun(params, res) = wellformedInterfaceType(eff) match {
-        case t: Kind.Fun => t
-        case _           => C.abort(s"Expected an effect that takes type parameters, but got: ${eff}")
-      }
-      if (args.size != params.size) {
-        C.abort(s"Wrong number of type arguments. Effect ${eff} expects ${params.size} parameters, but got ${args.size} arguments.")
-      }
-      args foreach { a => wellformed(a) }
-      res
-    case Interface(_, tparams, _) =>
-      Kind.BFun(tparams map { p => Kind.VType })
-  }
-
-  private implicit class ValueTypeWellformedOps[T <: ValueType](tpe: T) {
-    def wellformed(implicit C: Context): T = {
-      kinds.wellformed(tpe)
-      tpe
+      case Kind.Fun(params, res) =>
+        args foreach { a => wellformedType(a) };
+        Kind.VType
     }
   }
-  private implicit class EffectWellformedOps[T <: InterfaceType](eff: T) {
-    def wellformed(implicit C: Context): T = {
-      kinds.wellformed(eff)
-      eff
+
+  private def wellformedInterfaceType(e: InterfaceType)(using C: Context): Kind = e match {
+    case InterfaceType(eff, args) => wellformedInterface(eff) match {
+      case Kind.Fun(params, res) if args.isEmpty && params.nonEmpty =>
+        C.abort(s"Wrong number of type arguments. Interface ${eff} expects ${params.size} parameters, but no arguments were provided.")
+      case Kind.Fun(params, res) if args.size != params.size =>
+        C.abort(s"Wrong number of type arguments. Interface ${ eff } expects ${ params.size } parameters, but got ${ args.size } arguments.")
+      case Kind.Fun(params, res) =>
+        args foreach { a => wellformed(a) }
+        Kind.BType
     }
   }
-  private implicit class EffectsWellformedOps(effs: Effects) {
-    def wellformed(implicit C: Context): Effects = {
-      kinds.wellformed(effs)
-      effs
-    }
+
+  private def wellformedInterface(e: Interface)(using Context): Kind.Fun = e match {
+    case Interface(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
   }
 }

--- a/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
@@ -37,7 +37,7 @@ package object kinds {
   def wellformed(b: FunctionType)(using C: Context): Unit = b match {
     case FunctionType(tps, cps, vps, bps, res, effs) =>
       // TODO we could also check whether the same type variable shows up twice
-      if (cps.size != (bps.size + effs.controlEffects.size)) {
+      if (cps.size != (bps.size + effs.canonical.size)) {
         C.panic(s"Compiler invariant violated: different size of capture parameters and block parameters: ${b}")
       }
       vps.foreach { tpe => wellformed(tpe) }

--- a/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
@@ -29,7 +29,6 @@ package object kinds {
   }
 
   def wellformedEffect(eff: InterfaceType)(implicit C: Context): Unit = eff match {
-    case BuiltinEffect(_, tparams) => Kind.BFun(tparams map { p => Kind.VType })
     case i: InterfaceType          => wellformed(i)
   }
 
@@ -94,8 +93,6 @@ package object kinds {
       args foreach { a => wellformed(a) }
       res
     case Interface(_, tparams, _) =>
-      Kind.BFun(tparams map { p => Kind.VType })
-    case BuiltinEffect(_, tparams) =>
       Kind.BFun(tparams map { p => Kind.VType })
   }
 

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -58,9 +58,9 @@ case class Module(
   lazy val dependencies: List[Module] = imports.flatMap { im => im.dependencies :+ im }.distinct
 
   // toplevel declared effects
-  def effects: Effects = Effects(types.values.collect {
-    case e: InterfaceType => e
-  })
+  def effects: List[Interface] = types.values.toList.collect {
+    case e: Interface => e
+  }
 
   /**
    * It is actually possible, that exports is invoked on a single module multiple times:

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -1,4 +1,5 @@
 package effekt
+package symbols
 
 import effekt.source.{ DefDef, Def, ExternFlag, FunDef, ModuleDecl, ValDef, VarDef }
 import effekt.context.Context
@@ -15,495 +16,346 @@ import effekt.util.messages.ErrorReporter
  * - value / variable binders
  * - ...
  */
-package object symbols {
 
-  // reflecting the two namespaces
-  sealed trait TypeSymbol extends Symbol
-  sealed trait TermSymbol extends Symbol
 
-  // the two universes of values and blocks
-  trait ValueSymbol extends TermSymbol
-  trait BlockSymbol extends TermSymbol
+sealed trait TermSymbol extends Symbol
 
-  sealed trait Synthetic extends Symbol {
-    override def synthetic = true
-  }
+// the two universes of values and blocks
+trait ValueSymbol extends TermSymbol
+trait BlockSymbol extends TermSymbol
 
-  /**
-   * The result of running the frontend on a module.
-   * Symbols and types are stored globally in CompilerContext.
-   */
-  case class Module(
-    decl: ModuleDecl,
-    source: Source
-  ) extends Symbol {
-
-    val name = {
-      val segments = decl.path.split("/")
-      QualifiedName(segments.tail.toList, segments.head)
-    }
-
-    def path = decl.path
-
-    private var _terms: Map[String, Set[TermSymbol]] = _
-    def terms = _terms
-
-    private var _types: Map[String, TypeSymbol] = _
-    def types = _types
-
-    private var _imports: List[Module] = _
-    def imports = _imports
-
-    // a topological ordering of all transitive dependencies
-    // this is the order in which the modules need to be compiled / loaded
-    lazy val dependencies: List[Module] = imports.flatMap { im => im.dependencies :+ im }.distinct
-
-    // toplevel declared effects
-    def effects: Effects = Effects(types.values.collect {
-      case e: InterfaceType => e
-    })
-
-    /**
-     * It is actually possible, that exports is invoked on a single module multiple times:
-     * The dependencies of a module might change, which triggers frontend on the same module
-     * again. It is the same, since the source and AST did not change.
-     */
-    def exports(
-      imports: List[Module],
-      terms: Map[String, Set[TermSymbol]],
-      types: Map[String, TypeSymbol]
-    ): this.type = {
-      _imports = imports
-      _terms = terms
-      _types = types
-      this
-    }
-  }
-
-  sealed trait Param extends TermSymbol
-  case class ValueParam(name: Name, tpe: Option[ValueType]) extends Param with ValueSymbol
-
-  // TODO everywhere else the two universes are called "value" and "block"
-
-  sealed trait TrackedParam extends Param with BlockSymbol {
-    // every block parameter gives rise to a capture parameter
-    lazy val capture: Capture = CaptureParameter(name)
-  }
-  case class BlockParam(name: Name, tpe: BlockType) extends TrackedParam
-  //  case class CapabilityParam(name: Name, tpe: CapabilityType) extends TrackedParam with Capability {
-  //    def effect = tpe.eff
-  //    override def toString = s"@${tpe.eff.name}"
-  //  }
-
-  // to be fair, resume is not tracked anymore, but transparent.
-  case class ResumeParam(module: Module) extends TrackedParam { val name = Name.local("resume") }
-
-  /**
-   * Term-level representation of the current region.
-   */
-  case class SelfParam(tree: source.Tree) extends TrackedParam {
-    val name = Name.local("this")
-    def tpe = builtins.TRegion
-    override lazy val capture: Capture = LexicalRegion(name, tree)
-  }
-
-  // TODO rename to Callable
-  trait Fun extends BlockSymbol {
-    def tparams: List[TypeVar]
-    def vparams: List[ValueParam]
-    def bparams: List[BlockParam]
-    def annotatedResult: Option[ValueType]
-    def annotatedEffects: Option[Effects]
-  }
-
-  case class UserFunction(
-    name: Name,
-    tparams: List[TypeVar],
-    vparams: List[ValueParam],
-    bparams: List[BlockParam],
-    annotatedResult: Option[ValueType],
-    annotatedEffects: Option[Effects],
-    decl: FunDef
-  ) extends Fun
-
-  /**
-   * Anonymous symbols used to represent scopes / regions in the region checker
-   */
-  sealed trait Anon extends TermSymbol {
-    val name = NoName
-    def decl: source.Tree
-  }
-
-  case class Lambda(vparams: List[ValueParam], bparams: List[BlockParam], decl: source.Tree) extends Fun with Anon {
-    // Lambdas currently do not have an annotated return type
-    def annotatedResult = None
-    def annotatedEffects = None
-
-    // Lambdas currently do not take type parameters
-    def tparams = Nil
-  }
-
-  /**
-   * Binders represent local value and variable binders
-   *
-   * They also store a reference to the original defition in the source code
-   */
-  sealed trait Binder extends TermSymbol {
-    def tpe: Option[Type]
-    def decl: Def
-  }
-  case class ValBinder(name: Name, tpe: Option[ValueType], decl: ValDef) extends Binder with ValueSymbol
-  case class VarBinder(name: Name, tpe: Option[ValueType], region: BlockSymbol, decl: VarDef) extends Binder with BlockSymbol
-  case class DefBinder(name: Name, tpe: Option[BlockType], decl: DefDef) extends Binder with BlockSymbol
-
-  /**
-   * Synthetic symbol representing potentially multiple call targets
-   *
-   * Refined by typer.
-   */
-  case class CallTarget(name: Name, symbols: List[Set[BlockSymbol]]) extends Synthetic with BlockSymbol
-
-  /**
-   * Introduced by Transformer
-   */
-  case class Wildcard(module: Module) extends ValueSymbol { val name = Name.local("_") }
-  case class Tmp(module: Module) extends ValueSymbol { val name = Name.local("tmp" + Symbol.fresh.next()) }
-
-  /**
-   * Types
-   */
-  sealed trait Type
-
-  /**
-   * like Params but without name binders
-   */
-  type Sections = List[Type]
-
-  sealed trait ValueType extends Type
-
-  /**
-   * Types of first-class functions
-   */
-  case class BoxedType(tpe: BlockType, capture: Captures) extends ValueType {
-    // TODO move rendering to different component
-
-    //    override def toString: String = {
-    //
-    //      val FunctionType(_, params, ret, effs) = tpe
-    //      // copy and paste from BlockType.toString
-    //      val ps = params.map {
-    //        case List(b: FunctionType) => s"{${b.toString}}"
-    //        case ps: List[ValueType @unchecked] => s"(${ps.map { _.toString }.mkString(", ")})"
-    //        case _ => sys error "Parameter lists are either singleton block params or a list of value params."
-    //      }.mkString("")
-    //
-    //      val effects = effs.toList
-    //      val regs = region match {
-    //        case RegionSet(r) => r.regions.toList
-    //        // to not confuse users, we render uninstantiated region variables as ?
-    //        case e            => List("?")
-    //      }
-    //      val both: List[String] = (effects ++ regs).map { _.toString }
-    //
-    //      val tpeString = if (both.isEmpty) ret.toString else s"$ret / { ${both.mkString(", ")} }"
-    //
-    //      s"$ps ⟹ $tpeString"
-    //    }
-  }
-
-  class TypeVar(val name: Name) extends ValueType with TypeSymbol
-  object TypeVar {
-    def apply(name: Name): TypeVar = new TypeVar(name)
-  }
-
-  /**
-   * Introduced when instantiating type schemes
-   *
-   * Should neither occur in source programs, nor in inferred types
-   */
-  case class UnificationVar(role: UnificationVar.Role) extends TypeVar(Name.local("?")) {
-    override def toString = role match {
-      case UnificationVar.TypeVariableInstantiation(underlying, _) => "?" + underlying.toString + id
-      case _ => "?" + id
-    }
-  }
-  object UnificationVar {
-    sealed trait Role
-    case class TypeVariableInstantiation(underlying: TypeVar, call: source.Tree) extends Role
-  }
-
-  case class ValueTypeApp(tpe: ValueType, args: List[ValueType]) extends ValueType {
-    override def toString = s"${tpe}[${args.map { _.toString }.mkString(", ")}]"
-  }
-
-  case class TypeAlias(name: Name, tparams: List[TypeVar], tpe: ValueType) extends TypeSymbol
-
-  /**
-   * Types that _can_ be used in type constructor position. e.g. >>>List<<<[T]
-   */
-  sealed trait TypeConstructor extends TypeSymbol with ValueType
-
-  case class DataType(name: Name, tparams: List[TypeVar], var variants: List[Record] = Nil) extends TypeConstructor
-
-  /**
-   * Structures are also function symbols to represent the constructor
-   */
-  case class Record(name: Name, tparams: List[TypeVar], var tpe: ValueType, var fields: List[Field] = Nil) extends TypeConstructor with Fun with Synthetic {
-    // Parameter and return type of the constructor:
-    lazy val vparams = fields.map { f => f.param }
-    val bparams = List.empty[BlockParam]
-    def annotatedResult = Some(tpe)
-    def annotatedEffects = Some(Effects.Pure)
-  }
-
-  /**
-   * The record symbols is _both_ a type (record type) _and_ a term symbol (constructor).
-   *
-   * param: The underlying constructor parameter
-   */
-  case class Field(name: Name, param: ValueParam, record: Record) extends Fun with Synthetic {
-    val tparams = record.tparams
-    val tpe = param.tpe.get
-    val vparams = List(ValueParam(record.name, Some(if (record.tparams.isEmpty) record else ValueTypeApp(record, record.tparams))))
-    val bparams = List.empty[BlockParam]
-    def annotatedResult = Some(tpe)
-    def annotatedEffects = Some(Effects.Pure)
-  }
-
-  /**
-   * [[BlockType]]
-   *   |
-   *   |- [[FunctionType]]
-   *   |
-   *   |- [[InterfaceType]]
-   *      |
-   *      |- [[BlockTypeApp]]
-   *      |- [[Interface]]
-   *
-   * Effects are a
-   *   list of [[InterfaceType]]
-   *
-   * Outside of the hierarchy are
-   *   [[EffectAlias]]
-   * which are resolved by [[Namer]] to a list of [[InterfaceType]]s
-   */
-
-  sealed trait BlockType extends Type
-
-  // TODO new function type draft:
-  //   example
-  //     FunctionType(Nil, List(Cf), Nil, Nil, List((Exc -> Cf)), BoxedType(Exc, Cf), List(Console))
-  //   instantiated:
-  //     FunctionType(Nil, Nil, Nil, Nil, List((Exc -> ?C1)), BoxedType(Exc, ?C1), List(Console))
-  //  case class FunctionType(
-  //    tparams: List[TypeVar],
-  //    cparams: List[Capture],
-  //    vparams: List[ValueType],
-  //    // (S -> C) corresponds to { f :^C S }, that is a block parameter with capture C
-  //    bparams: List[(BlockType, Captures)],
-  //    capabilities: List[(InterfaceType, Captures)],
-  //    result: ValueType,
-  //    builtins: List[InterfaceType]
-  //  ) extends BlockType {
-  //    def controlEffects = capabilities.map { _._1 }
-  //    def effects: Effects = Effects(controlEffects)
-  //  }
-
-
-  case class FunctionType(
-    tparams: List[TypeVar],
-    cparams: List[Capture],
-    vparams: List[ValueType],
-    bparams: List[BlockType],
-    result: ValueType,
-    effects: Effects
-  ) extends BlockType
-
-
-  /** Effects */
-
-  sealed trait InterfaceType extends BlockType {
-    def name: Name
-  }
-
-  case class BlockTypeApp(typeConstructor: Interface, args: List[ValueType]) extends InterfaceType {
-    override def toString = s"${typeConstructor}[${args.map { _.toString }.mkString(", ")}]"
-    def name = typeConstructor.name
-  }
-
-  case class Interface(name: Name, tparams: List[TypeVar], var ops: List[Operation] = Nil) extends InterfaceType, TypeSymbol
-  case class Operation(name: Name, tparams: List[TypeVar], vparams: List[ValueParam], resultType: ValueType, otherEffects: Effects, effect: Interface) extends Fun {
-    val bparams = List.empty[BlockParam]
-    def annotatedResult = Some(resultType)
-    def annotatedEffects = Some(Effects(otherEffects.toList))
-
-    def appliedEffect = if (effect.tparams.isEmpty) effect else BlockTypeApp(effect, effect.tparams)
-
-    def isBidirectional: Boolean = otherEffects.nonEmpty
-  }
-
-  def interfaceOf(tpe: InterfaceType)(using C: ErrorReporter): Interface = tpe match {
-    case BlockTypeApp(i: Interface, args) => i
-    case i: Interface => i
-  }
-
-    /**
-     * Effect aliases are *not* block types; they cannot be used for example in `def foo { f : Alias }`.
-     */
-    case class EffectAlias(name: Name, tparams: List[TypeVar], effs: Effects) extends TypeSymbol
-
-  /**
-   * Represents effect sets on function types.
-   *
-   * All effects are dealiased by namer. Effects are inferred via [[typer.ConcreteEffects]] so
-   * by construction all entries in the set of effects here should be concrete (no unification variables).
-   *
-   * Effect sets are themselves *not* symbols, they are just aggregates.
-   *
-   * We do not enforce entries to be distinct. This way we can substitute types and keep duplicate entries.
-   * For instances { State[S], State[T] }[S -> Int, T -> Int] then becomes { State[Int], State[Int] }.
-   * This is important since we need to pass two capabilities in this case.
-   *
-   * Method [[controlEffects]] computes the canonical ordering of capabilities for this set of effects.
-   * Disjointness needs to be ensured manually when constructing effect sets (for instance via [[typer.ConcreteEffects]]).
-   */
-  case class Effects(effects: List[InterfaceType]) {
-
-    lazy val toList: List[InterfaceType] = effects.distinct
-
-    def isEmpty: Boolean = effects.isEmpty
-    def nonEmpty: Boolean = effects.nonEmpty
-
-    def filterNot(p: InterfaceType => Boolean): Effects =
-      Effects(effects.filterNot(p))
-
-    def forall(p: InterfaceType => Boolean): Boolean = effects.forall(p)
-    def exists(p: InterfaceType => Boolean): Boolean = effects.exists(p)
-
-    lazy val controlEffects: List[InterfaceType] = effects.controlEffects
-
-    def distinct: Effects = Effects(effects.distinct)
-
-    override def toString: String = toList match {
-      case Nil        => "{}"
-      case eff :: Nil => eff.toString
-      case effs       => s"{ ${effs.mkString(", ")} }"
-    }
-  }
-  object Effects {
-
-    def apply(effs: InterfaceType*): Effects =
-      new Effects(effs.toList)
-
-    def apply(effs: Iterable[InterfaceType]): Effects =
-      new Effects(effs.toList)
-
-    def empty: Effects = new Effects(Nil)
-    val Pure = empty
-  }
-
-  extension(effs: List[InterfaceType]) {
-    // establishes the canonical ordering
-    def controlEffects: List[InterfaceType] = effs.sortBy(canonicalOrdering)
-  }
-
-  /**
-   * The canonical ordering needs to be stable, but should also distinguish two types,
-   * if they are different.
-   *
-   * Bugs with the canonical ordering can lead to runtime errors as observed in ticket #108
-   */
-  def canonicalOrdering(i: InterfaceType): Int = i match {
-    case BlockTypeApp(typeConstructor: Interface, args) => typeConstructor.id + args.map(_.hashCode()).sum
-    case b : Interface => b.id
-  }
-
-  /**
-   * Capture Sets
-   */
-
-  sealed trait Captures
-
-  case class CaptureSet(captures: Set[Capture]) extends Captures {
-    override def toString = s"{${captures.mkString(", ")}}"
-
-    // This is a very simple form of subtraction, make sure that all constraints have been solved before using it!
-    def --(other: CaptureSet): CaptureSet = CaptureSet(captures -- other.captures)
-    def ++(other: CaptureSet): CaptureSet = CaptureSet(captures ++ other.captures)
-    def +(c: Capture): CaptureSet = CaptureSet(captures + c)
-    def flatMap(f: Capture => CaptureSet): CaptureSet = CaptureSet(captures.flatMap(x => f(x).captures))
-  }
-  object CaptureSet {
-    def apply(captures: Capture*): CaptureSet = CaptureSet(captures.toSet)
-    def apply(captures: List[Capture]): CaptureSet = CaptureSet(captures.toSet)
-    def empty = CaptureSet()
-  }
-
-  /**
-   * Something that can be substituted by a capture set
-   */
-  sealed trait CaptVar
-
-  /**
-   * "Tracked" capture parameters. Like [[TypeVar]] used to abstract
-   * over capture. Also see [[BlockParam.capture]].
-   *
-   * Can be either
-   * - [[LexicalRegion]] to model self regions of functions
-   */
-  trait Capture extends TypeSymbol, CaptVar
-  case class LexicalRegion(name: Name, tree: source.Tree) extends Capture
-  case class CaptureParameter(name: Name) extends Capture
-
-
-  case class CaptUnificationVar(role: CaptUnificationVar.Role) extends Captures, CaptVar, TypeSymbol {
-    val name = Name.local("?C")
-    override def toString = role match {
-      case CaptUnificationVar.VariableInstantiation(underlying, _) => "?" + underlying.toString + id
-      case CaptUnificationVar.Subtraction(handled, underlying) => s"?filter" + id
-      case CaptUnificationVar.FunctionRegion(fun) => s"?${fun.id.name}" + id
-      case CaptUnificationVar.AnonymousFunctionRegion(fun) => s"?anon" + id
-      case CaptUnificationVar.HandlerRegion(handler) => s"?Ck" + id
-      case _ => "?" + id
-    }
-  }
-  object CaptUnificationVar {
-    sealed trait Role
-    case class VariableInstantiation(underlying: Capture, call: source.Tree) extends Role
-    case class HandlerRegion(handler: source.TryHandle) extends Role
-    case class RegionRegion(handler: source.Region) extends Role
-    case class FunctionRegion(fun: source.FunDef) extends Role
-    case class BlockRegion(fun: source.DefDef) extends Role
-    case class AnonymousFunctionRegion(fun: source.BlockLiteral) extends Role
-    case class InferredBox(box: source.Box) extends Role
-    case class InferredUnbox(unbox: source.Unbox) extends Role
-    // underlying should be a UnificationVar
-    case class Subtraction(handled: List[Capture], underlying: CaptUnificationVar) extends Role
-    case class Substitution() extends Role
-  }
-
-  /**
-   * Builtins
-   */
-  sealed trait Builtin extends Symbol {
-    override def builtin = true
-  }
-
-  case class BuiltinFunction(
-    name: Name,
-    tparams: List[TypeVar],
-    vparams: List[ValueParam],
-    bparams: List[BlockParam],
-    result: ValueType,
-    effects: Effects,
-    purity: ExternFlag.Purity = ExternFlag.Pure,
-    body: String = ""
-  ) extends Fun with BlockSymbol with Builtin {
-    def annotatedResult = Some(result)
-    def annotatedEffects = Some(effects)
-  }
-
-  case class BuiltinType(name: Name, tparams: List[TypeVar]) extends ValueType, TypeSymbol, Builtin
-
-  def isBuiltin(e: Symbol): Boolean = e.builtin
+sealed trait Synthetic extends Symbol {
+  override def synthetic = true
 }
+
+/**
+ * The result of running the frontend on a module.
+ * Symbols and types are stored globally in CompilerContext.
+ */
+case class Module(
+  decl: ModuleDecl,
+  source: Source
+) extends Symbol {
+
+  val name = {
+    val segments = decl.path.split("/")
+    QualifiedName(segments.tail.toList, segments.head)
+  }
+
+  def path = decl.path
+
+  private var _terms: Map[String, Set[TermSymbol]] = _
+  def terms = _terms
+
+  private var _types: Map[String, TypeSymbol] = _
+  def types = _types
+
+  private var _imports: List[Module] = _
+  def imports = _imports
+
+  // a topological ordering of all transitive dependencies
+  // this is the order in which the modules need to be compiled / loaded
+  lazy val dependencies: List[Module] = imports.flatMap { im => im.dependencies :+ im }.distinct
+
+  // toplevel declared effects
+  def effects: Effects = Effects(types.values.collect {
+    case e: InterfaceType => e
+  })
+
+  /**
+   * It is actually possible, that exports is invoked on a single module multiple times:
+   * The dependencies of a module might change, which triggers frontend on the same module
+   * again. It is the same, since the source and AST did not change.
+   */
+  def exports(
+    imports: List[Module],
+    terms: Map[String, Set[TermSymbol]],
+    types: Map[String, TypeSymbol]
+  ): this.type = {
+    _imports = imports
+    _terms = terms
+    _types = types
+    this
+  }
+}
+
+sealed trait Param extends TermSymbol
+case class ValueParam(name: Name, tpe: Option[ValueType]) extends Param with ValueSymbol
+
+// TODO everywhere else the two universes are called "value" and "block"
+
+sealed trait TrackedParam extends Param with BlockSymbol {
+  // every block parameter gives rise to a capture parameter
+  lazy val capture: Capture = CaptureParameter(name)
+}
+case class BlockParam(name: Name, tpe: BlockType) extends TrackedParam
+//  case class CapabilityParam(name: Name, tpe: CapabilityType) extends TrackedParam with Capability {
+//    def effect = tpe.eff
+//    override def toString = s"@${tpe.eff.name}"
+//  }
+
+// to be fair, resume is not tracked anymore, but transparent.
+case class ResumeParam(module: Module) extends TrackedParam { val name = Name.local("resume") }
+
+/**
+ * Term-level representation of the current region.
+ */
+case class SelfParam(tree: source.Tree) extends TrackedParam {
+  val name = Name.local("this")
+  def tpe = builtins.TRegion
+  override lazy val capture: Capture = LexicalRegion(name, tree)
+}
+
+// TODO rename to Callable
+trait Fun extends BlockSymbol {
+  def tparams: List[TypeVar]
+  def vparams: List[ValueParam]
+  def bparams: List[BlockParam]
+  def annotatedResult: Option[ValueType]
+  def annotatedEffects: Option[Effects]
+}
+
+case class UserFunction(
+  name: Name,
+  tparams: List[TypeVar],
+  vparams: List[ValueParam],
+  bparams: List[BlockParam],
+  annotatedResult: Option[ValueType],
+  annotatedEffects: Option[Effects],
+  decl: FunDef
+) extends Fun
+
+/**
+ * Anonymous symbols used to represent scopes / regions in the region checker
+ */
+sealed trait Anon extends TermSymbol {
+  val name = NoName
+  def decl: source.Tree
+}
+
+case class Lambda(vparams: List[ValueParam], bparams: List[BlockParam], decl: source.Tree) extends Fun with Anon {
+  // Lambdas currently do not have an annotated return type
+  def annotatedResult = None
+  def annotatedEffects = None
+
+  // Lambdas currently do not take type parameters
+  def tparams = Nil
+}
+
+/**
+ * Binders represent local value and variable binders
+ *
+ * They also store a reference to the original defition in the source code
+ */
+sealed trait Binder extends TermSymbol {
+  def tpe: Option[Type]
+  def decl: Def
+}
+case class ValBinder(name: Name, tpe: Option[ValueType], decl: ValDef) extends Binder with ValueSymbol
+case class VarBinder(name: Name, tpe: Option[ValueType], region: BlockSymbol, decl: VarDef) extends Binder with BlockSymbol
+case class DefBinder(name: Name, tpe: Option[BlockType], decl: DefDef) extends Binder with BlockSymbol
+
+/**
+ * Synthetic symbol representing potentially multiple call targets
+ *
+ * Refined by typer.
+ */
+case class CallTarget(name: Name, symbols: List[Set[BlockSymbol]]) extends Synthetic with BlockSymbol
+
+/**
+ * Introduced by Transformer
+ */
+case class Wildcard(module: Module) extends ValueSymbol { val name = Name.local("_") }
+case class Tmp(module: Module) extends ValueSymbol { val name = Name.local("tmp" + Symbol.fresh.next()) }
+
+
+
+// reflecting the two namespaces
+sealed trait TypeSymbol extends Symbol
+
+sealed trait ValueTypeSymbol extends TypeSymbol
+
+sealed trait BlockTypeSymbol extends TypeSymbol
+
+/**
+ * Value Type Symbols
+ */
+
+/**
+ * Type variables are symbols that can be substituted for.
+ * - [[TypeParam]] type variables in user programs
+ * - [[UnificationVar]] type variables inserted by the type checker.
+ */
+sealed trait TypeVar extends ValueTypeSymbol
+
+/**
+ * Type parameters that show up in user programs
+ */
+case class TypeParam(name: Name) extends TypeVar
+
+/**
+ * Introduced when instantiating type schemes
+ *
+ * Should neither occur in source programs, nor in inferred types
+ */
+case class UnificationVar(role: UnificationVar.Role) extends TypeVar {
+  val name = Name.local("?")
+
+  override def toString = role match {
+    case UnificationVar.TypeVariableInstantiation(underlying, _) => "?" + underlying.toString + id
+    case _ => "?" + id
+  }
+}
+object UnificationVar {
+  sealed trait Role
+  case class TypeVariableInstantiation(underlying: TypeVar, call: source.Tree) extends Role
+}
+
+case class TypeAlias(name: Name, tparams: List[TypeVar], tpe: ValueType) extends ValueTypeSymbol
+
+/**
+ * Types that _can_ be used in type constructor position. e.g. >>>List<<<[T]
+ *
+ * - [[DataType]]
+ * - [[Record]]
+ * - [[BuiltinType]]
+ */
+sealed trait TypeConstructor extends TypeSymbol
+
+case class DataType(name: Name, tparams: List[TypeVar], var variants: List[Record] = Nil) extends TypeConstructor
+
+  /**
+ * Structures are also function symbols to represent the constructor
+ */
+case class Record(name: Name, tparams: List[TypeVar], var tpe: ValueType, var fields: List[Field] = Nil) extends TypeConstructor with Fun with Synthetic {
+  // Parameter and return type of the constructor:
+  lazy val vparams = fields.map { f => f.param }
+  val bparams = List.empty[BlockParam]
+
+  def annotatedResult = Some(tpe)
+
+  def annotatedEffects = Some(Effects.Pure)
+}
+
+/**
+ * The record symbols is _both_ a type (record type) _and_ a term symbol (constructor).
+ *
+ * param: The underlying constructor parameter
+ */
+case class Field(name: Name, param: ValueParam, record: Record) extends Fun with Synthetic {
+  val tparams = record.tparams
+  val tpe = param.tpe.get
+  val vparams = List(ValueParam(record.name, Some(ValueTypeApp(record, record.tparams map ValueTypeRef.apply))))
+  val bparams = List.empty[BlockParam]
+
+  def annotatedResult = Some(tpe)
+
+  def annotatedEffects = Some(Effects.Pure)
+}
+
+
+case class Interface(name: Name, tparams: List[TypeVar], var ops: List[Operation] = Nil) extends BlockTypeSymbol
+case class Operation(name: Name, tparams: List[TypeVar], vparams: List[ValueParam], resultType: ValueType, otherEffects: Effects, effect: Interface) extends Fun {
+  val bparams = List.empty[BlockParam]
+  def annotatedResult = Some(resultType)
+  def annotatedEffects = Some(Effects(otherEffects.toList))
+
+  def appliedEffect = InterfaceType(effect, effect.tparams map ValueTypeRef.apply)
+
+  def isBidirectional: Boolean = otherEffects.nonEmpty
+}
+
+/**
+ * Effect aliases are *not* block types; they cannot be used for example in `def foo { f : Alias }`.
+ */
+case class EffectAlias(name: Name, tparams: List[TypeVar], effs: Effects) extends BlockTypeSymbol
+
+
+/**
+ * Something that can be substituted by a capture set
+ */
+sealed trait CaptVar
+
+/**
+ * "Tracked" capture parameters. Like [[TypeVar]] used to abstract
+ * over capture. Also see [[BlockParam.capture]].
+ *
+ * Can be either
+ * - [[LexicalRegion]] to model self regions of functions
+ */
+trait Capture extends TypeSymbol, CaptVar
+case class LexicalRegion(name: Name, tree: source.Tree) extends Capture
+case class CaptureParameter(name: Name) extends Capture
+
+
+case class CaptUnificationVar(role: CaptUnificationVar.Role) extends Captures, CaptVar, TypeSymbol {
+  val name = Name.local("?C")
+  override def toString = role match {
+    case CaptUnificationVar.VariableInstantiation(underlying, _) => "?" + underlying.toString + id
+    case CaptUnificationVar.Subtraction(handled, underlying) => s"?filter" + id
+    case CaptUnificationVar.FunctionRegion(fun) => s"?${fun.id.name}" + id
+    case CaptUnificationVar.AnonymousFunctionRegion(fun) => s"?anon" + id
+    case CaptUnificationVar.HandlerRegion(handler) => s"?Ck" + id
+    case _ => "?" + id
+  }
+}
+object CaptUnificationVar {
+  sealed trait Role
+  case class VariableInstantiation(underlying: Capture, call: source.Tree) extends Role
+  case class HandlerRegion(handler: source.TryHandle) extends Role
+  case class RegionRegion(handler: source.Region) extends Role
+  case class FunctionRegion(fun: source.FunDef) extends Role
+  case class BlockRegion(fun: source.DefDef) extends Role
+  case class AnonymousFunctionRegion(fun: source.BlockLiteral) extends Role
+  case class InferredBox(box: source.Box) extends Role
+  case class InferredUnbox(unbox: source.Unbox) extends Role
+  // underlying should be a UnificationVar
+  case class Subtraction(handled: List[Capture], underlying: CaptUnificationVar) extends Role
+  case class Substitution() extends Role
+}
+
+/**
+ * Capture Sets
+ */
+
+sealed trait Captures
+
+case class CaptureSet(captures: Set[Capture]) extends Captures {
+  override def toString = s"{${captures.mkString(", ")}}"
+
+  // This is a very simple form of subtraction, make sure that all constraints have been solved before using it!
+  def --(other: CaptureSet): CaptureSet = CaptureSet(captures -- other.captures)
+  def ++(other: CaptureSet): CaptureSet = CaptureSet(captures ++ other.captures)
+  def +(c: Capture): CaptureSet = CaptureSet(captures + c)
+  def flatMap(f: Capture => CaptureSet): CaptureSet = CaptureSet(captures.flatMap(x => f(x).captures))
+}
+object CaptureSet {
+  def apply(captures: Capture*): CaptureSet = CaptureSet(captures.toSet)
+  def apply(captures: List[Capture]): CaptureSet = CaptureSet(captures.toSet)
+  def empty = CaptureSet()
+}
+
+/**
+ * Builtins
+ */
+sealed trait Builtin extends Symbol {
+  override def builtin = true
+}
+def isBuiltin(e: Symbol): Boolean = e.builtin
+
+case class BuiltinFunction(
+  name: Name,
+  tparams: List[TypeVar],
+  vparams: List[ValueParam],
+  bparams: List[BlockParam],
+  result: ValueType,
+  effects: Effects,
+  purity: ExternFlag.Purity = ExternFlag.Pure,
+  body: String = ""
+) extends Fun with BlockSymbol with Builtin {
+  def annotatedResult = Some(result)
+  def annotatedEffects = Some(effects)
+}
+
+case class BuiltinType(name: Name, tparams: List[TypeVar]) extends TypeConstructor, Builtin
+

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -169,13 +169,16 @@ case class Wildcard(module: Module) extends ValueSymbol { val name = Name.local(
 case class Tmp(module: Module) extends ValueSymbol { val name = Name.local("tmp" + Symbol.fresh.next()) }
 
 
-
-// reflecting the two namespaces
+/**
+ * Type Symbols
+ * - [[ValueTypeSymbol]]
+ * - [[BlockTypeSymbol]]
+ * - [[Capture]]
+ */
 sealed trait TypeSymbol extends Symbol
-
 sealed trait ValueTypeSymbol extends TypeSymbol
-
 sealed trait BlockTypeSymbol extends TypeSymbol
+
 
 /**
  * Value Type Symbols

--- a/effekt/shared/src/main/scala/effekt/symbols/types.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/types.scala
@@ -88,7 +88,6 @@ case class FunctionType(
 /** Interfaces */
 
 case class InterfaceType(typeConstructor: Interface, args: List[ValueType]) extends BlockType {
-  override def toString = s"${typeConstructor}[${args.map { _.toString }.mkString(", ")}]"
   def name = typeConstructor.name
 }
 

--- a/effekt/shared/src/main/scala/effekt/symbols/types.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/types.scala
@@ -76,7 +76,7 @@ sealed trait BlockType extends Type
 
 
 case class FunctionType(
-  tparams: List[TypeVar],
+  tparams: List[TypeParam],
   cparams: List[Capture],
   vparams: List[ValueType],
   bparams: List[BlockType],

--- a/effekt/shared/src/main/scala/effekt/symbols/types.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/types.scala
@@ -1,0 +1,160 @@
+package effekt
+package symbols
+
+/**
+ * Types
+ */
+sealed trait Type
+
+/**
+ * like Params but without name binders
+ */
+type Sections = List[Type]
+
+
+/**
+ * Value Types
+ *
+ * [[ValueType]]
+ *   |
+ *   |- [[ValueTypeRef]] references to type params
+ *   |- [[ValueTypeApp]] references to type constructors
+ *   |- [[BoxedType]] boxed block types
+ */
+
+sealed trait ValueType extends Type
+
+/**
+ * Types of first-class functions
+ */
+case class BoxedType(tpe: BlockType, capture: Captures) extends ValueType
+
+/**
+ * Reference to a type variable (we don't have type constructor polymorphism, so variables do not take arguments)
+ */
+case class ValueTypeRef(tvar: TypeVar) extends ValueType
+
+/**
+ * Reference to a type constructor with optional type arguments
+ */
+case class ValueTypeApp(constructor: TypeConstructor, args: List[ValueType]) extends ValueType
+
+
+/**
+ * [[BlockType]]
+ *   |
+ *   |- [[FunctionType]]
+ *   |- [[InterfaceType]]
+ *
+ * Effects are a
+ *   list of [[InterfaceType]]
+ *
+ * Outside of the hierarchy are
+ *   [[EffectAlias]]
+ * which are resolved by [[Namer]] to a list of [[InterfaceType]]s
+ */
+sealed trait BlockType extends Type
+
+// TODO new function type draft:
+//   example
+//     FunctionType(Nil, List(Cf), Nil, Nil, List((Exc -> Cf)), BoxedType(Exc, Cf), List(Console))
+//   instantiated:
+//     FunctionType(Nil, Nil, Nil, Nil, List((Exc -> ?C1)), BoxedType(Exc, ?C1), List(Console))
+//  case class FunctionType(
+//    tparams: List[TypeVar],
+//    cparams: List[Capture],
+//    vparams: List[ValueType],
+//    // (S -> C) corresponds to { f :^C S }, that is a block parameter with capture C
+//    bparams: List[(BlockType, Captures)],
+//    capabilities: List[(InterfaceType, Captures)],
+//    result: ValueType,
+//    builtins: List[InterfaceType]
+//  ) extends BlockType {
+//    def controlEffects = capabilities.map { _._1 }
+//    def effects: Effects = Effects(controlEffects)
+//  }
+
+
+case class FunctionType(
+  tparams: List[TypeVar],
+  cparams: List[Capture],
+  vparams: List[ValueType],
+  bparams: List[BlockType],
+  result: ValueType,
+  effects: Effects
+) extends BlockType
+
+
+/** Interfaces */
+
+case class InterfaceType(typeConstructor: Interface, args: List[ValueType]) extends BlockType {
+  override def toString = s"${typeConstructor}[${args.map { _.toString }.mkString(", ")}]"
+  def name = typeConstructor.name
+}
+
+
+
+/**
+ * Represents effect sets on function types.
+ *
+ * All effects are dealiased by namer. Effects are inferred via [[typer.ConcreteEffects]] so
+ * by construction all entries in the set of effects here should be concrete (no unification variables).
+ *
+ * Effect sets are themselves *not* symbols, they are just aggregates.
+ *
+ * We do not enforce entries to be distinct. This way we can substitute types and keep duplicate entries.
+ * For instances { State[S], State[T] }[S -> Int, T -> Int] then becomes { State[Int], State[Int] }.
+ * This is important since we need to pass two capabilities in this case.
+ *
+ * Method [[controlEffects]] computes the canonical ordering of capabilities for this set of effects.
+ * Disjointness needs to be ensured manually when constructing effect sets (for instance via [[typer.ConcreteEffects]]).
+ */
+case class Effects(effects: List[InterfaceType]) {
+
+  lazy val toList: List[InterfaceType] = effects.distinct
+
+  def isEmpty: Boolean = effects.isEmpty
+  def nonEmpty: Boolean = effects.nonEmpty
+
+  def filterNot(p: InterfaceType => Boolean): Effects =
+    Effects(effects.filterNot(p))
+
+  def forall(p: InterfaceType => Boolean): Boolean = effects.forall(p)
+  def exists(p: InterfaceType => Boolean): Boolean = effects.exists(p)
+
+  lazy val controlEffects: List[InterfaceType] = effects.controlEffects
+
+  def distinct: Effects = Effects(effects.distinct)
+
+  override def toString: String = toList match {
+    case Nil        => "{}"
+    case eff :: Nil => eff.toString
+    case effs       => s"{ ${effs.mkString(", ")} }"
+  }
+}
+object Effects {
+
+  def apply(effs: InterfaceType*): Effects =
+    new Effects(effs.toList)
+
+  def apply(effs: Iterable[InterfaceType]): Effects =
+    new Effects(effs.toList)
+
+  def empty: Effects = new Effects(Nil)
+  val Pure = empty
+}
+
+extension(effs: List[InterfaceType]) {
+  // establishes the canonical ordering
+  def controlEffects: List[InterfaceType] = effs.sortBy(canonicalOrdering)
+}
+
+/**
+ * The canonical ordering needs to be stable, but should also distinguish two types,
+ * if they are different.
+ *
+ * Bugs with the canonical ordering can lead to runtime errors as observed in ticket #108
+ */
+def canonicalOrdering(i: InterfaceType): Int = i match {
+  case InterfaceType(typeConstructor: Interface, args) => typeConstructor.id + args.map(_.hashCode()).sum
+}

--- a/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
@@ -31,7 +31,6 @@ class ConcreteEffects private[typer] (protected val effects: List[InterfaceType]
   def filterNot(p: InterfaceType => Boolean): ConcreteEffects = ConcreteEffects.fromList(effects.filterNot(p))
 
   def controlEffects: List[InterfaceType] = effects.controlEffects
-  def builtinEffects: List[InterfaceType] = effects.builtinEffects
 
   def forall(p: InterfaceType => Boolean): Boolean = effects.forall(p)
   def exists(p: InterfaceType => Boolean): Boolean = effects.exists(p)
@@ -98,13 +97,11 @@ private def isConcreteBlockType(tpe: BlockType): Boolean = tpe match {
     vparams.forall(isConcreteValueType) && bparams.forall(isConcreteBlockType) && isConcreteValueType(result) && isConcreteEffects(effects)
   case BlockTypeApp(tpe, args) => isConcreteBlockType(tpe) && args.forall(isConcreteValueType)
   case t: Interface => true
-  case b: BuiltinEffect => true
 }
 private def isConcreteCaptureSet(capt: Captures): Boolean = capt.isInstanceOf[CaptureSet]
 
 private def isConcreteEffect(eff: InterfaceType): Boolean = eff match {
   case t: Interface => true
-  case t: BuiltinEffect => true
   case BlockTypeApp(tpe, args) => isConcreteBlockType(tpe) && args.forall(isConcreteValueType)
 }
 private def isConcreteEffects(effs: Effects): Boolean = effs.toList.forall(isConcreteEffect)

--- a/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
@@ -30,12 +30,10 @@ class ConcreteEffects private[typer] (protected val effects: List[InterfaceType]
 
   def filterNot(p: InterfaceType => Boolean): ConcreteEffects = ConcreteEffects.fromList(effects.filterNot(p))
 
-  def controlEffects: List[InterfaceType] = effects.controlEffects
+  def canonical: List[InterfaceType] = effects.sorted(using CanonicalOrdering)
 
   def forall(p: InterfaceType => Boolean): Boolean = effects.forall(p)
   def exists(p: InterfaceType => Boolean): Boolean = effects.exists(p)
-
-  override def toString = toEffects.toString
 }
 object ConcreteEffects {
   // unsafe, doesn't perform check

--- a/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
@@ -79,29 +79,29 @@ private[typer] def assertConcrete(effs: Effects)(using C: Context): Unit =
   if (!isConcreteEffects(effs)) C.abort(pretty"Effects need to be fully known: ${effs}")
 
 private[typer] def assertConcrete(eff: InterfaceType)(using C: Context): Unit =
-  if (!isConcreteEffect(eff)) {
+  if (!isConcreteInterfaceType(eff)) {
     C.abort(pretty"Effects need to be fully known: ${eff}")
   }
 
 private def isConcreteValueType(tpe: ValueType): Boolean = tpe match {
+  case ValueTypeRef(x) => isConcreteValueType(x)
+  case ValueTypeApp(tpe, args) => args.forall(isConcreteValueType)
+  case BoxedType(tpe, capture) => isConcreteBlockType(tpe) && isConcreteCaptureSet(capture)
+}
+
+private def isConcreteValueType(tpe: TypeVar): Boolean = tpe match {
   case x: UnificationVar => false
   case x: TypeVar => true
-  case t: TypeConstructor => true
-  case t : BuiltinType => true
-  case ValueTypeApp(tpe, args) => isConcreteValueType(tpe) && args.forall(isConcreteValueType)
-  case BoxedType(tpe, capture) => isConcreteBlockType(tpe) && isConcreteCaptureSet(capture)
 }
 
 private def isConcreteBlockType(tpe: BlockType): Boolean = tpe match {
   case FunctionType(tparams, cparams, vparams, bparams, result, effects) =>
     vparams.forall(isConcreteValueType) && bparams.forall(isConcreteBlockType) && isConcreteValueType(result) && isConcreteEffects(effects)
-  case BlockTypeApp(tpe, args) => isConcreteBlockType(tpe) && args.forall(isConcreteValueType)
-  case t: Interface => true
+  case InterfaceType(tpe, args) => args.forall(isConcreteValueType)
 }
 private def isConcreteCaptureSet(capt: Captures): Boolean = capt.isInstanceOf[CaptureSet]
 
-private def isConcreteEffect(eff: InterfaceType): Boolean = eff match {
-  case t: Interface => true
-  case BlockTypeApp(tpe, args) => isConcreteBlockType(tpe) && args.forall(isConcreteValueType)
+private def isConcreteInterfaceType(eff: InterfaceType): Boolean = eff match {
+  case InterfaceType(tpe, args) => args.forall(isConcreteValueType)
 }
-private def isConcreteEffects(effs: Effects): Boolean = effs.toList.forall(isConcreteEffect)
+private def isConcreteEffects(effs: Effects): Boolean = effs.toList.forall(isConcreteInterfaceType)

--- a/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
@@ -195,7 +195,7 @@ class Constraints(
     }
 
     y match {
-      case y: UnificationVar => connectNodes(getNode(x), getNode(y))
+      case ValueTypeRef(y: UnificationVar) => connectNodes(getNode(x), getNode(y))
       case tpe => learnType(getNode(x), tpe)
     }
   }

--- a/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
@@ -173,7 +173,7 @@ class Constraints(
   def learn(x: UnificationVar, y: ValueType)(merge: (ValueType, ValueType) => Unit): Unit = {
 
     def learnType(x: Node, tpe: ValueType): Unit = {
-      assert(!tpe.isInstanceOf[UnificationVar])
+      // tpe should not be a reference to a unification variable
       typeOf(x) foreach { otherTpe => merge(tpe, otherTpe) }
       typeSubstitution = typeSubstitution.updated(x, tpe)
       updateSubstitution()

--- a/effekt/shared/src/main/scala/effekt/typer/ErrorContext.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ErrorContext.scala
@@ -65,7 +65,7 @@ object ErrorContext {
       //  (2) refactor so that explainMismatch is part of Messages and can add additional
       //      messages (with info about the trees and their types).
       case MergeTypes(left, right) =>
-        val msg = s"Different arms of a conditional/match have incompatible types.\n\nOne arm has type\n  $left\nwhile another one has type\n  $right"
+        val msg = pp"Different arms of a conditional/match have incompatible types.\n\nOne arm has type\n  $left\nwhile another one has type\n  $right"
 
         if (tpe2 != left || tpe1 != right)
           pp"$msg\n\nType mismatch between $tpe2 and $tpe1."

--- a/effekt/shared/src/main/scala/effekt/typer/PostTyper.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/PostTyper.scala
@@ -39,11 +39,11 @@ object Wellformedness extends Visit[WFContext] {
 
     // Effects that are lexically in scope at the top level
     // We use dependencies instead of imports, since types might mention effects of transitive imports.
-    val toplevelEffects = mod.dependencies.foldLeft(mod.effects.toList) { case (effs, mod) =>
-      effs ++ mod.effects.toList
+    val toplevelEffects = mod.dependencies.foldLeft(mod.effects) { case (effs, mod) =>
+      effs ++ mod.effects
     }
 
-    given WFContext = WFContext(extractInterfaces(toplevelEffects))
+    given WFContext = WFContext(toplevelEffects.distinct)
 
     query(tree)
   }
@@ -217,11 +217,11 @@ object Wellformedness extends Visit[WFContext] {
   // TODO extend check to also check in value types
   //   (now that we have first class functions, they could mention effects).
   def wellscoped(effects: Effects)(using C: Context, WF: WFContext): Unit = {
-//    def checkEffect(eff: InterfaceType): Unit =
-//      if (!(WF.effectsInScope contains eff.typeConstructor))
-//        Context.abort(pp"Effect ${eff} leaves its defining lexical scope as part of the inferred type.")
-//
-//    effects.toList foreach checkEffect
+    def checkEffect(eff: InterfaceType): Unit =
+      if (!(WF.effectsInScope contains eff.typeConstructor))
+        Context.abort(pp"Effect ${eff} leaves its defining lexical scope as part of the inferred type.")
+
+    effects.toList foreach checkEffect
   }
 
   def extractInterfaces(e: List[InterfaceType]): List[Interface] = e.map(_.typeConstructor).distinct

--- a/effekt/shared/src/main/scala/effekt/typer/PostTyper.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/PostTyper.scala
@@ -218,8 +218,6 @@ object Wellformedness extends Visit[WFContext] {
     def checkEffect(eff: InterfaceType): Unit = eff match {
       case e: Interface => checkInterface(e)
       case BlockTypeApp(e: Interface, args) => checkInterface(e)
-      case b: BuiltinEffect => ()
-      case BlockTypeApp(b: BuiltinEffect, args) => ()
     }
 
     effects.toList foreach checkEffect

--- a/effekt/shared/src/main/scala/effekt/typer/PostTyper.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/PostTyper.scala
@@ -149,20 +149,11 @@ object Wellformedness extends Visit[WFContext] {
       WF.addEffect(d.symbol)
   }
 
-  def checkExhaustivity(sc: ValueType, cls: List[MatchPattern])(using Context, WFContext): Unit = {
-    import source.{ AnyPattern, IgnorePattern }
-
-    val catchall = cls.exists { p => p.isInstanceOf[AnyPattern] || p.isInstanceOf[IgnorePattern] }
-
-    if (catchall)
-      return;
-
+  def checkExhaustivity(sc: ValueType, cls: List[MatchPattern])(using Context, WFContext): Unit =
     sc match {
-      case BoxedType(tpe, capture) => Context.error(pp"Cannot match on boxed type ${ tpe }.")
-      case ValueTypeRef(tvar) => Context.error(pp"Cannot match on type variable ${ tvar }.")
       case ValueTypeApp(constructor, args) => checkExhaustivity(constructor, cls)
+      case _ => ()
     }
-  }
 
   /**
    * This is a quick and dirty implementation of coverage checking. Both performance, and error reporting

--- a/effekt/shared/src/main/scala/effekt/typer/PreTyper.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/PreTyper.scala
@@ -163,7 +163,6 @@ class BoxUnboxInference {
     case d: EffectDef     => d
 
     case d: ExternType    => d
-    case d: ExternEffect  => d
     case d: ExternFun     => d
     case d: ExternInclude => d
   }

--- a/effekt/shared/src/main/scala/effekt/typer/PreTyper.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/PreTyper.scala
@@ -99,7 +99,7 @@ class BoxUnboxInference {
 
       val (funs, methods) = syms.partitionMap {
         case t: symbols.Operation => Right(t)
-        case t: symbols.Fun => Left(t)
+        case t: symbols.Callable => Left(t)
         case t => C.abort(pp"Not a valid method or function: ${t}")
       }
 

--- a/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
@@ -58,7 +58,7 @@ case class Substitutions(
   }
 
   def substitute(t: ValueType): ValueType = t match {
-    case ValueTypeRef(x: TypeVar) =>
+    case ValueTypeRef(x) =>
       values.getOrElse(x, t)
     case ValueTypeApp(t, args) =>
       ValueTypeApp(t, args.map { substitute })

--- a/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
@@ -93,9 +93,6 @@ case class Substitutions(
 object Substitutions {
   val empty: Substitutions = Substitutions(Map.empty[TypeVar, ValueType], Map.empty[CaptVar, Captures])
   def apply(values: List[(TypeVar, ValueType)], captures: List[(CaptVar, Captures)]): Substitutions = Substitutions(values.toMap, captures.toMap)
+  def types(keys: List[TypeVar], values: List[ValueType]): Substitutions = Substitutions((keys zip values).toMap, Map.empty)
+  def captures(keys: List[CaptVar], values: List[Captures]): Substitutions = Substitutions(Map.empty, (keys zip values).toMap)
 }
-
-// TODO Mostly for backwards compat
-implicit def typeMapToSubstitution(values: Map[TypeVar, ValueType]): Substitutions = Substitutions(values, Map.empty[CaptVar, Captures])
-implicit def captMapToSubstitution(captures: Map[CaptVar, Captures]): Substitutions = Substitutions(Map.empty[TypeVar, ValueType], captures)
-

--- a/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
@@ -58,19 +58,17 @@ case class Substitutions(
   }
 
   def substitute(t: ValueType): ValueType = t match {
-    case x: TypeVar =>
-      values.getOrElse(x, x)
+    case ValueTypeRef(x: TypeVar) =>
+      values.getOrElse(x, t)
     case ValueTypeApp(t, args) =>
       ValueTypeApp(t, args.map { substitute })
     case BoxedType(tpe, capt) =>
       BoxedType(substitute(tpe), substitute(capt))
-    case other => other
   }
 
   def substitute(t: Effects): Effects = Effects(t.toList.map(substitute))
   def substitute(t: InterfaceType): InterfaceType = t match {
-    case t: Interface => t
-    case BlockTypeApp(cons, args) => BlockTypeApp(cons, args.map(substitute))
+    case InterfaceType(cons, args) => InterfaceType(cons, args.map(substitute))
   }
 
   def substitute(t: BlockType): BlockType = t match {

--- a/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
@@ -70,7 +70,6 @@ case class Substitutions(
   def substitute(t: Effects): Effects = Effects(t.toList.map(substitute))
   def substitute(t: InterfaceType): InterfaceType = t match {
     case t: Interface => t
-    case t: BuiltinEffect => t
     case BlockTypeApp(cons, args) => BlockTypeApp(cons, args.map(substitute))
   }
 

--- a/effekt/shared/src/main/scala/effekt/typer/TypeComparer.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/TypeComparer.scala
@@ -32,21 +32,20 @@ trait TypeUnifier {
   def unifyValueTypes(tpe1: ValueType, tpe2: ValueType, ctx: ErrorContext): Unit = (tpe1, tpe2, ctx.polarity) match {
     case (t, s, _) if t == s => ()
 
-
     case (_, TTop, Covariant) => ()
     case (TBottom, _, Covariant) => ()
 
     case (TTop, _, Contravariant) => ()
     case (_, TBottom, Contravariant) => ()
 
-    case (s: UnificationVar, t: ValueType, Covariant) => requireUpperBound(s, t, ctx)
-    case (s: ValueType, t: UnificationVar, Covariant) => requireLowerBound(t, s, ctx)
+    case (ValueTypeRef(s: UnificationVar), t: ValueType, Covariant) => requireUpperBound(s, t, ctx)
+    case (s: ValueType, ValueTypeRef(t: UnificationVar), Covariant) => requireLowerBound(t, s, ctx)
 
-    case (s: UnificationVar, t: ValueType, Contravariant) => requireLowerBound(s, t, ctx)
-    case (s: ValueType, t: UnificationVar, Contravariant) => requireUpperBound(t, s, ctx)
+    case (ValueTypeRef(s: UnificationVar), t: ValueType, Contravariant) => requireLowerBound(s, t, ctx)
+    case (s: ValueType, ValueTypeRef(t: UnificationVar), Contravariant) => requireUpperBound(t, s, ctx)
 
-    case (s: UnificationVar, t: ValueType, Invariant) => requireEqual(s, t, ctx)
-    case (s: ValueType, t: UnificationVar, Invariant) => requireEqual(t, s, ctx)
+    case (ValueTypeRef(s: UnificationVar), t: ValueType, Invariant) => requireEqual(s, t, ctx)
+    case (s: ValueType, ValueTypeRef(t: UnificationVar), Invariant) => requireEqual(t, s, ctx)
 
     // For now, we treat all type constructors as invariant.
     case (ValueTypeApp(t1, args1), ValueTypeApp(t2, args2), _) =>
@@ -152,9 +151,9 @@ trait TypeMerger extends TypeUnifier {
 
       // reuses the type unifier implementation (will potentially register new constraints)
       // TODO we need to create a fresh unification variable here!
-      case (x: UnificationVar, tpe: ValueType, p) =>
+      case (x @ ValueTypeRef(_: UnificationVar), tpe: ValueType, p) =>
         unifyValueTypes(x, tpe, ctx); x
-      case (tpe: ValueType, x: UnificationVar, p) =>
+      case (tpe: ValueType, x @ ValueTypeRef(_: UnificationVar), p) =>
         unifyValueTypes(tpe, x, ctx); x
 
       case (ValueTypeApp(cons1, args1), ValueTypeApp(cons2, args2), _) =>

--- a/effekt/shared/src/main/scala/effekt/typer/Unification.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Unification.scala
@@ -200,7 +200,7 @@ class Unification(using C: ErrorReporter) extends TypeUnifier, TypeMerger, TypeI
 
     val typeRigids =
       if (targs.size == tparams.size) targs
-      else tparams map { t => fresh(UnificationVar.TypeVariableInstantiation(t, position)) }
+      else tparams map { t => ValueTypeRef(fresh(UnificationVar.TypeVariableInstantiation(t, position))) }
 
     if (cparams.size != (bparams.size + eff.controlEffects.size)) {
       sys error pp"Capture param count ${cparams.size} is not equal to bparam ${bparams.size} + controleffects ${eff.controlEffects.size}.\n  ${tpe}"
@@ -327,13 +327,12 @@ trait TypeInstantiator { self: Unification =>
 
 
   def instantiate(t: ValueType)(using Instantiation): ValueType = t match {
-    case x: TypeVar =>
-      valueInstantiations.getOrElse(x, x)
+    case ValueTypeRef(x: TypeVar) =>
+      valueInstantiations.getOrElse(x, t)
     case ValueTypeApp(t, args) =>
       ValueTypeApp(t, args.map { instantiate })
     case BoxedType(tpe, capt) =>
       BoxedType(instantiate(tpe), instantiate(capt))
-    case other => other
   }
 
   def instantiate(t: Effects)(using Instantiation): Effects = Effects(t.toList.map(instantiate))
@@ -344,8 +343,7 @@ trait TypeInstantiator { self: Unification =>
   }
 
   def instantiate(t: InterfaceType)(using Instantiation): InterfaceType = t match {
-    case b: Interface           => b
-    case BlockTypeApp(c, targs) => BlockTypeApp(c, targs map instantiate)
+    case InterfaceType(c, targs) => InterfaceType(c, targs map instantiate)
   }
 
   def instantiate(t: FunctionType)(using i: Instantiation): FunctionType = t match {

--- a/effekt/shared/src/main/scala/effekt/typer/Unification.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Unification.scala
@@ -327,7 +327,7 @@ trait TypeInstantiator { self: Unification =>
 
 
   def instantiate(t: ValueType)(using Instantiation): ValueType = t match {
-    case ValueTypeRef(x: TypeVar) =>
+    case ValueTypeRef(x) =>
       valueInstantiations.getOrElse(x, t)
     case ValueTypeApp(t, args) =>
       ValueTypeApp(t, args.map { instantiate })

--- a/effekt/shared/src/main/scala/effekt/typer/Unification.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Unification.scala
@@ -202,8 +202,8 @@ class Unification(using C: ErrorReporter) extends TypeUnifier, TypeMerger, TypeI
       if (targs.size == tparams.size) targs
       else tparams map { t => ValueTypeRef(fresh(UnificationVar.TypeVariableInstantiation(t, position))) }
 
-    if (cparams.size != (bparams.size + eff.controlEffects.size)) {
-      sys error pp"Capture param count ${cparams.size} is not equal to bparam ${bparams.size} + controleffects ${eff.controlEffects.size}.\n  ${tpe}"
+    if (cparams.size != (bparams.size + eff.canonical.size)) {
+      sys error pp"Capture param count ${cparams.size} is not equal to bparam ${bparams.size} + controleffects ${eff.canonical.size}.\n  ${tpe}"
     }
 
     val captRigids =

--- a/effekt/shared/src/main/scala/effekt/typer/Unification.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Unification.scala
@@ -346,7 +346,6 @@ trait TypeInstantiator { self: Unification =>
   def instantiate(t: InterfaceType)(using Instantiation): InterfaceType = t match {
     case b: Interface           => b
     case BlockTypeApp(c, targs) => BlockTypeApp(c, targs map instantiate)
-    case b: BuiltinEffect => b
   }
 
   def instantiate(t: FunctionType)(using i: Instantiation): FunctionType = t match {

--- a/examples/casestudies/ad.md
+++ b/examples/casestudies/ad.md
@@ -107,7 +107,7 @@ def backwards(in: Double) { prog: NumB => NumB / AD[NumB] }: Double = {
   val input = NumB(in, fresh(0.0))
 
   // a helper function to update the derivative of a given number by adding v
-  def push(n: NumB)(v: Double): Unit = n.d.put(n.d.get + v)
+  def push(n: NumB, v: Double): Unit = n.d.put(n.d.get + v)
 
   try { prog(input).push(1.0) } with AD[NumB] {
     def num(v) = resume(NumB(v, fresh(0.0)))

--- a/examples/casestudies/buildsystem.md
+++ b/examples/casestudies/buildsystem.md
@@ -49,7 +49,7 @@ spreadsheet:
 | **2**  | 20 | B1 * 2  |
 
 ```
-def example1(key: Key): Val / { Need, NeedInput, Console } = {
+def example1(key: Key): Val / { Need, NeedInput } = {
     println(key);
     key match {
         case "B1" => do Need("A1") + do Need("A2")

--- a/examples/casestudies/lexer.md
+++ b/examples/casestudies/lexer.md
@@ -76,7 +76,7 @@ def lexerFromList[R](l: List[Token]) { program: => R / Lexer }: R / LexerError =
 ```
 We define a separate handler to report lexer errors to the console:
 ```
-def report { prog: => Unit / LexerError }: Unit / Console =
+def report { prog: => Unit / LexerError }: Unit =
   try { prog() } with LexerError[A] { (msg, pos) =>
     println(pos.line.show ++ ":" ++ pos.col.show ++ " " ++ msg)
   }

--- a/examples/casestudies/naturalisticdsls.md
+++ b/examples/casestudies/naturalisticdsls.md
@@ -101,7 +101,7 @@ type Predicate {
   InLoveWith(p: Person)
   Woman()
 }
-def loves(lover: Person)(loved: Person) = Is(lover, InLoveWith(loved))
+def loves(lover: Person, loved: Person) = Is(lover, InLoveWith(loved))
 ```
 
 We can now construct sentences like
@@ -135,7 +135,7 @@ def said(p: Person) { s: => Sentence / Speaker }: Sentence / {} =
 Here is another definition of `said`, that does _not_ handle the speaker effect, corresponding
 to omitting the quotationmarks:
 ```
-def said(p: Person)(s: Sentence): Sentence =
+def said(p: Person, s: Sentence): Sentence =
   Say(p, s)
 ```
 

--- a/examples/llvm/boolean-algebra-with-literals.effekt
+++ b/examples/llvm/boolean-algebra-with-literals.effekt
@@ -1,7 +1,7 @@
 // Jonathan Frech, 2022-08-08, 2022-08-10
 
 
-def p(b: Boolean): Unit / Console = {
+def p(b: Boolean): Unit = {
   if (b) { println(1) } else { println(0) }
 }
 

--- a/examples/llvm/boolean-algebra.2.effekt
+++ b/examples/llvm/boolean-algebra.2.effekt
@@ -1,7 +1,7 @@
 // Jonathan Frech, 2022-08-17
 
 
-def output(p: Boolean): Unit / Console = {
+def output(p: Boolean): Unit = {
   if (p) { println(1) } else { println(0) }
 }
 

--- a/examples/llvm/boolean-algebra.effekt
+++ b/examples/llvm/boolean-algebra.effekt
@@ -1,7 +1,7 @@
 // Jonathan Frech, 2022-08-08, 2022-08-10
 
 
-def p(b: Boolean): Unit / Console = {
+def p(b: Boolean): Unit = {
   if (b) { println(1) } else { println(0) }
 }
 

--- a/examples/llvm/countdown.effekt
+++ b/examples/llvm/countdown.effekt
@@ -1,5 +1,5 @@
 
-def count(n: Int): Unit / Console = {
+def count(n: Int): Unit = {
   if(n < 0) {
     if(true) {
       println(0)

--- a/examples/llvm/factorial.effekt
+++ b/examples/llvm/factorial.effekt
@@ -1,5 +1,5 @@
 
-def factorial(n: Int): Int / Console = {
+def factorial(n: Int): Int = {
   def go(n: Int, a: Int): Int = {
     if(n < 1) {
       a
@@ -11,4 +11,3 @@ def factorial(n: Int): Int / Console = {
 }
 
 def main() = println(factorial(10))
-

--- a/examples/llvm/strings-refcount.effekt
+++ b/examples/llvm/strings-refcount.effekt
@@ -2,11 +2,11 @@ def g(x: String): String = {
     x
 }
 
-def f(x: String): Unit / Console = {
+def f(x: String): Unit = {
     println(g(x));
 }
 
-def main(): Unit / Console = {
+def main(): Unit = {
     val x = "ycks";
     f(x);
     f(x + x);

--- a/examples/llvm/strings.effekt
+++ b/examples/llvm/strings.effekt
@@ -1,3 +1,3 @@
-def main(): Unit / Console = {
+def main(): Unit = {
     println("left>" + ">right");
 }

--- a/examples/neg/duplicate_operation.effekt
+++ b/examples/neg/duplicate_operation.effekt
@@ -6,7 +6,7 @@ effect State {
     def set(n: Int): Unit
 }
 
-def state[R](init: Int) { f: => R / { State } }: Unit / Console = {
+def state[R](init: Int) { f: => R / { State } }: Unit = {
     var s = init;
     try { f(); () } with State {
         def get() = resume(s)

--- a/examples/neg/effect_not_part.effekt
+++ b/examples/neg/effect_not_part.effekt
@@ -8,7 +8,7 @@ effect State {
     def set(n: Int): Unit
 }
 
-def state[R](init: Int) { f: => R / { State, Exception } }: Unit / Console = {
+def state[R](init: Int) { f: => R / { State, Exception } }: Unit = {
     var s = init;
     try { f(); () } with State {
         def get() = resume(s)

--- a/examples/neg/existential_effect_leaks.effekt
+++ b/examples/neg/existential_effect_leaks.effekt
@@ -5,7 +5,7 @@ module existential_effect_leaks
 effect Flip(): Boolean
 effect GiveInt(): Int
 
-def flipTrue { prog: => Unit / { Flip, GiveInt } } : Unit / Console =
+def flipTrue { prog: => Unit / { Flip, GiveInt } } : Unit =
   try {
     try {
       prog()
@@ -19,7 +19,7 @@ def flipTrue { prog: => Unit / { Flip, GiveInt } } : Unit / Console =
     resume(42)
   }
 
-def main(): Unit / { Console } = {
+def main(): Unit = {
 
   try {
     flipTrue {

--- a/examples/neg/polymorphic_adts.effekt
+++ b/examples/neg/polymorphic_adts.effekt
@@ -12,7 +12,7 @@ type Tuple[A, B] {
 
 effect Raise[A](): A
 
-def f[A, B](a : A, b: B) { block: => A / Console } : A / Console = {
+def f[A, B](a : A, b: B) { block: => A } : A = {
   val b2: B = b;
   block()
 }

--- a/examples/neg/selecting_from_datatype.check
+++ b/examples/neg/selecting_from_datatype.check
@@ -1,3 +1,3 @@
-[error] examples/neg/selecting_from_datatype.effekt:8:29: Expected Bar but got MyList.
+[error] examples/neg/selecting_from_datatype.effekt:8:22: Cannot find type for myHead -- (mutually) recursive functions need to have an annotated return type.
 def foo(l: MyList) = myHead(l)
-                            ^
+                     ^

--- a/examples/neg/toplevel_effects.check
+++ b/examples/neg/toplevel_effects.check
@@ -1,3 +1,3 @@
-[error] examples/neg/toplevel_effects.effekt:4:1: Unhandled effects { Console }
+[error] examples/neg/toplevel_effects.effekt:8:28: Unhandled effect Console
 def pureFun(): Unit / {} = sayHello()
-^
+                           ^

--- a/examples/neg/toplevel_effects.effekt
+++ b/examples/neg/toplevel_effects.effekt
@@ -1,5 +1,9 @@
-def sayHello(): Unit / { Console } =
-  println("Hello World!")
+effect Console {
+  def println(msg: String): Unit
+}
+
+def sayHello(): Unit/ Console =
+  do println("Hello World!")
 
 def pureFun(): Unit / {} = sayHello()
 

--- a/examples/neg/unhandled_under_handler.effekt
+++ b/examples/neg/unhandled_under_handler.effekt
@@ -5,7 +5,7 @@ module unhandled_under_handler
 effect Flip(): Boolean
 effect MyPrint(n: Int): Unit
 
-def main(): Unit / { Console } = {
+def main(): Unit = {
 
   try {
     do MyPrint(4);

--- a/examples/neg/unhandledmain.check
+++ b/examples/neg/unhandledmain.check
@@ -1,3 +1,3 @@
-[error] examples/neg/unhandledmain.effekt:1:1: Main cannot have user defined effects, but includes effects: Flip
+[error] examples/neg/unhandledmain.effekt:1:1: Main cannot have user defined effects, but includes effects: { Flip }
 module unhandledmain
 ^

--- a/examples/pos/bidirectional/pingpong.effekt
+++ b/examples/pos/bidirectional/pingpong.effekt
@@ -3,7 +3,7 @@ module examples/pos/bidirectional/pingpong
 effect Ping(): Unit / { Pong }
 effect Pong(): Unit / { Ping }
 
-def pinger(i: Int, N: Int) : Unit / { Ping, Console } = {
+def pinger(i: Int, N: Int) : Unit / { Ping } = {
   println("enter pinger")
 
   println(i)
@@ -21,7 +21,7 @@ def pinger(i: Int, N: Int) : Unit / { Ping, Console } = {
   }
 }
 
-def ponger(): Unit / { Pong, Console } = {
+def ponger(): Unit / { Pong } = {
   println("enter ponger")
   try {
     do Pong()

--- a/examples/pos/bidirectional/selfrecursion.check
+++ b/examples/pos/bidirectional/selfrecursion.check
@@ -1,3 +1,3 @@
 [error] examples/pos/bidirectional/selfrecursion.effekt:3:1: Bidirectional effects that mention the same effect recursively are not (yet) supported.
 effect Loop(): Unit / Loop
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^

--- a/examples/pos/bug1.effekt
+++ b/examples/pos/bug1.effekt
@@ -9,7 +9,7 @@ def flipTrue { prog: => Unit / Flip }: Unit =
     resume(true); resume(false)
   }
 
-def main(): Unit / { Console} = {
+def main(): Unit = {
 
   try {
 

--- a/examples/pos/build.effekt
+++ b/examples/pos/build.effekt
@@ -51,7 +51,7 @@ def supplyInput[R](store: Store) { prog: => R / { NeedInput } } = {
 //  |  A | B
 // 1| 10 | A1 + A2
 // 2| 20 | B1 * 2
-def example1(key: Key): Val / { Need, NeedInput, Console } = {
+def example1(key: Key): Val / { Need, NeedInput } = {
     println(key);
     key match {
         case "B1" => do Need("A1") + do Need("A2")

--- a/examples/pos/capture/optimizing_unbox.check
+++ b/examples/pos/capture/optimizing_unbox.check
@@ -1,3 +1,3 @@
-[warning] examples/pos/capture/optimizing_unbox.effekt:3:14: Handling effects that are not used: Yield
+[warning] examples/pos/capture/optimizing_unbox.effekt:3:14: Handling effects that are not used: { Yield }
 def main() = try {
              ^

--- a/examples/pos/capture/regions.check
+++ b/examples/pos/capture/regions.check
@@ -10,6 +10,6 @@ before
 after
 after
 after
-[warning] examples/pos/capture/regions.effekt:12:3: Handling effects that are not used: Dummy
+[warning] examples/pos/capture/regions.effekt:12:3: Handling effects that are not used: { Dummy }
   try { prog() } with Dummy { resume(()) }
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/pos/defdef.check
+++ b/examples/pos/defdef.check
@@ -1,4 +1,4 @@
 hello
-[warning] examples/pos/defdef.effekt:10:14: Handling effects that are not used: Test
+[warning] examples/pos/defdef.effekt:10:14: Handling effects that are not used: { Test }
 def main() = try {
              ^

--- a/examples/pos/effectalias.effekt
+++ b/examples/pos/effectalias.effekt
@@ -2,6 +2,8 @@ module effectalias
 
 effect Pure = {}
 
+interface Console {}
+
 effect Foo = Console
 
 effect Bar = { Foo, Foo }
@@ -14,6 +16,6 @@ def bar(): Unit / { Foo, Bar, Pure } = {
   println("hello")
 }
 
-def main(): Unit / Foo = {
+def main(): Unit = try {
   foo()
-}
+} with Console {}

--- a/examples/pos/localdefs.effekt
+++ b/examples/pos/localdefs.effekt
@@ -1,11 +1,11 @@
 module localdefs
 
 def main1(): Unit = {
-    def foo(): Unit / Console = { println(42) }
+    def foo(): Unit = { println(42) }
     ()
 }
 
-def main(): Unit / Console = {
+def main(): Unit = {
     def foo(): Unit = println(42)
     foo()
 }

--- a/examples/pos/multieffects.effekt
+++ b/examples/pos/multieffects.effekt
@@ -20,7 +20,7 @@ effect State {
     def set(n: Int): Unit
 }
 
-def state[R](init: Int) { f: => R / { State, Exception } }: Unit / Console = {
+def state[R](init: Int) { f: => R / { State, Exception } }: Unit = {
     var s = init;
     try { f(); () } with State {
         def get() = resume(s)

--- a/examples/pos/polymorphic/exceptions.effekt
+++ b/examples/pos/polymorphic/exceptions.effekt
@@ -13,7 +13,7 @@ def saveDiv(x: Int, y: Int): Int / Exception[DivByZero] =
     x / y
   }
 
-def report[E] { prog: => Unit / Exception[E] }: Unit / { Console } =
+def report[E] { prog: => Unit / Exception[E] }: Unit =
   try { prog() } with Exception[E] {
     def raise[A](e) = println(e.show)
   }

--- a/examples/pos/probabilistic.effekt
+++ b/examples/pos/probabilistic.effekt
@@ -154,7 +154,7 @@ def heapTest() = heap {
   println(show(do get(r1)) ++ show(do get(r2)) ++ show(do get(r3)))
 }
 
-def catch[R] { p: => R / IndexOutOfBounds }: Unit / Console =
+def catch[R] { p: => R / IndexOutOfBounds }: Unit =
   try { p(); () }
   with IndexOutOfBounds[A] { () => println("Index out of bounds!") }
 

--- a/examples/pos/propagators.effekt
+++ b/examples/pos/propagators.effekt
@@ -20,7 +20,7 @@ effect Net {
   def unknown[R](): Cell[R]
   def make[R](value: R): Cell[R]
 
-  def learn[A](cell: Cell[A])(value: A): Unit
+  def learn[A](cell: Cell[A], value: A): Unit
 
   // this really needs to be Cell[A] and { A => Unit / Net } since
   // the updater needs to be run "in parallel". In particular it should
@@ -38,7 +38,7 @@ def watch[A](cell: Cell[A]) { f: A => Unit }: Unit / { Net, Console } =
 
 // establishes a connection between cellA and cellB
 // will run f once the value of cellA is available to update cellB
-def connect[A, B](cellA: Cell[A])(cellB: Cell[B]) { f: A => B }: Unit / { Net, Console } =
+def connect[A, B](cellA: Cell[A], cellB: Cell[B]) { f: A => B }: Unit / { Net, Console } =
   cellA.watch { a  => do learn(cellB, f(a)) }
 
 def connect[A, B, C](cellA: Cell[A], cellB: Cell[B], cellC: Cell[C]) { f: (A, B) => C }: Unit / { Net, Console } = {
@@ -46,13 +46,13 @@ def connect[A, B, C](cellA: Cell[A], cellB: Cell[B], cellC: Cell[C]) { f: (A, B)
   cellB.watch { b => do subscribe(cellA).foreach { a => do learn(cellC, f(a, b)) } }
 }
 
-def sumOf(res: Cell[Int])(arg1: Cell[Int], arg2: Cell[Int]) = {
+def sumOf(res: Cell[Int], arg1: Cell[Int], arg2: Cell[Int]) = {
   connect(arg1, arg2, res) { (a, b) => a + b }
   connect(res, arg2, arg1) { (a, b) => a - b }
   connect(res, arg1, arg2) { (a, b) => a - b }
 }
 
-def negated(that: Cell[Int])(inverse: Cell[Int]) = {
+def negated(that: Cell[Int], inverse: Cell[Int]) = {
   that.connect(inverse) { x => (0 - x) }
   inverse.connect(that) { x => (0 - x) }
 }
@@ -103,7 +103,7 @@ def propagators { net: => Unit / Net }: Unit / Console = {
       resume(fresh((None(), Nil())))
     def make[R](value) =
       resume(fresh((Some(value), Nil())))
-    def learn[A](cell)(value) = (cell.get) match {
+    def learn[A](cell, value) = (cell.get) match {
       case (None(), k) =>
         // update network with new information
         cell.put((Some(value), Nil()));

--- a/examples/pos/propagators.effekt
+++ b/examples/pos/propagators.effekt
@@ -31,17 +31,17 @@ effect Net {
   def abort(): Unit
 }
 
-def watch[A](cell: Cell[A]) { f: A => Unit }: Unit / { Net, Console } =
+def watch[A](cell: Cell[A]) { f: A => Unit }: Unit / { Net } =
   do subscribe(cell).foreach { a =>
     println("received a " ++ a.show);
     f(a); do abort() } // this abort seems to abort also other subscribers?
 
 // establishes a connection between cellA and cellB
 // will run f once the value of cellA is available to update cellB
-def connect[A, B](cellA: Cell[A], cellB: Cell[B]) { f: A => B }: Unit / { Net, Console } =
+def connect[A, B](cellA: Cell[A], cellB: Cell[B]) { f: A => B }: Unit / { Net } =
   cellA.watch { a  => do learn(cellB, f(a)) }
 
-def connect[A, B, C](cellA: Cell[A], cellB: Cell[B], cellC: Cell[C]) { f: (A, B) => C }: Unit / { Net, Console } = {
+def connect[A, B, C](cellA: Cell[A], cellB: Cell[B], cellC: Cell[C]) { f: (A, B) => C }: Unit / { Net } = {
   cellA.watch { a => do subscribe(cellB).foreach { b => do learn(cellC, f(a, b)) } }
   cellB.watch { b => do subscribe(cellA).foreach { a => do learn(cellC, f(a, b)) } }
 }
@@ -78,7 +78,7 @@ def example() = {
 }
 
 // cells must not leave the propagator!
-def propagators { net: => Unit / Net }: Unit / Console = {
+def propagators { net: => Unit / Net }: Unit = {
 
   val noop = cont[Unit, Unit] { _ => () }
 

--- a/examples/pos/raytracer.effekt
+++ b/examples/pos/raytracer.effekt
@@ -23,7 +23,7 @@ def dot(a: Vector, b: Vector): Double =
 def cross(a: Vector, b: Vector): Vector =
   Vector((a.y * b.z) - (a.z * b.y), (a.z * b.x) - (a.x * b.z), (a.x * b.y) - (a.y * b.x))
 
-def scale(a: Vector)(t: Double): Vector =
+def scale(a: Vector, t: Double): Vector =
   Vector(a.x * t, a.y * t, a.z * t)
 
 def add(a: Vector, b: Vector): Vector =
@@ -140,7 +140,7 @@ def render(scene: Scene, image: Buffer) = {
     trace(pos, dir, scene, 0).toColor
   }
 
-  def storeAt(color: Color)(x: Int, y: Int): Unit = {
+  def storeAt(color: Color, x: Int, y: Int): Unit = {
     val opaque = 255;
     val index = x * 4 + y * width * 4;
     image.put(index + 0, color.red);

--- a/examples/pos/simpleparser.effekt
+++ b/examples/pos/simpleparser.effekt
@@ -18,7 +18,7 @@ def handledExample() = try { perhapsAdd() } with Fail[A] { (msg) => println(msg)
 
 effect Next(): String
 
-def print3(): Unit / { Next, Console} = {
+def print3(): Unit / { Next } = {
   println(do Next());
   println(do Next());
   println(do Next())

--- a/examples/pos/state.check
+++ b/examples/pos/state.check
@@ -14,6 +14,6 @@
 3
 2
 1
-[warning] examples/pos/state.effekt:21:5: Handling effects that are not used: Yield
+[warning] examples/pos/state.effekt:21:5: Handling effects that are not used: { Yield }
     try { x = y } with Yield { def yield() = resume(()) }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/pos/unused_effects.check
+++ b/examples/pos/unused_effects.check
@@ -1,3 +1,3 @@
-[warning] examples/pos/unused_effects.effekt:5:14: Handling effects that are not used: Fail
+[warning] examples/pos/unused_effects.effekt:5:14: Handling effects that are not used: { Fail }
 def main() = try {
              ^

--- a/examples/pos/withstatement.effekt
+++ b/examples/pos/withstatement.effekt
@@ -4,14 +4,14 @@ import immutable/list
 
 effect Exc[A](msg: String): A
 
-def printer { p: => Unit / Exc }: Unit / Console = try { p() } with Exc[A] { (msg) =>
+def printer { p: => Unit / Exc }: Unit = try { p() } with Exc[A] { (msg) =>
   println(msg)
 }
 
 def bar { f: (Int, String) => Unit / {}}: Unit =
   f(4, "string")
 
-def user(): Unit / Console = {
+def user(): Unit = {
     with printer;
     with x: Int = foreach([1,2,3]);
     with (a, b) = bar;

--- a/libraries/chez/callcc/effekt.effekt
+++ b/libraries/chez/callcc/effekt.effekt
@@ -1,7 +1,5 @@
 module effekt
 
-extern effect Console
-
 // shift-0 based implementation
 extern include "../common/effekt_primitives.ss"
 // extern include "datatype.ss"
@@ -22,7 +20,7 @@ extern pure def infixConcat(s1: String, s2: String): String =
 extern pure def show[R](value: R): String =
   "(show_impl value)"
 
-extern io def println[R](r: R): Unit / Console =
+extern io def println[R](r: R): Unit =
   "(println_impl r)"
 
 extern io def error[R](msg: String): R =
@@ -173,7 +171,7 @@ def panicOn[E] { prog: => Unit / Exception[E] }: Unit =
   try { prog() } with Exception[E] { def raise[A](exception, msg) = panic(msg) }
 
 // reports exceptions of (static) type E to the console
-def report[E] { prog: => Unit / Exception[E] }: Unit / Console =
+def report[E] { prog: => Unit / Exception[E] }: Unit =
   try { prog() } with Exception[E] { def raise[A](exception, msg) = println(msg) }
 
 // ignores exceptions of (static) type E
@@ -185,5 +183,5 @@ def ignoring[E] { prog: => Unit / Exception[E] }: Unit =
 // Benchmarking
 // ============
 // should only be used with pure blocks
-extern control def measure(warmup: Int, iterations: Int) { block: => Unit }: Unit / Console =
+extern control def measure(warmup: Int, iterations: Int) { block: => Unit }: Unit =
   "(display (measure block warmup iterations))"

--- a/libraries/chez/common/immutable/dequeue.effekt
+++ b/libraries/chez/common/immutable/dequeue.effekt
@@ -51,7 +51,7 @@ def check[R](dq: Dequeue[R]): Dequeue[R] = dq match {
         }
 }
 
-def pushFront[R](dq: Dequeue[R])(el: R): Dequeue[R] = dq match {
+def pushFront[R](dq: Dequeue[R], el: R): Dequeue[R] = dq match {
     case Dequeue(f, fs, r, rs) => Dequeue(Cons(el, f), fs + 1, r, rs).check
 }
 
@@ -64,7 +64,7 @@ def popFront[R](dq: Dequeue[R]): Option[(R, Dequeue[R])] = dq match {
         Some((x, Dequeue(rest, fs - 1, r, rs).check))
 }
 
-def pushBack[R](dq: Dequeue[R])(el: R): Dequeue[R] = dq match {
+def pushBack[R](dq: Dequeue[R], el: R): Dequeue[R] = dq match {
     case Dequeue(f, fs, r, rs) => Dequeue(f, fs, Cons(el, r), rs + 1).check
 }
 

--- a/libraries/chez/common/immutable/list.effekt
+++ b/libraries/chez/common/immutable/list.effekt
@@ -28,7 +28,7 @@ def size[A](l: List[A]): Int = l match {
 }
 
 def reverse[A](l: List[A]): List[A] = {
-  def reverseWith(l: List[A])(acc: List[A]): List[A] = l match {
+  def reverseWith(l: List[A], acc: List[A]): List[A] = l match {
     case Nil() => acc
     case Cons(a, rest) => rest.reverseWith(Cons(a, acc))
   }
@@ -37,7 +37,7 @@ def reverse[A](l: List[A]): List[A] = {
 
 // [1,2,3].reverseOnto([4,5,6])
 // [3,2,1,4,5,6]
-def reverseOnto[A](l: List[A])(other: List[A]): List[A] = l match {
+def reverseOnto[A](l: List[A], other: List[A]): List[A] = l match {
   case Nil() => other
   case Cons(a, rest) => rest.reverseOnto(Cons(a, other))
 }
@@ -45,11 +45,11 @@ def reverseOnto[A](l: List[A])(other: List[A]): List[A] = l match {
 // [1,2,3].append([4,5,6])
 // [3,2,1].reverseOnto([4,5,6])
 // [1,2,3,4,5,6]
-def append[A](l: List[A])(other: List[A]): List[A] =
+def append[A](l: List[A], other: List[A]): List[A] =
   l.reverse.reverseOnto(other)
 
 // gracefully fails
-def take[A](l: List[A])(n: Int): List[A] =
+def take[A](l: List[A], n: Int): List[A] =
   if (n == 0) {
     Nil()
   } else l match {
@@ -57,7 +57,7 @@ def take[A](l: List[A])(n: Int): List[A] =
     case Cons(a, rest) => Cons(a, rest.take(n - 1))
   }
 
-def drop[A](l: List[A])(n: Int): List[A] =
+def drop[A](l: List[A], n: Int): List[A] =
   if (n == 0) {
     l
   } else l match {

--- a/libraries/chez/common/mutable/array.effekt
+++ b/libraries/chez/common/mutable/array.effekt
@@ -9,18 +9,18 @@ extern type Array[T]
 extern pure def emptyArray[T](size: Int): Array[T] =
   "(make-vector size)"
 
-def get[T](arr: Array[T])(index: Int): Option[T] =
+def get[T](arr: Array[T], index: Int): Option[T] =
   if (index >= arr.size) None() else Some(arr.unsafeGet(index))
 
 extern pure def size[T](arr: Array[T]): Int =
   "(vector-length arr)"
 
 // raises a scheme exception if out of bounds
-extern pure def unsafeGet[T](arr: Array[T])(index: Int): T =
+extern pure def unsafeGet[T](arr: Array[T], index: Int): T =
   "(vector-ref arr index)"
 
 // TODO raises a scheme exception if out of bounds
-extern pure def put[T](arr: Array[T])(index: Int, value: T): Unit =
+extern pure def put[T](arr: Array[T], index: Int, value: T): Unit =
   "(begin (vector-set! arr index value) #f)"
 
 extern pure def toArray[A](l: CSList[A]): Array[A] =

--- a/libraries/chez/common/mutable/dict.effekt
+++ b/libraries/chez/common/mutable/dict.effekt
@@ -11,7 +11,7 @@ extern io def emptyDict[K, V](): Dict[K, V] =
 extern io def emptyWeakDict[K, V](): Dict[K, V] =
     "(make-hash-table #t)"
 
-extern io def put[K, V](d: Dict[K, V])(key: K, value: V): Unit =
+extern io def put[K, V](d: Dict[K, V], key: K, value: V): Unit =
     "(put-hash-table! d key value)"
 
 extern io def get[K, V](d: Dict[K, V], key: K, default: V): V =
@@ -20,11 +20,11 @@ extern io def get[K, V](d: Dict[K, V], key: K, default: V): V =
 extern io def unsafeGet[K, V](d: Dict[K, V], key: K): V =
     "(hashtable-ref d key #f)"
 
-extern io def contains[K, V](d: Dict[K, V])(key: K): Boolean =
+extern io def contains[K, V](d: Dict[K, V], key: K): Boolean =
     "(hashtable-contains? d key)"
 
-extern io def remove[K, V](d: Dict[K, V])(key: K): Unit =
+extern io def remove[K, V](d: Dict[K, V], key: K): Unit =
     "(remove-hash-table! d key)"
 
-def get[K, V](d: Dict[K, V])(key: K): Option[V] =
+def get[K, V](d: Dict[K, V], key: K): Option[V] =
     undefinedToOption(unsafeGet(d, key))

--- a/libraries/chez/common/mutable/heap.effekt
+++ b/libraries/chez/common/mutable/heap.effekt
@@ -5,7 +5,7 @@ extern type Ref[T]
 extern io def fresh[T](init: T): Ref[T] =
     "(box init)"
 
-extern io def put[T](ref: Ref[T])(value: T): Unit =
+extern io def put[T](ref: Ref[T], value: T): Unit =
     "(set-box! ref value)"
 
 extern io def get[T](ref: Ref[T]): T =

--- a/libraries/chez/common/text/regex.effekt
+++ b/libraries/chez/common/text/regex.effekt
@@ -13,21 +13,21 @@ record Match(matched: String, index: Int)
 extern pure def regex(str: String): Regex =
   "(pregexp str)"
 
-def exec(reg: Regex)(str: String): Option[Match] = {
+def exec(reg: Regex, str: String): Option[Match] = {
   val matched = reg.unsafeMatchString(str)
   if (matched.isUndefined) { None() }
   else { Some(Match(matched, reg.unsafeMatchIndex(str))) }
 }
 
-extern pure def unsafeMatchIndex(reg: Regex)(str: String): Int =
+extern pure def unsafeMatchIndex(reg: Regex, str: String): Int =
   "(let ([m (pregexp-match-positions reg str)]) (if m (car (car m)) #f))"
 
 // we ignore the captures for now and only return the whole match
-extern pure def unsafeMatchString(reg: Regex)(str: String): String =
+extern pure def unsafeMatchString(reg: Regex, str: String): String =
   "(let ([m (pregexp-match reg str)]) (if m (car m) #f))"
 
-extern pure def split(reg: Regex)(str: String): CSList[String] =
+extern pure def split(reg: Regex, str: String): CSList[String] =
   "(pregexp-split reg str)"
 
-def split(str: String)(sep: String): Array[String] =
+def split(str: String, sep: String): Array[String] =
   sep.regex.split(str).toArray

--- a/libraries/chez/common/text/string.effekt
+++ b/libraries/chez/common/text/string.effekt
@@ -2,16 +2,16 @@ module text/string
 
 import immutable/option
 
-// def charAt(str: String)(index: Int): Option[String] =
+// def charAt(str: String, index: Int): Option[String] =
 //     str.unsafeCharAt(index).undefinedToOption
 
 extern pure def length(str: String): Int =
   "(string-length str)"
 
-extern pure def repeat(str: String)(n: Int): String =
+extern pure def repeat(str: String, n: Int): String =
   "(letrec ([repeat (lambda (n acc) (if (<= n 0) acc (repeat (- n 1) (string-append acc str))))]) (repeat n (list->string '())))"
 
-extern pure def substring(str: String)(from: Int): String =
+extern pure def substring(str: String, from: Int): String =
   "(substring str from (string-length str))"
 
 // extern pure def trim(str: String): String =
@@ -20,7 +20,7 @@ extern pure def substring(str: String)(from: Int): String =
 def toInt(str: String): Option[Int] =
   str.unsafeToInt.undefinedToOption
 
-// extern pure def unsafeCharAt(str: String)(n: Int): String =
+// extern pure def unsafeCharAt(str: String, n: Int): String =
 //   "str[n]"
 
 // returns #f if not a number

--- a/libraries/chez/lift/effekt.effekt
+++ b/libraries/chez/lift/effekt.effekt
@@ -1,7 +1,5 @@
 module effekt
 
-extern effect Console
-
 extern include "../common/effekt_primitives.ss"
 extern include "effekt.ss"
 extern include "../common/effekt_matching.ss"
@@ -18,7 +16,7 @@ extern pure def infixConcat(s1: String, s2: String): String =
 extern pure def show[R](value: R): String =
   "(show_impl value)"
 
-extern io def println[R](r: R): Unit / Console =
+extern io def println[R](r: R): Unit =
   "(println_impl r)"
 
 extern io def error[R](msg: String): R =
@@ -169,7 +167,7 @@ def panicOn[E] { prog: => Unit / Exception[E] }: Unit =
   try { prog() } with Exception[E] { def raise[A](exception, msg) = panic(msg) }
 
 // reports exceptions of (static) type E to the console
-def report[E] { prog: => Unit / Exception[E] }: Unit / Console =
+def report[E] { prog: => Unit / Exception[E] }: Unit =
   try { prog() } with Exception[E] { def raise[A](exception, msg) = println(msg) }
 
 // ignores exceptions of (static) type E
@@ -181,5 +179,5 @@ def ignoring[E] { prog: => Unit / Exception[E] }: Unit =
 // Benchmarking
 // ============
 // should only be used with pure blocks
-extern control def measure(warmup: Int, iterations: Int) { block: => Unit }: Unit / Console =
+extern control def measure(warmup: Int, iterations: Int) { block: => Unit }: Unit =
   "(delayed (display (measure (lambda () (run ((block here)))) warmup iterations)))"

--- a/libraries/chez/monadic/effekt.effekt
+++ b/libraries/chez/monadic/effekt.effekt
@@ -1,7 +1,5 @@
 module effekt
 
-extern effect Console
-
 extern include "../common/effekt_primitives.ss"
 extern include "seq0.ss"
 extern include "effekt.ss"
@@ -19,7 +17,7 @@ extern pure def infixConcat(s1: String, s2: String): String =
 extern pure def show[R](value: R): String =
   "(show_impl value)"
 
-extern io def println[R](r: R): Unit / Console =
+extern io def println[R](r: R): Unit =
   "(println_impl r)"
 
 extern io def error[R](msg: String): R =
@@ -170,7 +168,7 @@ def panicOn[E] { prog: => Unit / Exception[E] }: Unit =
   try { prog() } with Exception[E] { def raise[A](exception, msg) = panic(msg) }
 
 // reports exceptions of (static) type E to the console
-def report[E] { prog: => Unit / Exception[E] }: Unit / Console =
+def report[E] { prog: => Unit / Exception[E] }: Unit =
   try { prog() } with Exception[E] { def raise[A](exception, msg) = println(msg) }
 
 // ignores exceptions of (static) type E
@@ -182,5 +180,5 @@ def ignoring[E] { prog: => Unit / Exception[E] }: Unit =
 // Benchmarking
 // ============
 // should only be used with pure blocks
-extern control def measure(warmup: Int, iterations: Int) { block: => Unit }: Unit / Console =
+extern control def measure(warmup: Int, iterations: Int) { block: => Unit }: Unit =
   "(delayed (display (measure (lambda () (run (block))) warmup iterations)))"

--- a/libraries/js/lift/effekt.effekt
+++ b/libraries/js/lift/effekt.effekt
@@ -1,7 +1,5 @@
 module effekt
 
-extern effect Console
-
 // Runtime
 extern include "effekt_runtime.js"
 
@@ -15,7 +13,7 @@ def locally[R] { f: R }: R = f()
 
 // Side effecting ops
 // ==================
-extern def println[R](value: R): Unit / Console =
+extern def println[R](value: R): Unit =
   "println$impl(value)"
 
 extern def inspect[R](value: R): Unit =
@@ -126,7 +124,7 @@ def timed { block: Unit }: Int = {
   after - before
 }
 
-def measure(warmup: Int, iterations: Int) { block: Unit }: Unit / Console = {
+def measure(warmup: Int, iterations: Int) { block: Unit }: Unit = {
   def run(n: Int, report: Boolean): Unit = {
     if (n <= 0) { () } else {
       val time = timed { block() };

--- a/libraries/js/monadic/effekt.effekt
+++ b/libraries/js/monadic/effekt.effekt
@@ -1,7 +1,5 @@
 module effekt
 
-extern effect Console
-
 // Runtime
 extern include "effekt_runtime.js"
 
@@ -206,7 +204,7 @@ def panicOn[E] { prog: => Unit / Exception[E] }: Unit =
   try { prog() } with Exception[E] { def raise[A](exception: E, msg: String) = panic(msg) }
 
 // reports exceptions of (static) type E to the console
-def report[E] { prog: => Unit / Exception[E] }: Unit / Console =
+def report[E] { prog: => Unit / Exception[E] }: Unit =
   try { prog() } with Exception[E] { def raise[A](exception: E, msg: String) = println(msg) }
 
 // ignores exceptions of (static) type E
@@ -247,7 +245,7 @@ def timed { block: => Unit }: Int = {
   after - before
 }
 
-def measure(warmup: Int, iterations: Int) { block: => Unit }: Unit / Console = {
+def measure(warmup: Int, iterations: Int) { block: => Unit }: Unit = {
   def run(n: Int, report: Boolean): Unit = {
     if (n <= 0) { () } else {
       val time = timed { block() };

--- a/libraries/js/monadic/immutable/dequeue.effekt
+++ b/libraries/js/monadic/immutable/dequeue.effekt
@@ -51,7 +51,7 @@ def check[R](dq: Dequeue[R]): Dequeue[R] = dq match {
         }
 }
 
-def pushFront[R](dq: Dequeue[R])(el: R): Dequeue[R] = dq match {
+def pushFront[R](dq: Dequeue[R], el: R): Dequeue[R] = dq match {
     case Dequeue(f, fs, r, rs) => Dequeue(Cons(el, f), fs + 1, r, rs).check
 }
 
@@ -64,7 +64,7 @@ def popFront[R](dq: Dequeue[R]): Option[(R, Dequeue[R])] = dq match {
         Some((x, Dequeue(rest, fs - 1, r, rs).check))
 }
 
-def pushBack[R](dq: Dequeue[R])(el: R): Dequeue[R] = dq match {
+def pushBack[R](dq: Dequeue[R], el: R): Dequeue[R] = dq match {
     case Dequeue(f, fs, r, rs) => Dequeue(f, fs, Cons(el, r), rs + 1).check
 }
 

--- a/libraries/js/monadic/immutable/list.effekt
+++ b/libraries/js/monadic/immutable/list.effekt
@@ -40,7 +40,7 @@ def reverse[A](l: List[A]): List[A] = {
 
 // [1,2,3].reverseOnto([4,5,6])
 // [3,2,1,4,5,6]
-def reverseOnto[A](l: List[A])(other: List[A]): List[A] = l match {
+def reverseOnto[A](l: List[A], other: List[A]): List[A] = l match {
   case Nil() => other
   case Cons(a, rest) => rest.reverseOnto(Cons(a, other))
 }
@@ -48,11 +48,11 @@ def reverseOnto[A](l: List[A])(other: List[A]): List[A] = l match {
 // [1,2,3].append([4,5,6])
 // [3,2,1].reverseOnto([4,5,6])
 // [1,2,3,4,5,6]
-def append[A](l: List[A])(other: List[A]): List[A] =
+def append[A](l: List[A], other: List[A]): List[A] =
   l.reverse.reverseOnto(other)
 
 // gracefully fails
-def take[A](l: List[A])(n: Int): List[A] =
+def take[A](l: List[A], n: Int): List[A] =
   if (n == 0) {
     Nil()
   } else l match {
@@ -60,7 +60,7 @@ def take[A](l: List[A])(n: Int): List[A] =
     case Cons(a, rest) => Cons(a, rest.take(n - 1))
   }
 
-def drop[A](l: List[A])(n: Int): List[A] =
+def drop[A](l: List[A], n: Int): List[A] =
   if (n == 0) {
     l
   } else l match {

--- a/libraries/js/monadic/io/file.effekt
+++ b/libraries/js/monadic/io/file.effekt
@@ -1,7 +1,5 @@
 module io/file
 
-extern effect FileIO
-
 effect IOException[A](msg: String): A
 
 extern include "file_include.js"
@@ -17,23 +15,33 @@ type Result[A] {
 
 extern type Promise[T]
 
-extern def readPromise(path: String): Promise[String] / FileIO =
+extern io def readPromise(path: String): Promise[String] =
   "$effekt.delayed(() => fsPromises.readFile(path, 'utf8'))"
 
-extern def await[T](p: Promise[T]): T / { FileIO, IOException } =
+def await[T](p: Promise[T]): T / { IOException } =
+  try { awaitImpl(p){exc} } with exc : IOException[A] {
+    msg => do IOException(msg)
+  }
+
+extern io def awaitImpl[T](p: Promise[T]){exc: IOException}: T =
   "$effekt.callcc(k => p.then(res => k($effekt.pure(res)), err => k(IOException(err.message)))).then(c => c)"
 
-extern def open(path: String, mode: String): FileDescriptor / { FileIO, IOException } =
+def open(path: String, mode: String): FileDescriptor / { IOException } =
+  try { openImpl(path, mode){exc} } with exc : IOException[A] {
+    msg => do IOException(msg)
+  }
+
+extern io def openImpl(path: String, mode: String){exc: IOException}: FileDescriptor =
   "$effekt.delayed(() => { try { return $effekt.pure(fs.openSync(path, mode)); } catch (err) { return IOException(err.message); }}).then(c => c)"
 
-extern def close(fd: FileDescriptor): Unit / { FileIO } =
+extern io def close(fd: FileDescriptor): Unit =
   "$effekt.delayed(() => fs.closeSync(fd))"
 
 // uses the asynchronous API of node
-extern def readFile(path: String): Result[String] / FileIO =
+extern io def readFile(path: String): Result[String] =
   "$effekt.callcc(k => fs.readFile(path, 'utf8', (err, data) => k(err ? Error(err.message) : Success(data))))"
 
-def read(path: String): String / { FileIO, IOException } =
+def read(path: String): String / { IOException } =
   getResult(readFile(path))
 
 def getResult[R](r: Result[R]): R / { IOException } = r match {

--- a/libraries/js/monadic/mutable/array.effekt
+++ b/libraries/js/monadic/mutable/array.effekt
@@ -10,16 +10,16 @@ def emptyArray[T](): Array[T] = emptyArray(0)
 extern pure def emptyArray[T](initialSize: Int): Array[T] =
   "(new Array(initialSize))"
 
-def get[T](arr: Array[T])(index: Int): Option[T] =
+def get[T](arr: Array[T], index: Int): Option[T] =
     arr.unsafeGet(index).undefinedToOption
 
 extern pure def size[T](arr: Array[T]): Int =
     "arr.length"
 
-extern pure def unsafeGet[T](arr: Array[T])(index: Int): T =
+extern pure def unsafeGet[T](arr: Array[T], index: Int): T =
     "arr[index]"
 
-extern io def put[T](arr: Array[T])(index: Int, value: T): Unit =
+extern io def put[T](arr: Array[T], index: Int, value: T): Unit =
     "(function() { arr[index] = value; return $effekt.unit })()"
 
 extern pure def copy[T](arr: Array[T]): Array[T] =

--- a/libraries/js/monadic/mutable/heap.effekt
+++ b/libraries/js/monadic/mutable/heap.effekt
@@ -7,7 +7,7 @@ extern type Ref[T]
 extern def fresh[T](init: T): Ref[T] =
     "fresh$impl(init)"
 
-extern def put[T](ref: Ref[T])(value: T): Unit =
+extern def put[T](ref: Ref[T], value: T): Unit =
     "put$impl(ref, value)"
 
 extern def get[T](ref: Ref[T]): T =

--- a/libraries/js/monadic/mutable/map.effekt
+++ b/libraries/js/monadic/mutable/map.effekt
@@ -8,11 +8,11 @@ extern type Map[K, V]
 extern pure def emptyMap[K, V](): Map[K, V] =
     "new Map()"
 
-def get[K, V](m: Map[K, V])(key: K): Option[V] =
+def get[K, V](m: Map[K, V], key: K): Option[V] =
     m.unsafeGet(key).undefinedToOption
 
-extern pure def unsafeGet[K, V](m: Map[K, V])(key: K): V =
+extern pure def unsafeGet[K, V](m: Map[K, V], key: K): V =
     "m.get(key)"
 
-extern io def update[K, V](m: Map[K, V])(key: K, value: V): Unit =
+extern io def update[K, V](m: Map[K, V], key: K, value: V): Unit =
     "(function() { m.set(key, value); return $effekt.unit })()"

--- a/libraries/js/monadic/text/regex.effekt
+++ b/libraries/js/monadic/text/regex.effekt
@@ -10,9 +10,9 @@ record Match(matched: String, index: Int)
 extern pure def regex(str: String): Regex =
   "new RegExp(str)"
 
-def exec(reg: Regex)(str: String): Option[Match] =
+def exec(reg: Regex, str: String): Option[Match] =
   reg.unsafeExec(str).undefinedToOption
 
 // internals
-extern pure def unsafeExec(reg: Regex)(str: String): Match =
+extern pure def unsafeExec(reg: Regex, str: String): Match =
   "(function () { var res = reg.exec(str); if (res === null) { return undefined } else { return Match(res[0], res.index) }})()"

--- a/libraries/js/monadic/text/string.effekt
+++ b/libraries/js/monadic/text/string.effekt
@@ -3,19 +3,19 @@ module text/string
 import immutable/option
 import mutable/array
 
-def charAt(str: String)(index: Int): Option[String] =
+def charAt(str: String, index: Int): Option[String] =
     str.unsafeCharAt(index).undefinedToOption
 
 extern pure def length(str: String): Int =
   "str.length"
 
-extern pure def repeat(str: String)(n: Int): String =
+extern pure def repeat(str: String, n: Int): String =
   "str.repeat(n)"
 
-extern pure def substring(str: String)(from: Int): String =
+extern pure def substring(str: String, from: Int): String =
   "str.substring(from)"
 
-extern pure def split(str: String)(sep: String): Array[String] =
+extern pure def split(str: String, sep: String): Array[String] =
   "str.split(sep)"
 
 extern pure def trim(str: String): String =
@@ -24,7 +24,7 @@ extern pure def trim(str: String): String =
 def toInt(str: String): Option[Int] =
   str.unsafeToInt.undefinedToOption
 
-extern pure def unsafeCharAt(str: String)(n: Int): String =
+extern pure def unsafeCharAt(str: String, n: Int): String =
   "str[n]"
 
 extern pure def unsafeToInt(str: String): Int =

--- a/libraries/js/monadic/unsafe/cont.effekt
+++ b/libraries/js/monadic/unsafe/cont.effekt
@@ -8,4 +8,4 @@ extern io def cont[A, B] { r: A => B / {} }: Cont[A, B] = "r"
 
 // This is unsafe if the continuation left the scope of the
 // capabilities it closed over
-extern control def apply[A, B](k: Cont[A, B])(a: A): B / {} = "k(a)"
+extern control def apply[A, B](k: Cont[A, B], a: A): B / {} = "k(a)"

--- a/libraries/js/monadic/web/dom.effekt
+++ b/libraries/js/monadic/web/dom.effekt
@@ -12,17 +12,17 @@ extern pure def createElement(tag: String): Node =
 extern pure def createTextNode(text: String): Node =
   "document.createTextNode(text)"
 
-extern pure def setAttribute(node: Node)(key: String, value: String): Node =
+extern pure def setAttribute(node: Node, key: String, value: String): Node =
   "node.setAttribute(key, value)"
 
 // the string return type is wrong here...
-extern pure def getAttribute(node: Node)(key: String): String =
+extern pure def getAttribute(node: Node, key: String): String =
   "node.getAttribute(key)"
 
-extern pure def appendChild(node: Node)(child: Node): Node =
+extern pure def appendChild(node: Node, child: Node): Node =
   "node.appendChild(child)"
 
-extern pure def innerHTML(node: Node)(contents: String): Node =
+extern pure def innerHTML(node: Node, contents: String): Node =
   "(function() { node.innerHTML = contents; return node })()"
 
 extern type IdleDeadline
@@ -36,7 +36,7 @@ extern pure def didDimeout(deadline: IdleDeadline): Boolean =
 extern pure def timeRemaining(deadline: IdleDeadline): Double =
   "deadline.timeRemaining()"
 
-extern pure def onClick(node: Node)(handler: () => Unit): Node =
+extern pure def onClick(node: Node, handler: () => Unit): Node =
   "(function() { node.onclick = () => handler().run(); return node })()"
 
 extern def sleep(n: Int): Unit =

--- a/libraries/llvm/effekt.effekt
+++ b/libraries/llvm/effekt.effekt
@@ -21,24 +21,22 @@ def abs(n: Int): Int =
 
 // i/o
 
-extern effect Console
-
-extern io def println(n: Int): Unit / Console = """
+extern io def println(n: Int): Unit = """
     call void @c_io_println_Int(%Int %n)
     ret %Pos zeroinitializer ; Unit
 """
 
-extern io def println(b: Boolean): Unit / Console = """
+extern io def println(b: Boolean): Unit = """
     call void @c_io_println_Boolean(%Pos %b)
     ret %Pos zeroinitializer ; Unit
 """
 
-extern io def println(x: Double): Unit / Console = """
+extern io def println(x: Double): Unit = """
     call void @c_io_println_Double(%Double %x)
     ret %Pos zeroinitializer ; Unit
 """
 
-extern io def println(str: String): Unit / Console = """
+extern io def println(str: String): Unit = """
     call void @c_io_println_String(%Pos %str)
     call void @c_buffer_refcount_decrement(%Pos %str)
     ret %Pos zeroinitializer ; Unit


### PR DESCRIPTION
Over the weekend, I took the time to cleanup the code base a bit. Quite a few changes accumulated:

- dropped `extern effect` since we have capabilities to take over this job (will be reintroduced later as `extern interface`, though).
- started to separate symbols from types. Previously, symbols like `TypeVar` have been a symbol *and* a type at the same time. By separating the two, it was possible to split `symbols.scala` into `symbols.scala` and `types.scala` making the distinction a bit more clear: (there is work left to do: CaptureUnificationVars are still symbols AND captures -- that's for another weekend).
- split record into Record + Construtor. This way data types do not give rise to record definitions for their variants, again making things a bit clearer (@phischu this should also help the LLVM backend).