### PR TITLE
JIT: New calling convention

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/jit/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/jit/Transformer.scala
@@ -98,14 +98,14 @@ object Transformer {
 
         transform(typ) match {
         case Type.Datatype(adtType) =>
-          val (_, defParams, defBlock) = transformInline(defaultClause, reuse=false)
+          val (_, defParams, defBlock) = transformInline(defaultClause)
           val defLabel = emit(defBlock)
           val defaultClauseJit = Clause(defParams, defLabel)
 
           Match(adtType, transformArgument(v).id, (for (i <- 0 to clauseMap.keys.max) yield {
             if (clauseMap.contains(i)) {
               val clause = clauseMap(i)
-              val (closesOver, params, block) = transformInline(clause, reuse=false);
+              val (closesOver, params, block) = transformInline(clause);
               val label = emit(block);
               Clause(params, label)
             } else { defaultClauseJit }


### PR DESCRIPTION
Prepending parameters/returned values to the stored environment (instead of appending), and requiring the parameters to be in the correct registers already.

@b-studios This is a breaking change in the output format of the jit backend.