### PR TITLE
Whole program js

### DIFF
--- a/effekt/js/src/main/scala/effekt/LanguageServer.scala
+++ b/effekt/js/src/main/scala/effekt/LanguageServer.scala
@@ -163,9 +163,7 @@ class LanguageServer extends Intelligence {
   // really changed. Writing will change the timestamp and lazy reloading of modules
   // on the JS side uses the timestamp to determine whether we need to re-eval a
   // module or not.
-  private val compileCached = Phase.cached("compile-cached") {
-    Phase("compile") { compileSingle }
-  }
+  private val compileCached = Phase.cached("compile-cached") { compileSingle }
 
   private def messageToDiagnostic(m: EffektError) = {
     val from = m.startPosition.map(toLSPPosition).orNull

--- a/effekt/js/src/main/scala/effekt/LanguageServer.scala
+++ b/effekt/js/src/main/scala/effekt/LanguageServer.scala
@@ -1,7 +1,7 @@
 package effekt
 
 import effekt.context.{ Context, VirtualFileSource, VirtualModuleDB }
-import effekt.generator.js.JavaScriptVirtual
+import effekt.generator.js.JavaScript
 import effekt.lifted.LiftInference
 import effekt.util.{ PlainMessaging, getOrElseAborting }
 import effekt.util.messages.{ BufferedMessaging, EffektError, EffektMessaging, FatalPhaseError }
@@ -67,7 +67,7 @@ class LanguageServer extends Intelligence {
     /**
      * Don't output amdefine module declarations
      */
-    override def Backend(implicit C: Context) = JavaScriptVirtual
+    override def Backend(implicit C: Context) = JavaScript
 
     object messaging extends PlainMessaging
   }
@@ -153,7 +153,7 @@ class LanguageServer extends Intelligence {
   private def compileSingle(src: Source)(implicit C: Context): Option[(String, CoreTransformed)] =
     context.compileSeparate(src).map {
       case (core, doc) =>
-        val path = JavaScriptVirtual.path(core.mod)
+        val path = JavaScript.path(core.mod)
         writeFile(path, doc.layout)
         (path, core)
     }

--- a/effekt/js/src/main/scala/effekt/LanguageServer.scala
+++ b/effekt/js/src/main/scala/effekt/LanguageServer.scala
@@ -163,7 +163,9 @@ class LanguageServer extends Intelligence {
   // really changed. Writing will change the timestamp and lazy reloading of modules
   // on the JS side uses the timestamp to determine whether we need to re-eval a
   // module or not.
-  private val compileCached = Phase.cached("compile-cached") { compileSingle }
+  private val compileCached = Phase.cached("compile-cached") {
+    Phase("compile") { compileSingle }
+  }
 
   private def messageToDiagnostic(m: EffektError) = {
     val from = m.startPosition.map(toLSPPosition).orNull

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -84,7 +84,7 @@ trait LSPServer extends kiama.util.Server[Tree, ModuleDecl, EffektConfig, Effekt
     }
 
     if (showIR == "machine") {
-      val CompilationUnit(main, deps) = C.compileAll(source).getOrElseAborting { return; }
+      val main = C.compileAll(source).getOrElseAborting { return; }
       val machineProg = machine.Transformer.transform(main, symbols.TmpValue())
 
       if (showTree) publishTree("machine", machineProg.program)

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -85,7 +85,7 @@ trait LSPServer extends kiama.util.Server[Tree, ModuleDecl, EffektConfig, Effekt
 
     if (showIR == "machine") {
       val CompilationUnit(main, deps) = C.compileAll(source).getOrElseAborting { return; }
-      val machineProg = machine.Transformer.transform(main, deps)
+      val machineProg = machine.Transformer.transform(main)
 
       if (showTree) publishTree("machine", machineProg.program)
       else publishIR("machine", machine.PrettyPrinter.format(machineProg.program))

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -132,7 +132,7 @@ trait LSPServer extends kiama.util.Server[Tree, ModuleDecl, EffektConfig, Effekt
 
   override def getSymbols(source: Source): Option[Vector[DocumentSymbol]] =
 
-    val mod = context.runFrontend(source)(context)
+    context.runFrontend(source)(using context)
 
     val documentSymbols = for {
       sym <- context.sourceSymbolsFor(source).toVector

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -85,7 +85,7 @@ trait LSPServer extends kiama.util.Server[Tree, ModuleDecl, EffektConfig, Effekt
 
     if (showIR == "machine") {
       val CompilationUnit(main, deps) = C.compileAll(source).getOrElseAborting { return; }
-      val machineProg = machine.Transformer.transform(main)
+      val machineProg = machine.Transformer.transform(main, symbols.TmpValue())
 
       if (showTree) publishTree("machine", machineProg.program)
       else publishIR("machine", machine.PrettyPrinter.format(machineProg.program))

--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -10,7 +10,7 @@ import effekt.typer.{ PostTyper, PreTyper, Typer }
 import effekt.util.messages.FatalPhaseError
 import effekt.util.{ SourceTask, Task, VirtualSource, paths }
 import effekt.generator.Backend
-import effekt.generator.js.JavaScriptVirtual
+import effekt.generator.js.JavaScript
 import kiama.output.PrettyPrinterTypes.Document
 import kiama.util.{ Positions, Source }
 
@@ -155,7 +155,7 @@ trait Compiler {
    * Backend
    */
   def Backend(using C: Context): Backend = C.config.backend() match {
-    case "js"           => effekt.generator.js.JavaScriptMonadic
+    case "js"           => effekt.generator.js.JavaScript
     case "chez-callcc"  => effekt.generator.chez.ChezSchemeCallCC
     case "chez-monadic" => effekt.generator.chez.ChezSchemeMonadic
     case "chez-lift"    => effekt.generator.chez.ChezSchemeLift

--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -10,6 +10,7 @@ import effekt.typer.{ PostTyper, PreTyper, Typer }
 import effekt.util.messages.FatalPhaseError
 import effekt.util.{ SourceTask, Task, VirtualSource, paths }
 import effekt.generator.Backend
+import effekt.generator.js.JavaScriptVirtual
 import kiama.output.PrettyPrinterTypes.Document
 import kiama.util.{ Positions, Source }
 
@@ -226,11 +227,9 @@ trait Compiler {
    *
    * It does **not** generate files and write them using `saveOutput`!
    * This is achieved by `compileWhole`.
-   *
-   * TODO Currently the backend is not cached at all
    */
   def compileSeparate(source: Source)(using Context): Option[(CoreTransformed, Document)] =
-    ???
+    (Frontend andThen Middleend andThen Backend.separate).apply(source)
 
   /**
    * Used by [[Driver]] and by [[Repl]] to compile a file

--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -230,7 +230,7 @@ trait Compiler {
    * TODO Currently the backend is not cached at all
    */
   def compileSeparate(source: Source)(using Context): Option[(CoreTransformed, Document)] =
-    (Frontend andThen Middleend andThen Backend.separate).apply(source)
+    ???
 
   /**
    * Used by [[Driver]] and by [[Repl]] to compile a file

--- a/effekt/shared/src/main/scala/effekt/context/ModuleDB.scala
+++ b/effekt/shared/src/main/scala/effekt/context/ModuleDB.scala
@@ -50,7 +50,7 @@ trait ModuleDB { self: Context =>
    * Tries to find a module for the given source, will run compiler on demand
    */
   def tryModuleOf(source: Source): Option[Module] = for {
-    mod <- runFrontend(source)(this)
+    mod <- runFrontend(source)(using this)
   } yield mod
 
   /**

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -81,7 +81,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     handlerName <+> block(vsep(clauses))
   }
 
-  def toDoc(d: Decl): Doc = d match {
+  def toDoc(d: Declaration): Doc = d match {
     case Data(did, ctors) =>
       "type" <+> toDoc(did.name) <> parens(ctors.map { id => toDoc(id.name) })
 

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -31,13 +31,13 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
 
     val definitions = toplevelDeclarations.collect { case d: Definition => optimize(d) }
     val externals = toplevelDeclarations.collect { case d: Extern => d }
-    val declarations = toplevelDeclarations.collect { case d: Decl => d }
+    val declarations = toplevelDeclarations.collect { case d: Declaration => d }
 
     // We use the imports on the symbol (since they include the prelude)
     ModuleDecl(path, mod.imports.map { _.path }, declarations, externals, definitions, exports)
   }
 
-  def transformToplevel(d: source.Def)(using Context): List[Definition | Decl | Extern] = d match {
+  def transformToplevel(d: source.Def)(using Context): List[Definition | Declaration | Extern] = d match {
     case f @ source.FunDef(id, _, vps, bps, _, body) =>
       val sym = f.symbol
       val ps = (vps map transform) ++ (bps map transform)

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -66,6 +66,8 @@ case class ModuleDecl(
  * Toplevel data and interface declarations
  */
 enum Declaration extends Tree {
+  def id: Symbol
+
   case Data(id: Symbol, ctors: List[Symbol])
   case Record(id: Symbol, fields: List[Symbol])
   case Interface(id: Symbol, operations: List[Symbol])
@@ -79,6 +81,7 @@ enum Extern extends Tree {
   case Def(id: BlockSymbol, tpe: FunctionType, params: List[Param], body: String)
   case Include(contents: String)
 }
+
 
 enum Definition {
   case Def(id: BlockSymbol, tpe: BlockType, block: Block)
@@ -246,12 +249,13 @@ object Tree {
   // Generic traversal of trees, applying the partial function `f` to every contained
   // element of type Tree.
   def visit(obj: Any)(f: PartialFunction[Tree, Unit]): Unit = obj match {
+    case t: Tree if f.isDefinedAt(t) => f(t)
+    case s: symbols.Symbol => ()
     case t: Iterable[t] => t.foreach { t => visit(t)(f) }
     case p: Product => p.productIterator.foreach {
-      case t: Tree => f(t)
-      case other   => ()
+      case t => visit(t)(f)
     }
-    case leaf => Set.empty
+    case leaf => ()
   }
 
   // This solution is between a fine-grained visitor and a untyped and unsafe traversal.

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -10,7 +10,7 @@ import effekt.symbols.{ BlockSymbol, FunctionType, BlockType, Constructor, Inter
  *
  *   ─ [[ Tree ]]
  *     │─ [[ ModuleDecl ]]
- *     │─ [[ Decl ]]
+ *     │─ [[ Declaration ]]
  *     │  │─ [[ Data ]]
  *     │  │─ [[ Record ]]
  *     │  │─ [[ Interface ]]
@@ -56,7 +56,7 @@ sealed trait Tree
 case class ModuleDecl(
   path: String,
   imports: List[String],
-  decls: List[Decl],
+  declarations: List[Declaration],
   externs: List[Extern],
   definitions: List[Definition],
   exports: List[Symbol]
@@ -65,12 +65,12 @@ case class ModuleDecl(
 /**
  * Toplevel data and interface declarations
  */
-enum Decl extends Tree {
+enum Declaration extends Tree {
   case Data(id: Symbol, ctors: List[Symbol])
   case Record(id: Symbol, fields: List[Symbol])
   case Interface(id: Symbol, operations: List[Symbol])
 }
-export Decl.*
+export Declaration.*
 
 /**
  * FFI external definitions

--- a/effekt/shared/src/main/scala/effekt/generator/Backend.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/Backend.scala
@@ -34,12 +34,12 @@ trait Backend extends BackendPhase {
   /**
    * Entrypoint used by REPL and Driver to compile a file and execute it.
    */
-  def compileWhole(main: CoreTransformed)(implicit C: Context): Option[Compiled]
+  def compileWhole(main: CoreTransformed)(using Context): Option[Compiled]
 
   /**
    * Entrypoint used by the LSP server to show the compiled output
    */
-  def compileSeparate(input: CoreTransformed)(implicit C: Context): Option[Document]
+  def compileSeparate(input: CoreTransformed)(using Context): Option[Document]
 
   // Using the methods above, we can implement the required phases.
   val whole = Phase("compile-whole") { input => compileWhole(input.main) }

--- a/effekt/shared/src/main/scala/effekt/generator/Backend.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/Backend.scala
@@ -43,5 +43,6 @@ trait Backend extends BackendPhase {
 
   // Using the two methods above, we can implement the required phases.
   val whole = Phase("compile-whole") { input => compileWhole(input.main, input.dependencies) }
-  val separate = Phase("compile-separate") { core => compileSeparate(core) map { doc => (core, doc) } }
+  val separate = Phase("compile-separate") { core => ??? }
+    // compileSeparate(core) map { doc => (core, doc) } }
 }

--- a/effekt/shared/src/main/scala/effekt/generator/Backend.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/Backend.scala
@@ -2,7 +2,7 @@ package effekt
 package generator
 
 import effekt.context.Context
-import effekt.symbols.Module
+import effekt.symbols.{ Module, TermSymbol }
 
 import kiama.output.PrettyPrinterTypes.Document
 import kiama.util.Source
@@ -34,7 +34,7 @@ trait Backend extends BackendPhase {
   /**
    * Entrypoint used by REPL and Driver to compile a file and execute it.
    */
-  def compileWhole(main: CoreTransformed)(using Context): Option[Compiled]
+  def compileWhole(main: CoreTransformed, mainSymbol: TermSymbol)(using Context): Option[Compiled]
 
   /**
    * Entrypoint used by the LSP server to show the compiled output
@@ -42,7 +42,10 @@ trait Backend extends BackendPhase {
   def compileSeparate(input: CoreTransformed)(using Context): Option[Document]
 
   // Using the methods above, we can implement the required phases.
-  val whole = Phase("compile-whole") { input => compileWhole(input.main) }
+  val whole = Phase("compile-whole") { input =>
+    val mainSymbol = summon[Context].checkMain(input.main.mod)
+    compileWhole(input.main, mainSymbol)
+  }
 
   val separate = Phase("compile-separate") { core => compileSeparate(core) map { doc => (core, doc) } }
 }

--- a/effekt/shared/src/main/scala/effekt/generator/Backend.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/Backend.scala
@@ -22,7 +22,7 @@ trait BackendPhase {
   /**
    * Entrypoint used by the LSP server to show the compiled output
    */
-  def separate: Phase[CoreTransformed, (CoreTransformed, Document)] = ???
+  def separate: Phase[CoreTransformed, (CoreTransformed, Document)]
 }
 
 /**
@@ -32,10 +32,17 @@ trait BackendPhase {
 trait Backend extends BackendPhase {
 
   /**
-   * Entrypoint used by REPL and Driver to compile a file and execute it
+   * Entrypoint used by REPL and Driver to compile a file and execute it.
    */
   def compileWhole(main: CoreTransformed)(implicit C: Context): Option[Compiled]
 
-  // Using the method above, we can implement the required phases.
+  /**
+   * Entrypoint used by the LSP server to show the compiled output
+   */
+  def compileSeparate(input: CoreTransformed)(implicit C: Context): Option[Document]
+
+  // Using the methods above, we can implement the required phases.
   val whole = Phase("compile-whole") { input => compileWhole(input.main) }
+
+  val separate = Phase("compile-separate") { core => compileSeparate(core) map { doc => (core, doc) } }
 }

--- a/effekt/shared/src/main/scala/effekt/generator/Backend.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/Backend.scala
@@ -22,7 +22,7 @@ trait BackendPhase {
   /**
    * Entrypoint used by the LSP server to show the compiled output
    */
-  def separate: Phase[CoreTransformed, (CoreTransformed, Document)]
+  def separate: Phase[CoreTransformed, (CoreTransformed, Document)] = ???
 }
 
 /**
@@ -34,15 +34,8 @@ trait Backend extends BackendPhase {
   /**
    * Entrypoint used by REPL and Driver to compile a file and execute it
    */
-  def compileWhole(main: CoreTransformed, dependencies: List[CoreTransformed])(implicit C: Context): Option[Compiled]
+  def compileWhole(main: CoreTransformed)(implicit C: Context): Option[Compiled]
 
-  /**
-   * Entrypoint used by the LSP server to show the compiled output
-   */
-  def compileSeparate(input: CoreTransformed)(implicit C: Context): Option[Document]
-
-  // Using the two methods above, we can implement the required phases.
-  val whole = Phase("compile-whole") { input => compileWhole(input.main, input.dependencies) }
-  val separate = Phase("compile-separate") { core => ??? }
-    // compileSeparate(core) map { doc => (core, doc) } }
+  // Using the method above, we can implement the required phases.
+  val whole = Phase("compile-whole") { input => compileWhole(input.main) }
 }

--- a/effekt/shared/src/main/scala/effekt/generator/Backend.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/Backend.scala
@@ -17,7 +17,7 @@ trait BackendPhase {
   /**
    * Entrypoint used by REPL and Driver to compile a file and execute it
    */
-  def whole: Phase[CompilationUnit, Compiled]
+  def whole: Phase[CoreTransformed, Compiled]
 
   /**
    * Entrypoint used by the LSP server to show the compiled output
@@ -43,8 +43,8 @@ trait Backend extends BackendPhase {
 
   // Using the methods above, we can implement the required phases.
   val whole = Phase("compile-whole") { input =>
-    val mainSymbol = summon[Context].checkMain(input.main.mod)
-    compileWhole(input.main, mainSymbol)
+    val mainSymbol = summon[Context].checkMain(input.mod)
+    compileWhole(input, mainSymbol)
   }
 
   val separate = Phase("compile-separate") { core => compileSeparate(core) map { doc => (core, doc) } }

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -49,10 +49,9 @@ trait ChezScheme {
   /**
    * Returns [[Compiled]], containing the files that should be written to.
    */
-  def compileWhole(main: CoreTransformed, dependencies: List[CoreTransformed])(using C: Context) = {
+  def compileWhole(main: CoreTransformed)(using C: Context) = {
     val mainSym = C.checkMain(main.mod)
-    val deps = dependencies.flatMap { dep => compile(dep) }
-    val chezModule = cleanup(chez.Let(Nil, compilationUnit(mainSym, main.mod, main.core, deps)))
+    val chezModule = cleanup(chez.Let(Nil, compilationUnit(mainSym, main.mod, main.core)))
     val result = chez.PrettyPrinter.pretty(chez.PrettyPrinter.toDoc(chezModule), 100)
     val mainFile = path(main.mod)
     Some(Compiled(mainFile, Map(mainFile -> result)))
@@ -70,9 +69,9 @@ trait ChezScheme {
   private def compile(in: CoreTransformed)(using Context): List[chez.Def] =
     toChez(in.core)
 
-  def compilationUnit(mainSymbol: Symbol, mod: Module, core: ModuleDecl, dependencies: List[chez.Def])(implicit C: Context): chez.Block = {
-    val defs = toChez(core)
-    chez.Block(generateStateAccessors ++ dependencies ++ defs, Nil, runMain(nameRef(mainSymbol)))
+  def compilationUnit(mainSymbol: Symbol, mod: Module, core: ModuleDecl)(implicit C: Context): chez.Block = {
+    val definitions = toChez(core)
+    chez.Block(generateStateAccessors ++ definitions, Nil, runMain(nameRef(mainSymbol)))
   }
 
   /**

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -85,7 +85,7 @@ trait ChezScheme {
   def toChez(p: Param): ChezName = nameDef(p.id)
 
   def toChez(module: ModuleDecl): List[chez.Def] = {
-    val decls = module.decls.flatMap(toChez)
+    val decls = module.declarations.flatMap(toChez)
     val externs = module.externs.map(toChez)
      // TODO FIXME, once there is a let _ = ... in there, we are doomed!
     val defns = module.definitions.map(toChez).flatMap {
@@ -140,7 +140,7 @@ trait ChezScheme {
     case other => chez.Let(Nil, toChez(other))
   }
 
-  def toChez(decl: core.Decl): List[chez.Def] = decl match {
+  def toChez(decl: core.Declaration): List[chez.Def] = decl match {
     case Data(did, ctors) =>
       ctors.flatMap {
         case ctor: symbols.Constructor => generateConstructor(ctor, ctor.fields)
@@ -151,7 +151,7 @@ trait ChezScheme {
       generateConstructor(did, fields)
 
     // We use chez scheme records to also represent capabilities.
-    case Decl.Interface(id, operations) =>
+    case Declaration.Interface(id, operations) =>
       generateConstructor(id, operations)
   }
 

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -4,7 +4,7 @@ package chez
 
 import effekt.context.Context
 import effekt.core.*
-import effekt.symbols.{ Module, Symbol, Wildcard }
+import effekt.symbols.{ Module, Symbol, Wildcard, TermSymbol }
 
 import scala.language.implicitConversions
 import effekt.util.paths.*
@@ -49,8 +49,7 @@ trait ChezScheme {
   /**
    * Returns [[Compiled]], containing the files that should be written to.
    */
-  def compileWhole(main: CoreTransformed)(using C: Context) = {
-    val mainSym = C.checkMain(main.mod)
+  def compileWhole(main: CoreTransformed, mainSym: TermSymbol)(using C: Context) = {
     val chezModule = cleanup(chez.Let(Nil, compilationUnit(mainSym, main.mod, main.core)))
     val result = chez.PrettyPrinter.pretty(chez.PrettyPrinter.toDoc(chezModule), 100)
     val mainFile = path(main.mod)

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
@@ -4,7 +4,7 @@ package chez
 
 import effekt.context.Context
 import effekt.lifted.*
-import effekt.symbols.{ Module, Symbol, Wildcard }
+import effekt.symbols.{ Module, Symbol, Wildcard, TermSymbol }
 
 import scala.language.implicitConversions
 import effekt.util.paths.*
@@ -31,16 +31,13 @@ object ChezSchemeLift extends Backend {
   /**
    * Returns [[Compiled]], containing the files that should be written to.
    */
-  def compileWhole(main: CoreTransformed)(using C: Context) = {
-    val mainSymbol = C.checkMain(main.mod)
-
+  def compileWhole(main: CoreTransformed, mainSymbol: TermSymbol)(using C: Context) =
     LiftInference(main).map { lifted =>
       val chezModule = chez.Let(Nil, compilationUnit(mainSymbol, lifted.mod, lifted.core))
       val result = chez.PrettyPrinter.pretty(chez.PrettyPrinter.toDoc(chezModule), 100)
       val mainFile = path(main.mod)
       Compiled(mainFile, Map(mainFile -> result))
     }
-  }
 
   /**
    * Entrypoint used by the LSP server to show the compiled output

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
@@ -31,12 +31,11 @@ object ChezSchemeLift extends Backend {
   /**
    * Returns [[Compiled]], containing the files that should be written to.
    */
-  def compileWhole(main: CoreTransformed, dependencies: List[CoreTransformed])(using C: Context) = {
+  def compileWhole(main: CoreTransformed)(using C: Context) = {
     val mainSymbol = C.checkMain(main.mod)
-    val deps = dependencies.flatMap { dep => compile(dep) }
 
     LiftInference(main).map { lifted =>
-      val chezModule = chez.Let(Nil, compilationUnit(mainSymbol, lifted.mod, lifted.core, deps))
+      val chezModule = chez.Let(Nil, compilationUnit(mainSymbol, lifted.mod, lifted.core))
       val result = chez.PrettyPrinter.pretty(chez.PrettyPrinter.toDoc(chezModule), 100)
       val mainFile = path(main.mod)
       Compiled(mainFile, Map(mainFile -> result))
@@ -55,9 +54,9 @@ object ChezSchemeLift extends Backend {
   private def compile(in: CoreTransformed)(using Context): List[chez.Def] =
     LiftInference(in).toList.flatMap { lifted => toChez(lifted.core) }
 
-  def compilationUnit(mainSymbol: Symbol, mod: Module, core: ModuleDecl, dependencies: List[chez.Def])(implicit C: Context): chez.Block = {
-    val defs = toChez(core)
-    chez.Block(generateStateAccessors ++ dependencies ++ defs, Nil, runMain(nameRef(mainSymbol)))
+  def compilationUnit(mainSymbol: Symbol, mod: Module, core: ModuleDecl)(implicit C: Context): chez.Block = {
+    val definitions = toChez(core)
+    chez.Block(generateStateAccessors ++ definitions, Nil, runMain(nameRef(mainSymbol)))
   }
 
   /**
@@ -65,7 +64,6 @@ object ChezSchemeLift extends Backend {
    */
   def path(m: Module)(using C: Context): String =
     (C.config.outputPath() / m.path.replace('/', '_')).unixPath + ".ss"
-
 
   def toChez(p: Param): ChezName = nameDef(p.id)
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -19,13 +19,12 @@ object JavaScript extends Backend {
   /**
    * Returns [[Compiled]], containing the files that should be written to.
    */
-  def compileWhole(input: CoreTransformed)(using C: Context) = {
+  def compileWhole(input: CoreTransformed, mainSymbol: TermSymbol)(using C: Context) = {
 
     assert(input.core.imports.isEmpty, "All dependencies should have been inlined by now.")
 
     val module = input.mod
     val mainFile = path(module)
-    val mainSymbol = C.checkMain(module)
     val exports = List(js.Export(JSName("main"), nameRef(mainSymbol)))
 
     val result = js.PrettyPrinter.format(toJS(input.core, Nil, exports).commonjs)

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -5,7 +5,6 @@ package js
 import effekt.context.Context
 import effekt.context.assertions.*
 import effekt.core.*
-import effekt.lifted.EvidenceSymbol
 import effekt.symbols.{ LocalName, Module, Name, NoName, QualifiedName, Symbol, TermSymbol, TypeConstructor, TypeSymbol, Wildcard }
 import effekt.util.paths.*
 import effekt.{ Compiled, CoreTransformed, symbols }
@@ -32,11 +31,10 @@ trait JavaScript extends Backend {
   /**
    * Returns [[Compiled]], containing the files that should be written to.
    */
-  def compileWhole(main: CoreTransformed, dependencies: List[CoreTransformed])(implicit C: Context) = {
-    val compiledDependencies = dependencies.flatMap { dep => compile(dep) }.toMap
+  def compileWhole(main: CoreTransformed)(implicit C: Context) = {
     compile(main).map {
       case (mainFile, result) =>
-        Compiled(mainFile, compiledDependencies.updated(mainFile, result))
+        Compiled(mainFile, Map(mainFile -> result))
     }
   }
 
@@ -92,8 +90,6 @@ trait JavaScript extends Backend {
   def jsModuleName(path: String): String = "$" + path.replace('/', '_').replace('-', '_')
 
   def jsModuleFile(path: String): String = path.replace('/', '_').replace('-', '_') + ".js"
-
-  def toJSName(s: String): JSName = JSName(jsEscape(s))
 
   val `fresh` = JSName("fresh")
   val `tag` = JSName("__tag")

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -175,9 +175,11 @@ trait JavaScript extends Backend {
     val state   = generateStateAccessors
 
     // TODO this is not necessary, once we implement proper exports.
-    val exports = module.exports.collectFirst {
+    val allMains = module.exports.collect {
       case sym if sym.name.name == "main" => js.Export(JSName("main"), nameRef(sym))
-    }.toList
+    }
+
+    val exports = List(allMains.last)
 
     js.Module(name, imports, exports, state ++ decls ++ externs ++ stmts)
   }

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -14,19 +14,7 @@ import kiama.util.Source
 
 import scala.language.implicitConversions
 
-// used by the website
-object JavaScriptVirtual extends JavaScript {
-  def jsModuleSystem(module: js.Module): List[js.Stmt] = module.virtual
-}
-
-// used by REPL and compiler
-object JavaScriptMonadic extends JavaScript {
-  def jsModuleSystem(module: js.Module): List[js.Stmt] = module.commonjs
-}
-
-trait JavaScript extends Backend {
-
-  def jsModuleSystem(module: js.Module): List[js.Stmt]
+object JavaScript extends Backend {
 
   /**
    * Returns [[Compiled]], containing the files that should be written to.
@@ -40,7 +28,7 @@ trait JavaScript extends Backend {
     val mainSymbol = C.checkMain(module)
     val exports = List(js.Export(JSName("main"), nameRef(mainSymbol)))
 
-    val result = js.PrettyPrinter.format(jsModuleSystem(toJS(input.core, Nil, exports)))
+    val result = js.PrettyPrinter.format(toJS(input.core, Nil, exports).commonjs)
     Some(Compiled(mainFile, Map(mainFile -> result)))
   }
 
@@ -82,8 +70,8 @@ trait JavaScript extends Backend {
     }
 
     C.using(module = input.mod) {
-      val result = toJS(input.core, imports, exports)
-      Some(js.PrettyPrinter.format(jsModuleSystem(result)))
+      val result = toJS(input.core, imports, exports).virtual
+      Some(js.PrettyPrinter.format(result))
     }
   }
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -32,6 +32,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Return(expr)                  => "return" <+> toDoc(expr) <> ";"
     case ExprStmt(expr)                => toDoc(expr) <> ";"
     case Const(id, expr)               => "const" <+> toDoc(id) <+> "=" <+> toDoc(expr) <> ";"
+    case Destruct(ids, expr)           => "const" <+> braces(hsep(ids.map(toDoc), comma)) <+> "=" <+> toDoc(expr) <> ";"
+    case Assign(target, expr)          => toDoc(target) <+> "=" <+> toDoc(expr) <> ";"
     case Function(name, params, stmts) => "function" <+> toDoc(name) <> parens(params map toDoc) <+> jsBlock(stmts map toDoc)
     case Switch(sc, branches, default) => "switch" <+> parens(toDoc(sc)) <+> jsBlock(branches.map {
       case (tag, body) => "case" <+> toDoc(tag) <> ":" <+> toDoc(body)

--- a/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
@@ -46,13 +46,27 @@ case class Module(name: JSName, imports: List[Import], exports: List[Export], st
     importStmts ++ moduleBody
   }
 
+  /**
+   * Generates the Javascript module skeleton
+   *
+   * {{{
+   *   const MYMODULE = {}
+   *   // ... contents of the module
+   *   module.exports = Object.assign(MYMODULE, {
+   *     // EXPORTS...
+   *   })
+   * }}}
+   */
   def moduleBody: List[Stmt] = {
-    // module.exports = { EXPORTS }
-    val exportStatement = js.Assign(js.Member(js.Variable(JSName("module")), JSName("exports")),
-      js.Object(exports.map { e => e.name -> e.expr })
-    )
+    val declaration = js.Const(name, js.Object())
 
-    stmts :+ exportStatement
+    // module.exports = Object.assign(MODULE, { EXPORTS })
+    val exportStatement = js.ExprStmt(js.Call(RawExpr("module.exports = Object.assign"), List(
+      js.Variable(name),
+      js.Object(exports.map { e => e.name -> e.expr })
+    )))
+
+    (declaration :: stmts) :+ exportStatement
   }
 }
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
@@ -129,7 +129,6 @@ object monadic {
 
   def Call(callee: Expr, args: List[Expr]): Control = js.Call(callee, args)
   def If(cond: Expr, thn: Control, els: Control): Control = js.IfExpr(cond, thn, els)
-  def While(cond: Control, body: Control): Control = Builtin("_while", js.Lambda(Nil, cond), js.Lambda(Nil, body))
   def Handle(handlers: List[Expr], body: Expr): Control = js.Call(Builtin("handle", js.ArrayLiteral(handlers)), List(body))
 
   def Builtin(name: String, args: Expr*): Control = js.MethodCall($effekt, JSName(name), args: _*)

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/LLVM.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/LLVM.scala
@@ -14,9 +14,9 @@ import effekt.context.assertions.*
 import effekt.util.paths.*
 
 object LLVM extends Backend {
-  def compileWhole(main: CoreTransformed, dependencies: List[CoreTransformed])(using Context): Option[Compiled] = {
+  def compileWhole(main: CoreTransformed)(using Context): Option[Compiled] = {
     val mainFile = path(main.mod)
-    val machineMod = machine.Transformer.transform(main, dependencies)
+    val machineMod = machine.Transformer.transform(main)
     val llvmDefinitions = Transformer.transform(machineMod)
 
     val llvmString = effekt.llvm.PrettyPrinter.show(llvmDefinitions)
@@ -37,7 +37,7 @@ object LLVM extends Backend {
    * and the prelude.
    */
   def compileSeparate(main: CoreTransformed)(using Context): Option[Document] = {
-    val machine.Program(decls, prog) = machine.Transformer.transform(main, Nil)
+    val machine.Program(decls, prog) = machine.Transformer.transform(main)
 
     // we don't print declarations here.
     val llvmDefinitions = Transformer.transform(machine.Program(Nil, prog))

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/LLVM.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/LLVM.scala
@@ -9,14 +9,14 @@ import effekt.context.Context
 import effekt.lifted.*
 import effekt.machine
 import effekt.llvm.*
-import effekt.symbols.{ Module, BlockSymbol, Name, Symbol, ValueSymbol }
+import effekt.symbols.{ Module, BlockSymbol, Name, Symbol, ValueSymbol, TermSymbol }
 import effekt.context.assertions.*
 import effekt.util.paths.*
 
 object LLVM extends Backend {
-  def compileWhole(main: CoreTransformed)(using Context): Option[Compiled] = {
+  def compileWhole(main: CoreTransformed, mainSymbol: TermSymbol)(using Context): Option[Compiled] = {
     val mainFile = path(main.mod)
-    val machineMod = machine.Transformer.transform(main)
+    val machineMod = machine.Transformer.transform(main, mainSymbol)
     val llvmDefinitions = Transformer.transform(machineMod)
 
     val llvmString = effekt.llvm.PrettyPrinter.show(llvmDefinitions)
@@ -37,7 +37,7 @@ object LLVM extends Backend {
    * and the prelude.
    */
   def compileSeparate(main: CoreTransformed)(using Context): Option[Document] = {
-    val machine.Program(decls, prog) = machine.Transformer.transform(main)
+    val machine.Program(decls, prog) = machine.Transformer.transform(main, symbols.TmpValue())
 
     // we don't print declarations here.
     val llvmDefinitions = Transformer.transform(machine.Program(Nil, prog))

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -23,7 +23,7 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
     // TODO drop once we also ported lifted to use [[core.Definition]]
     val env = pretransform(mod.definitions)
     val definitions = mod.definitions.map(d => transform(d)(using env, Context))
-    ModuleDecl(mod.path, mod.imports, mod.decls.map(transform), mod.externs.map(transform), definitions, mod.exports)
+    ModuleDecl(mod.path, mod.imports, mod.declarations.map(transform), mod.externs.map(transform), definitions, mod.exports)
   }
 
   def transform(param: core.Param): Param = param match {
@@ -43,7 +43,7 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
       New(Implementation(interface, transformedMethods))
   }
 
-  def transform(tree: core.Decl)(using Context): lifted.Decl = tree match {
+  def transform(tree: core.Declaration)(using Context): lifted.Decl = tree match {
     case core.Data(id, ctors) =>
       Data(id, ctors)
 

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -11,10 +11,7 @@ import effekt.symbols.builtins.TState
 
 object Transformer {
 
-  def transform(main: CoreTransformed)(using C: Context): Program = {
-
-    val mainSymbol = C.checkMain(main.mod)
-
+  def transform(main: CoreTransformed, mainSymbol: TermSymbol)(using C: Context): Program = {
     val Some(CoreLifted(_, _, _, liftedMain)) = LiftInference(main) : @unchecked
 
     C.using(module = main.mod) {

--- a/libraries/js/monadic/effekt_builtins.js
+++ b/libraries/js/monadic/effekt_builtins.js
@@ -1,6 +1,6 @@
 function show$impl(obj) {
   if (!!obj && !!obj.__name) {
-    return obj.__name + "(" + obj.__data.map(show).join(", ") + ")"
+    return obj.__name + "(" + obj.__data.map(show$impl).join(", ") + ")"
   } else if (!!obj && obj.__unit) {
     return "()";
   } else {
@@ -23,7 +23,7 @@ function equals$impl(obj1, obj2) {
 
 function println$impl(obj) {
   //return $effekt.delayed(() => { console.log(show(obj)); return $effekt.unit; });
-  console.log(show(obj)); return $effekt.unit;
+  console.log(show$impl(obj)); return $effekt.unit;
 }
 
 $effekt.unit = { __unit: true }

--- a/libraries/js/monadic/effekt_runtime.js
+++ b/libraries/js/monadic/effekt_runtime.js
@@ -1,22 +1,26 @@
+$effekt = {};
+
 const $runtime = (function() {
 
   // Regions
   function Cell(init) {
     var _value = init;
-    return {
-      "op$get": function() {
-        return _value
-      },
-      "op$put": function(v) {
-        _value = v;
-        return $effekt.unit
-      },
+    const cell = ({
       backup: function() {
         var _backup = _value
         var cell = this;
         return () => { _value = _backup; return cell }
       }
-    }
+    });
+    // $getOp and $putOp are auto generated from the compiler
+    cell[$getOp] = function() {
+      return _value
+    };
+    cell[$putOp] = function(v) {
+      _value = v;
+      return $effekt.unit;
+    };
+    return cell
   }
 
   function Arena() {

--- a/libraries/js/monadic/effekt_runtime.js
+++ b/libraries/js/monadic/effekt_runtime.js
@@ -1,5 +1,3 @@
-$effekt = {};
-
 const $runtime = (function() {
 
   // Regions

--- a/libraries/js/monadic/text/regex.effekt
+++ b/libraries/js/monadic/text/regex.effekt
@@ -11,8 +11,16 @@ extern pure def regex(str: String): Regex =
   "new RegExp(str)"
 
 def exec(reg: Regex, str: String): Option[Match] =
-  reg.unsafeExec(str).undefinedToOption
+  reg.unsafeExec(str).undefinedToOption match {
+    case None() => None()
+    case Some(v) => Some(Match(v.matched, v.index))
+  }
+
+// internal representation { matched: String, index: Int }
+extern type RegexMatch
+extern pure def matched(r: RegexMatch): String = "r.matched"
+extern pure def index(r: RegexMatch): Int = "r.index"
 
 // internals
-extern pure def unsafeExec(reg: Regex, str: String): Match =
-  "(function () { var res = reg.exec(str); if (res === null) { return undefined } else { return Match(res[0], res.index) }})()"
+extern pure def unsafeExec(reg: Regex, str: String): RegexMatch =
+  "(function () { var res = reg.exec(str); if (res === null) { return undefined } else { return { matched: res[0], index: res.index} }})()"


### PR DESCRIPTION
WIP.

Idea: also use whole program compilation in JS. We *do* need to support some form of separate compilation for the website (for performance reasons and to avoid calling `eval` over and over again -- which results in a quadratic explosion). 

However, I first want to make the JS backend conform with all the other backends and THEN think about how to support the website again. Maybe this results in a design that works better in the common case.

For example, it would be fine to not run optimizations on the code generated for the website (so optimizations can be whole-program).