### PR TITLE
Feature/match void

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -533,7 +533,7 @@ class EffektParsers(positions: Positions) extends Parsers(positions) {
     )
 
   lazy val matchExpr: P[Term] =
-    (accessExpr <~ `match` ~/ `{`) ~/ (some(clause) <~ `}`) ^^ Match.apply
+    (accessExpr <~ `match` ~/ `{`) ~/ (many(clause) <~ `}`) ^^ Match.apply
 
   lazy val doExpr: P[Term] =
     `do` ~/> idRef ~ maybeTypeArgs ~ valueArgs ^^ {

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -376,7 +376,8 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
    */
   private def compileMatch(clauses: Seq[Clause])(using Context): core.Stmt = {
 
-    if (clauses.isEmpty) Context.error("Non-exhaustive pattern match.")
+    // matching on void will result in this case
+    if (clauses.isEmpty) return core.Return(core.UnitLit()) // TODO return void
 
     val normalizedClauses = clauses.map(normalize)
 

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -377,7 +377,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
   private def compileMatch(clauses: Seq[Clause])(using Context): core.Stmt = {
 
     // matching on void will result in this case
-    if (clauses.isEmpty) return core.Return(core.UnitLit()) // TODO return void
+    if (clauses.isEmpty) return core.Hole
 
     val normalizedClauses = clauses.map(normalize)
 

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -109,7 +109,7 @@ trait ChezScheme {
       }
       chez.Cond(cls, default.map(toChezExpr))
 
-    case Hole => ???
+    case Hole => chez.Builtin("hole")
 
     case State(id, init, region, body) if region == symbols.builtins.globalRegion =>
       chez.Let(List(Binding(nameDef(id), chez.Builtin("box", toChez(init)))), toChez(body))

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
@@ -95,7 +95,7 @@ object ChezSchemeLift extends Backend {
       }
       chez.Cond(cls, default.map(toChezExpr))
 
-    case Hole => ???
+    case Hole => chez.Builtin("hole")
 
     case State(id, init, region, body) if region == symbols.builtins.globalRegion =>
       chez.Let(List(Binding(nameDef(id), chez.Builtin("box", toChez(init)))), toChez(body))

--- a/examples/pos/emptymatch.effekt
+++ b/examples/pos/emptymatch.effekt
@@ -1,0 +1,8 @@
+type Void {}
+
+def undef(x: Option[Void]): Option[Int] = x match {
+  case None() => None()
+  case Some(v) => v match {}
+}
+
+def main() = ()

--- a/libraries/chez/common/effekt_primitives.ss
+++ b/libraries/chez/common/effekt_primitives.ss
@@ -89,3 +89,9 @@
   (begin
     (run warmup)
     (run iterations)))
+
+(define (hole)
+  (raise
+    (condition
+      (make-error)
+      (make-message-condition "not implemented"))))


### PR DESCRIPTION
Matching an empty type gives you any type. Since this is "ad-absurdum" we operationally translate it to a hole in the program that crashes at runtime.