### PR TITLE
Fix bug in tuple pattern

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -435,7 +435,7 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
     | literals ^^ { l => LiteralPattern(l) }
     | idRef ~ (`(` ~> manySep(pattern, `,`)  <~ `)`) ^^ TagPattern.apply
     | idDef ^^ AnyPattern.apply
-    | `(` ~> pattern ~ (`,` ~> some(pattern) <~ `)`) ^^ { case f ~ r =>
+    | `(` ~> pattern ~ (some(`,` ~> pattern) <~ `)`) ^^ { case f ~ r =>
         TagPattern(IdRef(s"Tuple${r.size + 1}") withPositionOf f, f :: r)
       }
     )


### PR DESCRIPTION
Pattern matching on tuples with at least 3 elements didn't work, unless you used the constructors by name. This commit fixes that.