### PR TITLE
machine: Val(x,s,Return(x)) -> s

### DIFF
--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -122,6 +122,9 @@ object Transformer {
       case lifted.Return(expr) =>
         transform(expr).run { value => Return(List(value)) }
 
+      case lifted.Val(id, binding, lifted.Return(lifted.ValueVar(id2, tpe))) if id == id2 =>
+        transform(binding)
+
       case lifted.Val(id, binding, rest) =>
         PushFrame(
           Clause(List(transform(lifted.ValueParam(id, binding.tpe))), transform(rest)),


### PR DESCRIPTION
Currently, `machine.Transformer` generates an unnecessary `PushFrame` when given lifted code like
```lifted
val x = s; return x
```

In particular, PolymorphismBoxing generates code of this form sometimes. Other phases might, too (someday).
This is analogous to the special case for Run(Return(...)), and avoids pushing the unnecessary stack frame.