### PR TITLE
Refactor/syntax into enums

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -540,11 +540,6 @@ object Namer extends Phase[Parsed, NameResolved] {
         Substitutions.types(tparams, targs).substitute(tpe)
       case other => Context.abort(pretty"Expected a value type, but got ${other}")
     }
-    case source.TypeVar(id) => Context.resolveType(id) match {
-      case TypeAlias(name, tparams, tpe) =>
-        if (tparams.nonEmpty) Context.abort(pretty"Type alias ${name.name} expects ${tparams.size} type arguments, but got none.") else tpe
-      case other => Context.abort(pretty"Expected a value type, but got ${other}")
-    }
     case source.ValueTypeTree(tpe) =>
       tpe
     // TODO reconsider reusing the same set for terms and types...
@@ -643,7 +638,7 @@ object Namer extends Phase[Parsed, NameResolved] {
 
   def resolvingType[T <: source.Type, R <: symbols.Type](tpe: T)(f: T => R)(using Context): R = Context.at(tpe) {
     val res = f(tpe)
-    Context.annotateResolvedType(tpe)(res.asInstanceOf[tpe.resolved])
+    Context.annotateResolvedType(tpe)(res)
     kinds.wellformed(res)
     res
   }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -7,7 +7,7 @@ package namer
 import effekt.context.{ Annotations, Context, ContextOps }
 import effekt.context.assertions.*
 import effekt.typer.Substitutions
-import effekt.source.{ Def, Id, IdDef, IdRef, ModuleDecl, Named, Tree }
+import effekt.source.{ Def, Id, IdDef, IdRef, ModuleDecl, Tree }
 import effekt.symbols.*
 import effekt.util.messages.ErrorMessageReifier
 
@@ -249,7 +249,7 @@ object Namer extends Phase[Parsed, NameResolved] {
 
     // FunDef and EffDef have already been resolved as part of the module declaration
     case f @ source.FunDef(id, tparams, vparams, bparams, ret, body) =>
-      val sym = Context.symbolOf(f)
+      val sym = f.symbol
       Context scoped {
         sym.tparams.foreach { p => Context.bind(p) }
         Context.bindValues(sym.vparams)

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -658,7 +658,7 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
     )
 
   lazy val interfaceType: P[BlockTypeRef] =
-    ( idRef ~ maybeTypeArgs ^^ BlockTypeRef.apply
+    ( idRef ~ maybeTypeArgs ^^ { case (id ~ targs) => BlockTypeRef(id, targs): BlockTypeRef }
     | failure("Expected an interface / effect")
     )
 

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -607,7 +607,7 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
     | `<{` ~> stmts <~ `}>` ^^ Hole.apply
     )
 
-  lazy val literals: P[Literal[_]] =
+  lazy val literals: P[Literal] =
     double | int | bool | unit | string
 
   lazy val boxedExpr: P[Box] =

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -6,7 +6,7 @@ package typer
  */
 import effekt.context.{ Annotation, Annotations, Context, ContextOps }
 import effekt.context.assertions.*
-import effekt.source.{ AnyPattern, Def, IgnorePattern, MatchPattern, ModuleDecl, Stmt, TagPattern, Term, Tree, resolve }
+import effekt.source.{ AnyPattern, Def, IgnorePattern, MatchPattern, ModuleDecl, Stmt, TagPattern, Term, Tree, resolve, symbol }
 import effekt.symbols.*
 import effekt.symbols.builtins.*
 import effekt.symbols.kinds.*

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -6,7 +6,7 @@ package typer
  */
 import effekt.context.{ Annotation, Annotations, Context, ContextOps }
 import effekt.context.assertions.*
-import effekt.source.{ AnyPattern, Def, IgnorePattern, MatchPattern, ModuleDecl, Stmt, TagPattern, Term, Tree }
+import effekt.source.{ AnyPattern, Def, IgnorePattern, MatchPattern, ModuleDecl, Stmt, TagPattern, Term, Tree, resolve }
 import effekt.symbols.*
 import effekt.symbols.builtins.*
 import effekt.symbols.kinds.*

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -98,11 +98,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
 
   def checkExpr(expr: Term, expected: Option[ValueType])(using Context, Captures): Result[ValueType] =
     checkAgainst(expr, expected) {
-      case source.IntLit(n)     => Result(TInt, Pure)
-      case source.BooleanLit(n) => Result(TBoolean, Pure)
-      case source.UnitLit()     => Result(TUnit, Pure)
-      case source.DoubleLit(n)  => Result(TDouble, Pure)
-      case source.StringLit(s)  => Result(TString, Pure)
+      case source.Literal(_, tpe)     => Result(tpe, Pure)
 
       case source.If(cond, thn, els) =>
         val Result(cndTpe, cndEffs) = cond checkAgainst TBoolean

--- a/effekt/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Annotations.scala
@@ -489,8 +489,8 @@ trait AnnotationsDB { self: Context =>
    *
    * This one can fail.
    */
-  def symbolOf(tree: source.Reference): tree.symbol = {
-    val sym = symbolOf(tree.id).asInstanceOf[tree.symbol]
+  def symbolOf(tree: source.Reference): Symbol = {
+    val sym = symbolOf(tree.id)
 
     val refs = annotationOption(Annotations.References, sym).getOrElse(Nil)
     annotate(Annotations.References, sym, tree :: refs)
@@ -502,8 +502,8 @@ trait AnnotationsDB { self: Context =>
    *
    * These lookups should not fail (except there is a bug in the compiler)
    */
-  def symbolOf(tree: source.Definition): tree.symbol =
-    symbolOf(tree.id).asInstanceOf[tree.symbol]
+  def symbolOf(tree: source.Definition): Symbol =
+    symbolOf(tree.id)
 
   /**
    * Searching the definition for a symbol

--- a/effekt/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Annotations.scala
@@ -392,16 +392,16 @@ trait AnnotationsDB { self: Context =>
     case _              => panic(s"Trying to store a value type for non value '${s}'")
   }
 
-  def annotateResolvedType(tree: source.Type)(tpe: tree.resolved): Unit =
+  def annotateResolvedType(tree: source.Type)(tpe: symbols.Type): Unit =
     annotate(Annotations.Type, tree, tpe)
 
-  def resolvedType(tree: source.Type): tree.resolved =
-    annotation(Annotations.Type, tree).asInstanceOf[tree.resolved]
+  def resolvedType(tree: source.Type): symbols.Type =
+    annotation(Annotations.Type, tree)
 
-  def annotateResolvedCapture(tree: source.CaptureSet)(capt: tree.resolved): Unit =
+  def annotateResolvedCapture(tree: source.CaptureSet)(capt: symbols.CaptureSet): Unit =
     annotate(Annotations.Capture, tree, capt)
 
-  def resolvedCapture(tree: source.CaptureSet): tree.resolved =
+  def resolvedCapture(tree: source.CaptureSet): symbols.CaptureSet =
     annotation(Annotations.Capture, tree)
 
   def typeOf(s: Symbol): Type = s match {

--- a/effekt/shared/src/main/scala/effekt/context/Assertions.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Assertions.scala
@@ -89,11 +89,4 @@ object assertions {
       case _ => reporter.abort("Expected a capability type")
     }
   }
-
-  extension(t: source.Type)(using reporter: ErrorReporter) {
-    def asTypeVar: source.TypeVar = t match {
-      case t: source.TypeVar => t
-      case _ => reporter.abort("Expected a value type")
-    }
-  }
 }

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -110,12 +110,13 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       transform(b)
   }
 
-  def transformLit[T](tree: source.Literal[T])(using Context): Literal[T] = tree match {
-    case source.UnitLit()         => UnitLit()
-    case source.IntLit(value)     => IntLit(value)
-    case source.BooleanLit(value) => BooleanLit(value)
-    case source.DoubleLit(value)  => DoubleLit(value)
-    case source.StringLit(value)  => StringLit(value)
+  def transformLit(tree: source.Literal)(using Context): Literal[_] = tree match {
+    case source.Literal(value: Unit, _)    => UnitLit()
+    case source.Literal(value: Int, _)     => IntLit(value)
+    case source.Literal(value: Boolean, _) => BooleanLit(value)
+    case source.Literal(value: Double, _)  => DoubleLit(value)
+    case source.Literal(value: String, _)  => StringLit(value)
+    case source.Literal(value, _)          => Context.panic(s"Unknown literal value: ${value}")
   }
 
   def transformUnbox(tree: source.Term)(implicit C: Context): Block =
@@ -168,7 +169,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       case sym: BlockSymbol => transformBox(tree)
     }
 
-    case l: source.Literal[t] => transformLit(l)
+    case l: source.Literal => transformLit(l)
 
     case source.Select(receiver, selector) =>
       Select(transformAsPure(receiver), selector.symbol)

--- a/effekt/shared/src/main/scala/effekt/source/Elaborator.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Elaborator.scala
@@ -46,7 +46,7 @@ trait ElaborationOps extends ContextOps { Context: Context =>
   private[source] def definitionFor(s: symbols.BlockParam): source.BlockParam =
     val id = IdDef(s.name.name)
     assignSymbol(id, s)
-    val tree = source.BlockParam(id, source.BlockTypeTree(s.tpe))
+    val tree: source.BlockParam = source.BlockParam(id, source.BlockTypeTree(s.tpe))
     tree
 
 }

--- a/effekt/shared/src/main/scala/effekt/typer/PreTyper.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/PreTyper.scala
@@ -61,7 +61,7 @@ class BoxUnboxInference {
 
     case b: BlockLiteral => Box(None, rewriteAsBlock(b)).inheritPosition(b)
 
-    case l: Literal[t]            => l
+    case l: Literal => l
 
     case Assign(id, expr) =>
       Assign(id, rewriteAsExpr(expr))

--- a/effekt/shared/src/main/scala/effekt/typer/Unification.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Unification.scala
@@ -4,7 +4,7 @@ package typer
 import effekt.context.Context
 import effekt.source.MatchPattern
 import effekt.symbols.*
-import effekt.symbols.builtins.{ TBottom, TInt, TTop }
+import effekt.symbols.builtins.{ TBottom, TTop }
 import effekt.util.messages.ErrorReporter
 
 


### PR DESCRIPTION
In this PR I refactor the source syntax into enums. This makes grouping a lot easier. Also factoring `Named` and `Resolvable` to separate objects separates concerns, which could make the source tree easier to understand for newcomers.

I plan to move those two objects to `Namer`, later.

Advantages:
- Potentially easier to read.
- `Named` serves as documentation (https://github.com/effekt-lang/effekt/pull/183/files#diff-90c294a2587a165cc230975b6fc6787f865eee7a9bc4987cd6cbfffb8a776434R443-R492)

Disadvantages:
- Enum support in Intellij is broken: https://youtrack.jetbrains.com/issue/SCL-20658/Jump-to-definition-does-not-work-for-exported-constructors
- Widening of enums is noisy https://github.com/lampepfl/dotty/issues/16299
- Instead of a complicated feature (existential type members) `Named` uses another complicated (and pretty new) feature "match types".