### PR TITLE
Convert filename of location of node to URI

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -7,7 +7,7 @@ import effekt.source.{ FunDef, Hole, ModuleDecl, Tree }
 import effekt.util.{ PlainMessaging, getOrElseAborting }
 import effekt.util.messages.EffektError
 
-import kiama.util.{ Position, Services, Source }
+import kiama.util.{ Filenames, Position, Services, Source }
 import kiama.output.PrettyPrinterTypes.Document
 
 import org.eclipse.lsp4j.{ Diagnostic, DocumentSymbol, SymbolKind, ExecuteCommandParams }
@@ -107,12 +107,22 @@ trait LSPServer extends kiama.util.Server[Tree, ModuleDecl, EffektConfig, Effekt
   } yield info
 
   // The implementation in kiama.Server does not support file sources
+  def toURI(filename: String): String = {
+    if (filename startsWith "file://")
+      filename
+    else
+      if (filename startsWith "./")
+        "file://" ++ Filenames.cwd() ++ "/" ++ Filenames.dropPrefix(filename, ".")
+      else
+        s"file://$filename"
+  }
+
   override def locationOfNode(node: Tree): Location = {
     (positions.getStart(node), positions.getFinish(node)) match {
       case (start @ Some(st), finish @ Some(_)) =>
         val s = convertPosition(start)
         val f = convertPosition(finish)
-        new Location(st.source.name, new LSPRange(s, f))
+        new Location(toURI(st.source.name), new LSPRange(s, f))
       case _ =>
         null
     }


### PR DESCRIPTION
LSP-Locations should be provided with a URI as source, however in the current implementation of `locationOfNode` the source name of the node is not necessarily a URI but can also be a (relative) path without scheme. This causes the "textDocument/definition"-action to fail in neovim if the definition is not in the current file, as the file the definition is in cannot be opened then.

This PR contains simple solution that correctly yields a URI and works for all my test cases. But someone with a VSCode installation should probably check whether the VSCode-plugin still works fine with this change.

Moreover, I'm not perfectly sure if this is the correct place (maybe it should also be available somewhere else?) for the definition of `toURI` and whether this case analysis is sufficient. For me only these cases occurred but I'm not sure if an incomplete relative path like "folder/filename.effekt" without a "./" could occur as well. I hope not, as it does not seem to be clear whether prepending `cwd()` would always work in that case.