### PR TITLE
WIP: Make more types extern instead of builtin

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -317,12 +317,14 @@ object Namer extends Phase[Parsed, NameResolved] {
     case source.ExternResource(id, tpe) => ()
     case source.ExternInclude(path, _, _) => ()
 
-    case source.If(cond, thn, els) =>
+    case source.If(cond, condTpe, thn, els) =>
+      resolveGeneric(condTpe);
       resolveGeneric(cond);
       Context scoped { resolveGeneric(thn) }
       Context scoped { resolveGeneric(els) }
 
-    case source.While(cond, block) =>
+    case source.While(cond, condTpe, block, returnTpe) =>
+      resolveGeneric(condTpe); resolveGeneric(returnTpe);
       resolveGeneric(cond);
       Context scoped { resolveGeneric(block) }
 
@@ -449,7 +451,7 @@ object Namer extends Phase[Parsed, NameResolved] {
 
     case source.Literal(v, tpe) => resolve(tpe)
 
-    case source.Assign(id, expr) => Context.resolveVar(id) match {
+    case source.Assign(id, expr, returnTpe) => resolve(returnTpe); Context.resolveVar(id) match {
       case x: VarBinder => resolveGeneric(expr)
       case _: ValBinder | _: ValueParam => Context.abort(pretty"Can only assign to mutable variables, but ${id.name} is a constant.")
       case y: Wildcard => Context.abort(s"Trying to assign to a wildcard, which is not allowed.")

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -154,16 +154,16 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
       Context.define(id, sym)
 
-    case source.ExternType(id, tparams) =>
+    case source.ExternType(id, tparams, body) =>
       Context.define(id, Context scoped {
         val tps = tparams map resolve
-        ExternType(Context.nameFor(id), tps)
+        ExternType(Context.nameFor(id), tps, body)
       })
 
-    case source.ExternInterface(id, tparams) =>
+    case source.ExternInterface(id, tparams, body) =>
       Context.define(id, Context scoped {
         val tps = tparams map resolve
-        ExternInterface(Context.nameFor(id), tps)
+        ExternInterface(Context.nameFor(id), tps, body)
       })
 
     case source.ExternDef(capture, id, tparams, vparams, bparams, ret, body) => {
@@ -311,8 +311,8 @@ object Namer extends Phase[Parsed, NameResolved] {
       record.constructor = constructor
       constructor.fields = resolveFields(fs, constructor)
 
-    case source.ExternType(id, tparams) => ()
-    case source.ExternInterface(id, tparams) => ()
+    case source.ExternType(id, tparams, body) => ()
+    case source.ExternInterface(id, tparams, body) => ()
     case source.ExternDef(pure, id, tps, vps, bps, ret, body) => ()
     case source.ExternResource(id, tpe) => ()
     case source.ExternInclude(path, _, _) => ()

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -447,6 +447,8 @@ object Namer extends Phase[Parsed, NameResolved] {
 
     case source.Var(id) => Context.resolveVar(id)
 
+    case source.Literal(v, tpe) => resolve(tpe)
+
     case source.Assign(id, expr) => Context.resolveVar(id) match {
       case x: VarBinder => resolveGeneric(expr)
       case _: ValBinder | _: ValueParam => Context.abort(pretty"Can only assign to mutable variables, but ${id.name} is a constant.")

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -147,7 +147,7 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
   lazy val externFun: P[Def] =
     `extern` ~> (externCapture <~ `def`) ~/ idDef ~ maybeTypeParams ~ params ~ (`:` ~> effectful) ~ ( `=` ~/> externBody) ^^ {
       case pure ~ id ~ tparams ~ (vparams ~ bparams) ~ tpe ~ body =>
-        ExternDef(pure, id, tparams, vparams, bparams, tpe, body.stripPrefix("\"").stripSuffix("\""))
+        ExternDef(pure, id, tparams, vparams, bparams, tpe, body)
     }
 
   lazy val externResource: P[Def] =
@@ -158,7 +158,7 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
     ( multilineString
     | s"(?!${multi})\"([^\"\n]*)\"".r // single-line strings
     | failure(s"Expected an extern definition, which can either be a single-line string (e.g., \"x + y\") or a multi-line string (e.g., $multi...$multi)")
-    )
+    ) ^^ { c => c.stripPrefix("\"").stripSuffix("\"")}
 
   lazy val externCapture: P[CaptureSet] =
     ( "pure" ^^^ CaptureSet(Nil)

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -139,10 +139,10 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
     )
 
   lazy val externType: P[Def] =
-    `extern` ~> `type` ~/> idDef ~ maybeTypeParams ^^ ExternType.apply
+    `extern` ~> `type` ~/> idDef ~ maybeTypeParams ~ opt(`=` ~> externBody) ^^ ExternType.apply
 
   lazy val externInterface: P[Def] =
-    `extern` ~> `interface` ~/> idDef ~ maybeTypeParams ^^ ExternInterface.apply
+    `extern` ~> `interface` ~/> idDef ~ maybeTypeParams ~ opt(`=` ~> externBody) ^^ ExternInterface.apply
 
   lazy val externFun: P[Def] =
     `extern` ~> (externCapture <~ `def`) ~/ idDef ~ maybeTypeParams ~ params ~ (`:` ~> effectful) ~ ( `=` ~/> externBody) ^^ {

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -444,13 +444,19 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
 
 
   lazy val assignExpr: P[Term] =
-    idRef ~ (`=` ~> expr) ^^ Assign.apply
+    idRef ~ (`=` ~> expr) ^^ { case lhs ~ rhs => Assign(lhs, rhs, ValueType.ValueTypeRef(IdRef("Unit"), Nil)) }
 
   lazy val ifExpr: P[Term] =
-    `if` ~/> (`(` ~/> expr <~ `)`) ~/ stmt ~ (`else` ~/> stmt | success(Return(UnitLit()))) ^^ If.apply
+    `if` ~/> (`(` ~/> expr <~ `)`) ~/ stmt ~ (`else` ~/> stmt | success(Return(UnitLit()))) ^^ {
+      case cond ~ thn ~ els => If(cond, ValueType.ValueTypeRef(IdRef("Boolean"), Nil), thn, els)
+    }
 
   lazy val whileExpr: P[Term] =
-    `while` ~/> (`(` ~/> expr <~ `)`) ~/ stmt ^^ While.apply
+    `while` ~/> (`(` ~/> expr <~ `)`) ~/ stmt ^^ {
+      case cond ~ body => While(
+        cond, ValueType.ValueTypeRef(IdRef("Boolean"), Nil),
+        body, ValueType.ValueTypeRef(IdRef("Unit"), Nil))
+    }
 
   lazy val primExpr: P[Term] =
     variable | literals | tupleLiteral | listLiteral | hole | `(` ~/> expr <~ `)`

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -99,7 +99,11 @@ object Typer extends Phase[NameResolved, Typechecked] {
 
   def checkExpr(expr: Term, expected: Option[ValueType])(using Context, Captures): Result[ValueType] =
     checkAgainst(expr, expected) {
-      case source.Literal(_, tpe)     => Result(tpe, Pure)
+      case source.Literal(_, tpe)     => Context.resolvedType(tpe) match {
+        case valueType: ValueType => Result(valueType, Pure)
+        case blockType: BlockType =>
+          Context.panic(pretty"Literal has block type ${blockType}. This should not happen.")
+      }
 
       case source.If(cond, thn, els) =>
         val Result(cndTpe, cndEffs) = cond checkAgainst TBoolean

--- a/effekt/shared/src/main/scala/effekt/core/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Parser.scala
@@ -37,11 +37,14 @@ class CoreParsers(positions: Positions, names: Names) extends EffektLexers(posit
   /**
    * Literals
    */
-  lazy val int    = integerLiteral ^^ { n => Literal(n.toInt, Type.TInt) }
-  lazy val bool   = `true` ^^^ Literal(true, Type.TBoolean) | `false` ^^^ Literal(false, Type.TBoolean)
-  lazy val unit   = literal("()") ^^^ Literal((), Type.TUnit)
-  lazy val double = doubleLiteral ^^ { n => Literal(n.toDouble, Type.TDouble) }
-  lazy val string = stringLiteral ^^ { s => Literal(s.substring(1, s.size - 1), Type.TString) }
+  lazy val int    = integerLiteral ^^ { n => Literal(n.toInt, ValueType.Data(names.idFor("Int"), Nil)) }
+  lazy val bool   =
+    ( `true` ^^^ Literal(true, ValueType.Data(names.idFor("Boolean"), Nil))
+    | `false` ^^^ Literal(false, ValueType.Data(names.idFor("Boolean"), Nil))
+    )
+  lazy val unit   = literal("()") ^^^ Literal((), ValueType.Data(names.idFor("Unit"), Nil))
+  lazy val double = doubleLiteral ^^ { n => Literal(n.toDouble, ValueType.Data(names.idFor("Double"), Nil)) }
+  lazy val string = stringLiteral ^^ { s => Literal(s.substring(1, s.size - 1), ValueType.Data(names.idFor("String"), Nil)) }
 
   /**
    * Names

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -36,14 +36,14 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Extern.Def(id, tps, cps, vps, bps, ret, capt, body) =>
       "extern" <+> toDoc(capt) <+> "def" <+> toDoc(id.name) <+> "=" <+> paramsToDoc(tps, vps, bps) <> ":" <+> toDoc(ret) <+> "=" <+> "\"" <> body <> "\""
     case Extern.Include(contents) => emptyDoc // right now, do not print includes.
-    case Extern.Type(id, Nil) =>
-      "extern" <+> "type" <+> toDoc(id)
-    case Extern.Type(id, tparams) =>
-      "extern" <+> "type" <+> toDoc(id) <> brackets(tparams map toDoc)
-    case Extern.Interface(id, Nil) =>
-      "extern" <+> "interface" <+> toDoc(id)
-    case Extern.Interface(id, tparams) =>
-      "extern" <+> "interface" <+> toDoc(id) <> brackets(tparams map toDoc)
+    case Extern.Type(id, tparams, body) =>
+      "extern" <+> "type" <+> toDoc(id) <>
+        (if tparams.isEmpty then emptyDoc else brackets(tparams map toDoc)) <+>
+        (if body.isEmpty then emptyDoc else "=" <+> "\"" <> body.get <> "\"")
+    case Extern.Interface(id, tparams, body) =>
+      "extern" <+> "interface" <+> toDoc(id) <>
+        (if tparams.isEmpty then emptyDoc else brackets(tparams map toDoc)) <+>
+        (if body.isEmpty then emptyDoc else "=" <+> "\"" <> body.get <> "\"")
     case Extern.Resource(id, tpe) =>
       "extern" <+> "resource" <+> toDoc(id) <> ":" <+> toDoc(tpe)
   }

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -36,6 +36,16 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Extern.Def(id, tps, cps, vps, bps, ret, capt, body) =>
       "extern" <+> toDoc(capt) <+> "def" <+> toDoc(id.name) <+> "=" <+> paramsToDoc(tps, vps, bps) <> ":" <+> toDoc(ret) <+> "=" <+> "\"" <> body <> "\""
     case Extern.Include(contents) => emptyDoc // right now, do not print includes.
+    case Extern.Type(id, Nil) =>
+      "extern" <+> "type" <+> toDoc(id)
+    case Extern.Type(id, tparams) =>
+      "extern" <+> "type" <+> toDoc(id) <> brackets(tparams map toDoc)
+    case Extern.Interface(id, Nil) =>
+      "extern" <+> "interface" <+> toDoc(id)
+    case Extern.Interface(id, tparams) =>
+      "extern" <+> "interface" <+> toDoc(id) <> brackets(tparams map toDoc)
+    case Extern.Resource(id, tpe) =>
+      "extern" <+> "resource" <+> toDoc(id) <> ":" <+> toDoc(tpe)
   }
 
   def toDoc(b: Block): Doc = b match {

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -2,7 +2,7 @@ package effekt
 package core
 
 import scala.collection.mutable.ListBuffer
-import effekt.context.{ Annotations, Context, ContextOps }
+import effekt.context.{Annotations, Context, ContextOps}
 import effekt.symbols.*
 import effekt.symbols.builtins.*
 import effekt.context.assertions.*
@@ -102,8 +102,17 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     case e @ source.ExternInclude(path, contents, _) =>
       List(Extern.Include(contents.get))
 
+    case source.Def.ExternType(id, tparams) =>
+      List(Extern.Type(id.symbol, tparams.map(_.symbol)))
+
+    case source.Def.ExternInterface(id, tparams) =>
+      List(Extern.Interface(id.symbol, tparams.map(_.symbol)))
+
+    case source.Def.ExternResource(id, _) =>
+      val btpe = Context.blockTypeOf(id.symbol)
+      List(Extern.Resource(id.symbol, transform(btpe)))
+
     // For now we forget about all of the following definitions in core:
-    case d: source.Def.Extern => Nil
     case d: source.Def.Alias => Nil
   }
 

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -217,7 +217,11 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     }
 
     case source.Literal(value, tpe) =>
-      Literal(value, transform(tpe))
+      Context.resolvedType(tpe) match {
+        case valueType: ValueType => Literal(value, transform(valueType))
+        case blockType: BlockType =>
+          Context.abort(s"Literal has block type ${blockType}. This should not happen.")
+      }
 
     case s @ source.Select(receiver, selector) =>
       Select(transformAsPure(receiver), s.definition, transform(Context.inferredTypeOf(s)))

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -102,11 +102,11 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     case e @ source.ExternInclude(path, contents, _) =>
       List(Extern.Include(contents.get))
 
-    case source.Def.ExternType(id, tparams) =>
-      List(Extern.Type(id.symbol, tparams.map(_.symbol)))
+    case source.Def.ExternType(id, tparams, body) =>
+      List(Extern.Type(id.symbol, tparams.map(_.symbol), body))
 
-    case source.Def.ExternInterface(id, tparams) =>
-      List(Extern.Interface(id.symbol, tparams.map(_.symbol)))
+    case source.Def.ExternInterface(id, tparams, body) =>
+      List(Extern.Interface(id.symbol, tparams.map(_.symbol), body))
 
     case source.Def.ExternResource(id, _) =>
       val btpe = Context.blockTypeOf(id.symbol)

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -99,8 +99,8 @@ case class Property(id: Id, tpe: BlockType) extends Tree
 enum Extern extends Tree {
   case Def(id: Id, tparams: List[Id], cparams: List[Id], vparams: List[Param.ValueParam], bparams: List[Param.BlockParam], ret: ValueType, annotatedCapture: Captures, body: String)
   case Include(contents: String)
-  case Type(id: Id, tparams: List[Id])
-  case Interface(id: Id, tparams: List[Id])
+  case Type(id: Id, tparams: List[Id], body: Option[String])
+  case Interface(id: Id, tparams: List[Id], body: Option[String])
   case Resource(id: Id, tpe: BlockType)
 }
 

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -99,6 +99,9 @@ case class Property(id: Id, tpe: BlockType) extends Tree
 enum Extern extends Tree {
   case Def(id: Id, tparams: List[Id], cparams: List[Id], vparams: List[Param.ValueParam], bparams: List[Param.BlockParam], ret: ValueType, annotatedCapture: Captures, body: String)
   case Include(contents: String)
+  case Type(id: Id, tparams: List[Id])
+  case Interface(id: Id, tparams: List[Id])
+  case Resource(id: Id, tpe: BlockType)
 }
 
 

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -55,10 +55,6 @@ object Type {
   val TBottom = ValueType.Data(builtins.BottomSymbol, Nil)
 
   val TUnit   = ValueType.Data(builtins.UnitSymbol, Nil)
-  val TInt = ValueType.Data(builtins.IntSymbol, Nil)
-  val TBoolean = ValueType.Data(builtins.BooleanSymbol, Nil)
-  val TString = ValueType.Data(builtins.StringSymbol, Nil)
-  val TDouble = ValueType.Data(builtins.DoubleSymbol, Nil)
 
   val TRegion = BlockType.Interface(builtins.RegionSymbol, Nil)
 

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -155,6 +155,10 @@ trait ChezScheme {
 
     case Extern.Include(contents) =>
       RawDef(contents)
+
+    case Extern.Type(id,_) => RawDef(s"#|extern type ${id.name.name}|#")
+    case Extern.Interface(id,_) => RawDef(s"#|extern interface ${id.name.name}|#")
+    case Extern.Resource(id,_) => RawDef(s"#|extern resource ${id.name.name}|#")
   }
 
   def toChez(defn: Definition): Either[chez.Def, Option[chez.Expr]] = defn match {

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -156,8 +156,8 @@ trait ChezScheme {
     case Extern.Include(contents) =>
       RawDef(contents)
 
-    case Extern.Type(id,_) => RawDef(s"#|extern type ${id.name.name}|#")
-    case Extern.Interface(id,_) => RawDef(s"#|extern interface ${id.name.name}|#")
+    case Extern.Type(id,_,_) => RawDef(s"#|extern type ${id.name.name}|#")
+    case Extern.Interface(id,_,_) => RawDef(s"#|extern interface ${id.name.name}|#")
     case Extern.Resource(id,_) => RawDef(s"#|extern resource ${id.name.name}|#")
   }
 

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
@@ -138,6 +138,10 @@ object ChezSchemeLift extends Backend {
 
     case Extern.Include(contents) =>
       RawDef(contents)
+
+    case Extern.Type(id,_) => RawDef(s"#|extern type ${id.name.name}|#")
+    case Extern.Interface(id,_) => RawDef(s"#|extern interface ${id.name.name}|#")
+    case Extern.Resource(id, _) => RawDef(s"#|extern resource ${id.name.name}|#")
   }
 
   def toChez(defn: Definition): Either[chez.Def, Option[chez.Expr]] = defn match {

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeLift.scala
@@ -139,8 +139,8 @@ object ChezSchemeLift extends Backend {
     case Extern.Include(contents) =>
       RawDef(contents)
 
-    case Extern.Type(id,_) => RawDef(s"#|extern type ${id.name.name}|#")
-    case Extern.Interface(id,_) => RawDef(s"#|extern interface ${id.name.name}|#")
+    case Extern.Type(id,_,_) => RawDef(s"#|extern type ${id.name.name}|#")
+    case Extern.Interface(id,_,_) => RawDef(s"#|extern interface ${id.name.name}|#")
     case Extern.Resource(id, _) => RawDef(s"#|extern resource ${id.name.name}|#")
   }
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -105,10 +105,10 @@ object JavaScript extends Backend {
     case Extern.Include(contents) =>
       js.RawStmt(contents)
 
-    case Extern.Type(id, _) =>
+    case Extern.Type(id, _, _) =>
       js.RawStmt(s"/* extern type ${id.name.name} */")
 
-    case Extern.Interface(id, _) =>
+    case Extern.Interface(id, _, _) =>
       js.RawStmt(s"/* extern interface ${id.name.name} */")
 
     case Extern.Resource(id, _) =>

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -104,6 +104,15 @@ object JavaScript extends Backend {
 
     case Extern.Include(contents) =>
       js.RawStmt(contents)
+
+    case Extern.Type(id, _) =>
+      js.RawStmt(s"/* extern type ${id.name.name} */")
+
+    case Extern.Interface(id, _) =>
+      js.RawStmt(s"/* extern interface ${id.name.name} */")
+
+    case Extern.Resource(id, _) =>
+      js.RawStmt(s"/* extern resource ${id.name.name} */")
   }
 
   def toJS(b: core.Block)(using DeclarationContext, Context): js.Expr = b match {

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -132,6 +132,7 @@ ${indentedLines(instructions.map(show).mkString("\n"))}
     case StructureType(elementTypes) => s"{${commaSeparated(elementTypes.map(show))}}"
     case FunctionType(returnType, argumentTypes) => s"${show(returnType)} (${commaSeparated(argumentTypes.map(show))})"
     case NamedType(name) => localName(name)
+    case RawType(name) => name
   }
 
   def show(parameter: Parameter): LLVMString = parameter match {

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
@@ -70,5 +70,6 @@ enum Type {
   case StructureType(elementTypes: List[Type])
   case FunctionType(resultType: Type, argumentTypes: List[Type])
   case NamedType(name: String)
+  case RawType(name: String)
 }
 export Type.*

--- a/effekt/shared/src/main/scala/effekt/lifted/ExternContext.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/ExternContext.scala
@@ -1,5 +1,6 @@
-package effekt.core
+package effekt.lifted
 
+import effekt.core.Id
 import effekt.util.messages.ErrorReporter
 
 class ExternContext(val externs: List[Extern]) {

--- a/effekt/shared/src/main/scala/effekt/lifted/ExternContext.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/ExternContext.scala
@@ -1,0 +1,16 @@
+package effekt.core
+
+import effekt.util.messages.ErrorReporter
+
+class ExternContext(val externs: List[Extern]) {
+
+  lazy val types = externs.collect{
+    case t: Extern.Type => (t.id -> t)
+  }.toMap
+
+  def findExternType(id: Id): Option[Extern.Type] = types.get(id)
+  def getExternType(id: Id)(using E: ErrorReporter): Extern.Type = findExternType(id).getOrElse{
+    E.panic(s"Cannot find extern type declaration for ${id}")
+  }
+
+}

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -57,6 +57,12 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
       Extern.Def(id, funTpe, (vps ++ bps).map { p => transform(p) }, body)
     case core.Extern.Include(contents) =>
       Extern.Include(contents)
+    case core.Extern.Type(id, tparams) =>
+      Extern.Type(id, tparams)
+    case core.Extern.Interface(id, tparams) =>
+      Extern.Interface(id, tparams)
+    case core.Extern.Resource(id, tpe) =>
+      Extern.Resource(id, tpe)
   }
 
   def transform(tree: core.Definition)(using Environment, ErrorReporter): lifted.Definition = tree match {

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -57,10 +57,10 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
       Extern.Def(id, funTpe, (vps ++ bps).map { p => transform(p) }, body)
     case core.Extern.Include(contents) =>
       Extern.Include(contents)
-    case core.Extern.Type(id, tparams) =>
-      Extern.Type(id, tparams)
-    case core.Extern.Interface(id, tparams) =>
-      Extern.Interface(id, tparams)
+    case core.Extern.Type(id, tparams, body) =>
+      Extern.Type(id, tparams, body)
+    case core.Extern.Interface(id, tparams, body) =>
+      Extern.Interface(id, tparams, body)
     case core.Extern.Resource(id, tpe) =>
       Extern.Resource(id, tpe)
   }

--- a/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
@@ -32,14 +32,14 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Extern.Def(id, tpe, ps, body) =>
       "extern def" <+> toDoc(id.name) <+> "=" <+> parens(hsep(ps map toDoc, comma)) <+> "=" <+> "\"" <> body <> "\""
     case Extern.Include(contents) => emptyDoc // right now, do not print includes.
-    case Extern.Type(id, Nil) =>
-      "extern" <+> "type" <+> toDoc(id.name)
-    case Extern.Type(id, tparams) =>
-      "extern" <+> "type" <+> toDoc(id.name) <> brackets(tparams.map{ p => toDoc(p.name)})
-    case Extern.Interface(id, Nil) =>
-      "extern" <+> "type" <+> toDoc(id.name)
-    case Extern.Interface(id, tparams) =>
-      "extern" <+> "type" <+> toDoc(id.name) <> brackets(tparams.map{ p => toDoc(p.name)})
+    case Extern.Type(id, tparams, body) =>
+      "extern" <+> "type" <+> toDoc(id.name) <>
+        (if tparams.isEmpty then emptyDoc else brackets(tparams.map{ p => toDoc(p.name)})) <+>
+        (if body.isEmpty then emptyDoc else "=" <+> "\"" <> body.get <> "\"")
+    case Extern.Interface(id, tparams, body) =>
+      "extern" <+> "type" <+> toDoc(id.name) <>
+        (if tparams.isEmpty then emptyDoc else brackets(tparams.map{ p => toDoc(p.name)})) <+>
+        (if body.isEmpty then emptyDoc else "=" <+> "\"" <> body.get <> "\"")
     case Extern.Resource(id, tpe) =>
       "extern" <+> "resource" <+> toDoc(id.name)
   }

--- a/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
@@ -32,6 +32,16 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Extern.Def(id, tpe, ps, body) =>
       "extern def" <+> toDoc(id.name) <+> "=" <+> parens(hsep(ps map toDoc, comma)) <+> "=" <+> "\"" <> body <> "\""
     case Extern.Include(contents) => emptyDoc // right now, do not print includes.
+    case Extern.Type(id, Nil) =>
+      "extern" <+> "type" <+> toDoc(id.name)
+    case Extern.Type(id, tparams) =>
+      "extern" <+> "type" <+> toDoc(id.name) <> brackets(tparams.map{ p => toDoc(p.name)})
+    case Extern.Interface(id, Nil) =>
+      "extern" <+> "type" <+> toDoc(id.name)
+    case Extern.Interface(id, tparams) =>
+      "extern" <+> "type" <+> toDoc(id.name) <> brackets(tparams.map{ p => toDoc(p.name)})
+    case Extern.Resource(id, tpe) =>
+      "extern" <+> "resource" <+> toDoc(id.name)
   }
 
   def toDoc(b: Block): Doc = b match {

--- a/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
@@ -23,6 +23,9 @@ case class ModuleDecl(
 enum Extern {
   case Def(id: Symbol, tpe: core.BlockType.Function, params: List[Param], body: String)
   case Include(contents: String)
+  case Type(id: Symbol, tparams: List[Symbol])
+  case Interface(id: Symbol, tparams: List[Symbol])
+  case Resource(id: Symbol, tpe: core.BlockType)
 }
 
 enum Definition {

--- a/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
@@ -23,8 +23,8 @@ case class ModuleDecl(
 enum Extern {
   case Def(id: Symbol, tpe: core.BlockType.Function, params: List[Param], body: String)
   case Include(contents: String)
-  case Type(id: Symbol, tparams: List[Symbol])
-  case Interface(id: Symbol, tparams: List[Symbol])
+  case Type(id: Symbol, tparams: List[Symbol], body: Option[String])
+  case Interface(id: Symbol, tparams: List[Symbol], body: Option[String])
   case Resource(id: Symbol, tpe: core.BlockType)
 }
 

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -31,11 +31,9 @@ object PrettyPrinter extends ParenPrettyPrinter {
   })
 
   def toDoc(tpe: Type): Doc = tpe match {
+    case Type.Extern(name)   => s"extern(${name})"
     case Positive(name)      => name
     case Negative(name)      => name
-    case Type.Int()          => "Int"
-    case Type.Double()       => "Double"
-    case Type.String()       => "String"
     case Type.Stack()        => "Stack"
     case Type.Reference(tpe) => toDoc(tpe) <> "*"
     case Type.Region()       => "Region"

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -31,7 +31,7 @@ object Transformer {
     given DC: DeclarationContext = core.DeclarationContext(mod.decls)
 
     // collect all information
-    val declarations = mod.externs.map(transform)
+    val declarations = mod.externs.flatMap(transform)
     val definitions = mod.definitions
     val mainEntry = Jump(Label(mainName, List()))
 
@@ -54,10 +54,12 @@ object Transformer {
         case lifted.BlockParam(id, tpe) => ErrorReporter.abort("Foreign functions currently cannot take block arguments.")
         case lifted.EvidenceParam(id) => Variable(id.name.name, builtins.Evidence)
       }
-      Extern(transform(name), transformedParams, transform(functionType.result), body)
+      List(Extern(transform(name), transformedParams, transform(functionType.result), body))
 
     case lifted.Extern.Include(contents) =>
-      Include(contents)
+      List(Include(contents))
+
+    case lifted.Extern.Type(_,_) | lifted.Extern.Interface(_,_) | lifted.Extern.Resource(_,_) => Nil
   }
 
   def transform(stmt: lifted.Stmt)(using BlocksParamsContext, DeclarationContext, ErrorReporter): Statement =

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -47,7 +47,7 @@ object Transformer {
     Program(declarations, transformedDefinitions)
   }
 
-  def transform(extern: lifted.Extern)(using BlocksParamsContext, ErrorReporter): Declaration = extern match {
+  def transform(extern: lifted.Extern)(using BlocksParamsContext, ErrorReporter): List[Declaration] = extern match {
     case lifted.Extern.Def(name, functionType, params, body) =>
       val transformedParams = params.map {
         case lifted.ValueParam(id, tpe) => Variable(id.name.name, transform(tpe))
@@ -59,7 +59,7 @@ object Transformer {
     case lifted.Extern.Include(contents) =>
       List(Include(contents))
 
-    case lifted.Extern.Type(_,_) | lifted.Extern.Interface(_,_) | lifted.Extern.Resource(_,_) => Nil
+    case lifted.Extern.Type(_,_,_) | lifted.Extern.Interface(_,_,_) | lifted.Extern.Resource(_,_) => Nil
   }
 
   def transform(stmt: lifted.Stmt)(using BlocksParamsContext, DeclarationContext, ErrorReporter): Statement =

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -203,12 +203,10 @@ export Statement.*
  * Types
  */
 enum Type {
+  case Extern(name: Predef.String)
   case Positive(name: Predef.String)
   case Negative(name: Predef.String)
   case Stack()
-  case Int()
-  case Double()
-  case String()
   case Reference(tpe: Type)
   case Region()
 }
@@ -217,7 +215,7 @@ export Type.{ Positive, Negative }
 type Evidence = Int
 object builtins {
 
-  val Evidence = Type.Int()
+  val Evidence = Type.Extern("%Int 8")
   val Here: Evidence = 0
   val There: Evidence = 1
 

--- a/effekt/shared/src/main/scala/effekt/source/Elaborator.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Elaborator.scala
@@ -208,7 +208,7 @@ class AnnotateCaptures(src: Source) extends Query[Unit, CaptureSet] {
       case x: ValueSymbol => CaptureSet.empty
     }
 
-    case e @ source.Assign(id, expr) =>
+    case e @ source.Assign(id, expr, returnTpe) =>
       query(expr) ++ captureOf(id.symbol.asBlockSymbol)
 
     case l @ source.Box(annotatedCapture, block) =>

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -269,7 +269,7 @@ enum Term extends Tree {
 
   // Variable / Value use (can now also stand for blocks)
   case Var(id: IdRef) extends Term, Reference
-  case Assign(id: IdRef, expr: Term) extends Term, Reference
+  case Assign(id: IdRef, expr: Term, returnTpe: ValueType) extends Term, Reference
 
   case Literal(value: Any, tpe: ValueType)
   case Hole(stmts: Stmt)
@@ -310,8 +310,8 @@ enum Term extends Tree {
   case MethodCall(receiver: Term, id: IdRef, targs: List[ValueType], vargs: List[Term], bargs: List[Term]) extends Term, Reference
 
   // Control Flow
-  case If(cond: Term, thn: Stmt, els: Stmt)
-  case While(cond: Term, block: Stmt)
+  case If(cond: Term, condTpe: ValueType, thn: Stmt, els: Stmt)
+  case While(cond: Term, condTpe: ValueType, block: Stmt, returnTpe: ValueType)
   case Match(scrutinee: Term, clauses: List[MatchClause])
 
   /**

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -190,13 +190,13 @@ enum Def extends Definition {
   /**
    * Only valid on the toplevel!
    */
-  case ExternType(id: IdDef, tparams: List[Id])
+  case ExternType(id: IdDef, tparams: List[Id], body: Option[String])
 
   case ExternDef(capture: CaptureSet, id: IdDef, tparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: Effectful, body: String) extends Def
 
   case ExternResource(id: IdDef, tpe: BlockType)
 
-  case ExternInterface(id: IdDef, tparams: List[Id])
+  case ExternInterface(id: IdDef, tparams: List[Id], body: Option[String])
 
   /**
    * Namer resolves the path and loads the contents in field [[contents]]

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -271,7 +271,7 @@ enum Term extends Tree {
   case Var(id: IdRef) extends Term, Reference
   case Assign(id: IdRef, expr: Term) extends Term, Reference
 
-  case Literal(value: Any, tpe: symbols.ValueType)
+  case Literal(value: Any, tpe: ValueType)
   case Hole(stmts: Stmt)
 
   // Boxing and unboxing to represent first-class values
@@ -336,11 +336,11 @@ export Term.*
 
 // Smart Constructors for literals
 // -------------------------------
-def UnitLit(): Literal = Literal((), symbols.builtins.TUnit)
-def IntLit(value: Int): Literal = Literal(value, symbols.builtins.TInt)
-def BooleanLit(value: Boolean): Literal = Literal(value, symbols.builtins.TBoolean)
-def DoubleLit(value: Double): Literal = Literal(value, symbols.builtins.TDouble)
-def StringLit(value: String): Literal = Literal(value, symbols.builtins.TString)
+def UnitLit(): Literal = Literal((), ValueType.ValueTypeRef(IdRef("Unit"), Nil))
+def IntLit(value: Int): Literal = Literal(value, ValueType.ValueTypeRef(IdRef("Int"), Nil))
+def BooleanLit(value: Boolean): Literal = Literal(value, ValueType.ValueTypeRef(IdRef("Boolean"), Nil))
+def DoubleLit(value: Double): Literal = Literal(value, ValueType.ValueTypeRef(IdRef("Double"), Nil))
+def StringLit(value: String): Literal = Literal(value, ValueType.ValueTypeRef(IdRef("String"), Nil))
 
 type CallLike = Call | Do | Select | MethodCall
 

--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -50,11 +50,11 @@ object DeclPrinter extends ParenPrettyPrinter {
     case f: ExternFunction =>
       format("extern def", f, f.annotatedResult, f.annotatedEffects)
 
-    case ExternType(name, tparams) =>
+    case ExternType(name, tparams, body) =>
       val tps = show(tparams)
       pp"extern type ${name}$tps"
 
-    case ExternInterface(name, tparams) =>
+    case ExternInterface(name, tparams, body) =>
       pp"extern interface ${name}${show(tparams)}"
 
     case ExternResource(name, tpe) =>

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -59,13 +59,13 @@ object TypePrinter extends ParenPrettyPrinter {
 
   def toDoc(t: BlockTypeConstructor): Doc = t match {
     case Interface(name, tparams, ops) => name
-    case ExternInterface(name, tparams) => name
+    case ExternInterface(name, tparams, body) => name
   }
 
   def toDoc(t: TypeConstructor): Doc = t match {
     case DataType(name, tparams, constructors)  => name <> typeParams(tparams)
     case Record(name, tparams, constructor) => name <> typeParams(tparams)
-    case ExternType(name, tparams) => name
+    case ExternType(name, tparams, body) => name
   }
 
   def toDoc(eff: Effects): Doc =

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -22,18 +22,6 @@ object builtins {
   val UnitSymbol = ExternType(name("Unit"), Nil, None)
   val TUnit = ValueTypeApp(UnitSymbol, Nil)
 
-  val BooleanSymbol = ExternType(name("Boolean"), Nil, None)
-  val TBoolean = ValueTypeApp(BooleanSymbol, Nil)
-
-  val IntSymbol = ExternType(name("Int"), Nil, None)
-  val TInt = ValueTypeApp(IntSymbol, Nil)
-
-  val DoubleSymbol = ExternType(name("Double"), Nil, None)
-  val TDouble = ValueTypeApp(DoubleSymbol, Nil)
-
-  val StringSymbol = ExternType(name("String"), Nil, None)
-  val TString = ValueTypeApp(StringSymbol, Nil)
-
   val TopSymbol = ExternType(name("Top"), Nil, None)
   val TTop = ValueTypeApp(TopSymbol, Nil)
 
@@ -67,10 +55,6 @@ object builtins {
 
   val rootTypes: Map[String, TypeSymbol] = Map(
     "Unit" -> UnitSymbol,
-    "Boolean" -> BooleanSymbol,
-    "Int" -> IntSymbol,
-    "Double" -> DoubleSymbol,
-    "String" -> StringSymbol,
     "Bottom" -> BottomSymbol,
     "Top" -> TopSymbol,
     "IO" -> IOSymbol,

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -19,25 +19,25 @@ object builtins {
 
   private def name(s: String) = Name.qualified(s, prelude)
 
-  val UnitSymbol = ExternType(name("Unit"), Nil)
+  val UnitSymbol = ExternType(name("Unit"), Nil, None)
   val TUnit = ValueTypeApp(UnitSymbol, Nil)
 
-  val BooleanSymbol = ExternType(name("Boolean"), Nil)
+  val BooleanSymbol = ExternType(name("Boolean"), Nil, None)
   val TBoolean = ValueTypeApp(BooleanSymbol, Nil)
 
-  val IntSymbol = ExternType(name("Int"), Nil)
+  val IntSymbol = ExternType(name("Int"), Nil, None)
   val TInt = ValueTypeApp(IntSymbol, Nil)
 
-  val DoubleSymbol = ExternType(name("Double"), Nil)
+  val DoubleSymbol = ExternType(name("Double"), Nil, None)
   val TDouble = ValueTypeApp(DoubleSymbol, Nil)
 
-  val StringSymbol = ExternType(name("String"), Nil)
+  val StringSymbol = ExternType(name("String"), Nil, None)
   val TString = ValueTypeApp(StringSymbol, Nil)
 
-  val TopSymbol = ExternType(name("Top"), Nil)
+  val TopSymbol = ExternType(name("Top"), Nil, None)
   val TTop = ValueTypeApp(TopSymbol, Nil)
 
-  val BottomSymbol = ExternType(name("Bottom"), Nil)
+  val BottomSymbol = ExternType(name("Bottom"), Nil, None)
   val TBottom = ValueTypeApp(BottomSymbol, Nil)
 
   val IOSymbol = Interface(Name.local("IO"), Nil, Nil)

--- a/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
@@ -56,7 +56,7 @@ package object kinds {
   private def wellformedTypeConstructor(tpe: TypeConstructor)(using C: Context): Kind.Fun = tpe match {
     case DataType(_, tparams, _)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
     case Record(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
-    case ExternType(_, tparams)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
+    case ExternType(_, tparams, _)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
   }
 
   private def wellformedType(tpe: ValueType)(using C: Context): Kind = tpe match {
@@ -87,6 +87,6 @@ package object kinds {
 
   private def wellformedBlockTypeConstructor(e: BlockTypeConstructor)(using Context): Kind.Fun = e match {
     case Interface(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
-    case ExternInterface(_, tparams) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
+    case ExternInterface(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
   }
 }

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -211,7 +211,7 @@ enum TypeConstructor extends TypeSymbol {
 
   case DataType(name: Name, tparams: List[TypeParam], var constructors: List[Constructor] = Nil)
   case Record(name: Name, tparams: List[TypeParam], var constructor: Constructor)
-  case ExternType(name: Name, tparams: List[TypeParam])
+  case ExternType(name: Name, tparams: List[TypeParam], body: Option[String])
 }
 export TypeConstructor.*
 
@@ -242,7 +242,7 @@ enum BlockTypeConstructor extends BlockTypeSymbol {
   def tparams: List[TypeParam]
 
   case Interface(name: Name, tparams: List[TypeParam], var operations: List[Operation] = Nil)
-  case ExternInterface(name: Name, tparams: List[TypeParam])
+  case ExternInterface(name: Name, tparams: List[TypeParam], body: Option[String])
 }
 export BlockTypeConstructor.*
 

--- a/effekt/shared/src/main/scala/effekt/typer/PreTyper.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/PreTyper.scala
@@ -63,14 +63,14 @@ class BoxUnboxInference {
 
     case l: Literal => l
 
-    case Assign(id, expr) =>
-      Assign(id, rewriteAsExpr(expr))
+    case Assign(id, expr, returnTpe) =>
+      Assign(id, rewriteAsExpr(expr), returnTpe)
 
-    case If(cond, thn, els) =>
-      If(rewriteAsExpr(cond), rewrite(thn), rewrite(els))
+    case If(cond, condTpe, thn, els) =>
+      If(rewriteAsExpr(cond), condTpe, rewrite(thn), rewrite(els))
 
-    case While(cond, body) =>
-      While(rewriteAsExpr(cond), rewrite(body))
+    case While(cond, condTpe, body, returnTpe) =>
+      While(rewriteAsExpr(cond), condTpe, rewrite(body), returnTpe)
 
     case Match(sc, clauses) =>
       Match(rewriteAsExpr(sc), clauses.map(rewrite))

--- a/libraries/chez/callcc/effekt.effekt
+++ b/libraries/chez/callcc/effekt.effekt
@@ -1,5 +1,10 @@
 module effekt
 
+extern type Boolean
+extern type String
+extern type Int
+extern type Double
+
 // shift-0 based implementation
 extern include "../common/effekt_primitives.ss"
 // extern include "datatype.ss"

--- a/libraries/chez/lift/effekt.effekt
+++ b/libraries/chez/lift/effekt.effekt
@@ -1,5 +1,10 @@
 module effekt
 
+extern type Boolean
+extern type String
+extern type Int
+extern type Double
+
 extern include "../common/effekt_primitives.ss"
 extern include "effekt.ss"
 extern include "../common/effekt_matching.ss"

--- a/libraries/chez/monadic/effekt.effekt
+++ b/libraries/chez/monadic/effekt.effekt
@@ -1,5 +1,10 @@
 module effekt
 
+extern type Boolean
+extern type String
+extern type Int
+extern type Double
+
 extern include "../common/effekt_primitives.ss"
 extern include "seq0.ss"
 extern include "effekt.ss"

--- a/libraries/js/effekt.effekt
+++ b/libraries/js/effekt.effekt
@@ -1,5 +1,10 @@
 module effekt
 
+extern type Boolean
+extern type Int
+extern type Double
+extern type String
+
 // Runtime
 extern include "effekt_runtime.js"
 

--- a/libraries/llvm/effekt.effekt
+++ b/libraries/llvm/effekt.effekt
@@ -1,5 +1,10 @@
 module effekt
 
+extern type Boolean = "%Pos 16 sharePositive erasePositive"
+extern type Int = "%Int 8"
+extern type Double = "%Double 8"
+extern type String = "%Pos 16 c_buffer_refcount_increment c_buffer_refcount_decrement"
+
 extern include "rts.ll"
 extern include "forward-declare-c.ll"
 


### PR DESCRIPTION
This PR is a draft to move types from being builtins (in `symbols.builtins`) to `extern type` declarations in the prelude.
To do so, it annotates the operations using those types (`If`, `While` for `Boolean`, `Assign` for `Unit` (and `Ref`)) with `Id`s referring to them, which are then resolved by Namer and used by Typer.

For phases after core, it will also add an `ExternContext` (sim. to `DeclarationContext` in #204).

Implications:
- Using e.g. `If` in a backend that does not support `Boolean`s yet will lead to an error in Namer
- All of the builtin types are identified by name (only) and can potentially be overwritten, possibly leading to strange behaviour
    - This might be solved by having a #30.
    - On the plus side, this also allows individual backends to decide that, e.g., `Boolean` is a data type (not builtin)