### PR TITLE
Add support for Holes to machine and llvm

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -338,6 +338,10 @@ object Transformer {
         shareValues(values, freeVariables(rest));
         emit(Call(resultName, transform(resultType), ConstantGlobal(functionType, foreign), values.map(transform)));
         transform(rest)
+
+      case machine.Statement.Hole =>
+        emit(Call("_", VoidType(), ConstantGlobal(FunctionType(VoidType(), Nil), "hole"), List.empty))
+        RetVoid()
     }
 
   def transform(label: machine.Label): ConstantGlobal =

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -57,4 +57,5 @@ def freeVariables(statement: Statement): Set[Variable] =
       freeVariables(rest) - name
     case ForeignCall(name, builtin, arguments, rest) =>
       arguments.toSet ++ freeVariables(rest) - name
+    case Hole => Set.empty
   }

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -106,6 +106,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
 
     case LiteralEvidence(name, evidence, rest) =>
       "let" <+> name <+> "=" <+> evidenceToDoc(evidence) <> ";" <> line <> toDoc(rest)
+
+    case Hole => "<>"
   }
 
   def nested(content: Doc): Doc = group(nest(line <> content))

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -253,6 +253,8 @@ object Transformer {
               transform(body))
         }
 
+      case lifted.Hole() => machine.Statement.Hole
+
       case _ =>
         ErrorReporter.abort(s"Unsupported statement: $stmt")
     }

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -195,6 +195,11 @@ enum Statement {
   case LiteralDouble(name: Variable, value: Double, rest: Statement)
   case LiteralUTF8String(name: Variable, utf8: Array[Byte], rest: Statement)
   case LiteralEvidence(name: Variable, value: Evidence, rest: Statement)
+
+  /**
+   * Statement that is executed when a Hole is encountered.
+   */
+  case Hole
 }
 export Statement.*
 

--- a/libraries/llvm/forward-declare-c.ll
+++ b/libraries/llvm/forward-declare-c.ll
@@ -9,3 +9,5 @@ declare %Pos @c_buffer_construct(i64, i8*)
 declare void @c_buffer_refcount_increment(%Pos)
 declare void @c_buffer_refcount_decrement(%Pos)
 declare %Pos @c_buffer_concatenate(%Pos, %Pos)
+
+declare void @hole()

--- a/libraries/llvm/hole.c
+++ b/libraries/llvm/hole.c
@@ -1,0 +1,11 @@
+#ifndef EFFEKT_HOLE_C
+#define EFFEKT_HOLE_C
+
+#include <stdio.h>
+
+void hole() {
+    fprintf(stderr, "PANIC: Reached a hole in the program\n");
+    exit(1);
+}
+
+#endif

--- a/libraries/llvm/main.c
+++ b/libraries/llvm/main.c
@@ -12,6 +12,7 @@
 #include "types.c"
 #include "buffer.c"
 #include "io.c"
+#include "hole.c"
 
 
 extern void effektMain();


### PR DESCRIPTION
When executed, a hole will print a generic error message and exit with exit code 1.