### PR TITLE
Recursive mono

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
@@ -50,6 +50,7 @@ object Transformer {
    * is not supported by the ml backend, yet.
    */
   def sortDefinitions(defs: List[Definition])(using C: Context): List[Definition] =
+
     sortTopologically(defs, d => freeVariables(d).vars.keySet, d => d.id)
 
   def sortDeclarations(defs: List[Declaration])(using C: Context): List[Declaration] =
@@ -196,7 +197,7 @@ object Transformer {
     // TODO maybe don't drop the continuation here? Although, it is dead code.
     case lifted.Hole() => CPS.inline { k => ml.Expr.RawExpr("raise Hole") }
 
-    case lifted.Scope(definitions, body) => CPS.inline { k => ml.mkLet(sortDefinitions(definitions).map(toML), toMLExpr(body)(k)) }
+    case lifted.Scope(definitions, body) => CPS.inline { k => ml.mkLet(definitions.map(toML), toMLExpr(body)(k)) }
 
     case lifted.Alloc(id, init, region, ev, body) if region == symbols.builtins.globalRegion =>
       CPS.inline { k =>

--- a/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
@@ -5,12 +5,14 @@ package ml
 import effekt.context.Context
 import effekt.lifted.*
 import effekt.core.Id
+
 import effekt.symbols.{ Symbol, TermSymbol, Module, Wildcard }
 import effekt.util.messages.{ INTERNAL_ERROR, FIXME }
 
 import effekt.util.paths.*
 import kiama.output.PrettyPrinterTypes.Document
 
+import scala.annotation.tailrec
 import scala.language.implicitConversions
 
 object Transformer {
@@ -39,8 +41,33 @@ object Transformer {
   def toML(module: ModuleDecl)(using Context): List[ml.Binding] = {
     val decls = module.decls.flatMap(toML)
     val externs = module.externs.map(toML)
-    val rest = module.definitions.map(toML)
+    val rest = sortTopologically(module.definitions).map(toML)
     decls ++ externs ++ rest
+  }
+
+  /**
+   * Sorts the definitions topologically. Fails if functions are mutually recursive, since this
+   * is not supported by the ml backend, yet.
+   */
+  def sortTopologically(defs: List[Definition])(using C: Context): List[Definition] = {
+    val ids = defs.map { _.id }.toSet
+    val fvs = defs.map { d =>
+      d.id -> (freeVariables(d).vars.keySet intersect ids)
+    }.toMap
+
+    @tailrec
+    def go(todo: List[Definition], out: List[Definition], emitted: Set[Id]): List[Definition] =
+      if (todo.isEmpty) {
+        out
+      } else {
+        val (noDependencies, rest) = todo.partition { d => (fvs(d.id) -- emitted).isEmpty }
+        if (noDependencies.isEmpty) {
+          val mutuals = rest.map(_.id).mkString(", ")
+          Context.abort(s"Mutual definitions are currently not supported by this backend.\nThe following definitinos could be mutually recursive: ${mutuals} ")
+        } else go(rest, noDependencies ++ out, emitted ++ noDependencies.map(_.id).toSet)
+    }
+
+    go(defs, Nil, Set.empty).reverse
   }
 
   def tpeToML(tpe: BlockType)(using C: Context): ml.Type = tpe match {
@@ -165,7 +192,7 @@ object Transformer {
     // TODO maybe don't drop the continuation here? Although, it is dead code.
     case lifted.Hole() => CPS.inline { k => ml.Expr.RawExpr("raise Hole") }
 
-    case lifted.Scope(definitions, body) => CPS.inline { k => ml.mkLet(definitions.map(toML), toMLExpr(body)(k)) }
+    case lifted.Scope(definitions, body) => CPS.inline { k => ml.mkLet(sortTopologically(definitions).map(toML), toMLExpr(body)(k)) }
 
     case lifted.Alloc(id, init, region, ev, body) if region == symbols.builtins.globalRegion =>
       CPS.inline { k =>

--- a/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
@@ -39,9 +39,9 @@ object Transformer {
   }
 
   def toML(module: ModuleDecl)(using Context): List[ml.Binding] = {
-    val decls = module.decls.flatMap(toML)
+    val decls = sortDeclarations(module.decls).flatMap(toML)
     val externs = module.externs.map(toML)
-    val rest = sortTopologically(module.definitions).map(toML)
+    val rest = sortDefinitions(module.definitions).map(toML)
     decls ++ externs ++ rest
   }
 
@@ -49,22 +49,26 @@ object Transformer {
    * Sorts the definitions topologically. Fails if functions are mutually recursive, since this
    * is not supported by the ml backend, yet.
    */
-  def sortTopologically(defs: List[Definition])(using C: Context): List[Definition] = {
-    val ids = defs.map { _.id }.toSet
-    val fvs = defs.map { d =>
-      d.id -> (freeVariables(d).vars.keySet intersect ids)
-    }.toMap
+  def sortDefinitions(defs: List[Definition])(using C: Context): List[Definition] =
+    sortTopologically(defs, d => freeVariables(d).vars.keySet, d => d.id)
+
+  def sortDeclarations(defs: List[Declaration])(using C: Context): List[Declaration] =
+    sortTopologically(defs, d => freeTypeVariables(d), d => d.id)
+
+  def sortTopologically[T](defs: List[T], dependencies: T => Set[Id], id: T => Id)(using C: Context): List[T] = {
+    val ids = defs.map(id).toSet
+    val fvs = defs.map{ d => id(d) -> dependencies(d).intersect(ids) }.toMap
 
     @tailrec
-    def go(todo: List[Definition], out: List[Definition], emitted: Set[Id]): List[Definition] =
+    def go(todo: List[T], out: List[T], emitted: Set[Id]): List[T] =
       if (todo.isEmpty) {
         out
       } else {
-        val (noDependencies, rest) = todo.partition { d => (fvs(d.id) -- emitted).isEmpty }
+        val (noDependencies, rest) = todo.partition { d => (fvs(id(d)) -- emitted).isEmpty }
         if (noDependencies.isEmpty) {
-          val mutuals = rest.map(_.id).mkString(", ")
+          val mutuals = rest.map(id).mkString(", ")
           Context.abort(s"Mutual definitions are currently not supported by this backend.\nThe following definitinos could be mutually recursive: ${mutuals} ")
-        } else go(rest, noDependencies ++ out, emitted ++ noDependencies.map(_.id).toSet)
+        } else go(rest, noDependencies ++ out, emitted ++ noDependencies.map(id).toSet)
     }
 
     go(defs, Nil, Set.empty).reverse
@@ -192,7 +196,7 @@ object Transformer {
     // TODO maybe don't drop the continuation here? Although, it is dead code.
     case lifted.Hole() => CPS.inline { k => ml.Expr.RawExpr("raise Hole") }
 
-    case lifted.Scope(definitions, body) => CPS.inline { k => ml.mkLet(sortTopologically(definitions).map(toML), toMLExpr(body)(k)) }
+    case lifted.Scope(definitions, body) => CPS.inline { k => ml.mkLet(sortDefinitions(definitions).map(toML), toMLExpr(body)(k)) }
 
     case lifted.Alloc(id, init, region, ev, body) if region == symbols.builtins.globalRegion =>
       CPS.inline { k =>

--- a/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
@@ -48,10 +48,20 @@ object Transformer {
   /**
    * Sorts the definitions topologically. Fails if functions are mutually recursive, since this
    * is not supported by the ml backend, yet.
+   *
+   * Keep let-definitions in the order they are, since they might have observable side-effects
    */
-  def sortDefinitions(defs: List[Definition])(using C: Context): List[Definition] =
+  def sortDefinitions(defs: List[Definition])(using C: Context): List[Definition] = {
+    def sort(defs: List[Definition], toSort: List[Definition]): List[Definition] = defs match {
+      case (d: Definition.Let) :: rest  =>
+        val sorted = sortTopologically(toSort, d => freeVariables(d).vars.keySet, d => d.id)
+         sorted ++ (d :: sort(rest, Nil))
+      case (d: Definition.Def) :: rest => sort(rest, d :: toSort)
+      case Nil => sortTopologically(toSort, d => freeVariables(d).vars.keySet, d => d.id)
+    }
 
-    sortTopologically(defs, d => freeVariables(d).vars.keySet, d => d.id)
+    sort(defs, Nil)
+  }
 
   def sortDeclarations(defs: List[Declaration])(using C: Context): List[Declaration] =
     sortTopologically(defs, d => freeTypeVariables(d), d => d.id)
@@ -197,7 +207,7 @@ object Transformer {
     // TODO maybe don't drop the continuation here? Although, it is dead code.
     case lifted.Hole() => CPS.inline { k => ml.Expr.RawExpr("raise Hole") }
 
-    case lifted.Scope(definitions, body) => CPS.inline { k => ml.mkLet(definitions.map(toML), toMLExpr(body)(k)) }
+    case lifted.Scope(definitions, body) => CPS.inline { k => ml.mkLet(sortDefinitions(definitions).map(toML), toMLExpr(body)(k)) }
 
     case lifted.Alloc(id, init, region, ev, body) if region == symbols.builtins.globalRegion =>
       CPS.inline { k =>

--- a/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
@@ -56,6 +56,7 @@ enum Extern {
 }
 
 enum Definition {
+  def id: Id
   case Def(id: Id, block: Block)
   case Let(id: Id, binding: Expr)
 }
@@ -189,11 +190,13 @@ case class FreeVariables(vars: immutable.HashMap[Id, lifted.Param]) {
   def --(o: FreeVariables): FreeVariables = {
     FreeVariables(vars.filter{ case (leftId -> leftParam) =>
       if(o.vars.contains(leftId)) {
-        assert(leftParam == o.vars(leftId), "Id bound with different type than it's occurences.")
+        //assert(leftParam == o.vars(leftId), s"Id bound with different type ${o.vars(leftId)} than it's occurences ${leftParam}.")
         false
       } else { true }
     })
   }
+
+  def -(id: Id) = FreeVariables(vars - id)
 
   def toList: List[lifted.Param] = vars.values.toList
   // TODO add further accessors as needed
@@ -210,7 +213,7 @@ object FreeVariables {
 }
 import FreeVariables.{toFV, combineFV}
 def freeVariables(d: Definition): FreeVariables = d match {
-  case Definition.Def(id, block) => freeVariables(block)
+  case Definition.Def(id, block) => freeVariables(block) - id // recursive definitions
   case Definition.Let(id, binding) => freeVariables(binding)
 }
 

--- a/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
@@ -287,3 +287,24 @@ def freeVariables(ev: Evidence): FreeVariables = ev.lifts.flatMap {
   case Lift.Try() => List()
   case Lift.Reg() => List()
 }.toFV
+
+
+def freeTypeVariables(d: Declaration): Set[Id] = d match {
+  case Declaration.Data(id, tparams, constructors) => constructors.flatMap(freeTypeVariables).toSet -- Set(id) -- tparams.toSet
+  case Declaration.Interface(id, tparams, properties) => properties.flatMap(freeTypeVariables).toSet -- Set(id) -- tparams.toSet
+}
+
+def freeTypeVariables(c: Constructor): Set[Id] = c.fields.flatMap(f => freeTypeVariables(f.tpe)).toSet
+def freeTypeVariables(p: Property): Set[Id] = freeTypeVariables(p.tpe)
+
+
+def freeTypeVariables(tpe: ValueType): Set[Id] = tpe match {
+  case ValueType.Var(name) => Set(name)
+  case ValueType.Data(name, targs) => Set(name) ++ targs.toSet.flatMap(freeTypeVariables)
+  case ValueType.Boxed(tpe) => freeTypeVariables(tpe)
+}
+def freeTypeVariables(tpe: BlockType): Set[Id] = tpe match {
+  case BlockType.Function(tparams, eparams, vparams, bparams, result) =>
+    (vparams.flatMap(freeTypeVariables).toSet ++ bparams.flatMap(freeTypeVariables).toSet ++ freeTypeVariables(result)) -- tparams.toSet
+  case BlockType.Interface(name, targs) => Set(name) ++ targs.toSet.flatMap(freeTypeVariables)
+}


### PR DESCRIPTION
This is an experiment to lift some restrictions in the mlton monomorphization PR #229

There are many different ways to solve the problem of (mutual) recursion over datatypes / records which are introduced by monomorphization. None is really satisfying.

https://gist.github.com/b-studios/c52a5c7a9cfa6c0021f441d3ac2655a2


## Alternative 1

```fun myFun () =
  (fn a => 1 + a,
   fn b => fn c =>
    if b then (#2 (myFun ())) b c else c);

print (Int.toString ((#2 (myFun ())) false 1));
```

This works, but is suboptimal, since ALL block member selections need to be translated to first "force". I don't like it, but it is the only solution so far, that actually works...

## Alternative 2
Here is another version of the same idea, but it does not require to change any use sites:

```val myFun = let
  fun left self = (case (self ()) of
    (l, r) => l
  );
  fun right self = (case (self ()) of
    (l, r) => r
  );
  fun makeFun () = (fn a => 1 + a, fn b => if b then (right makeFun) b else false);
in makeFun () end;

print (Bool.toString ((#2 myFun) false));
```

It only requires to redefine the extractors locally (since they need to force `self`). However, it does not work in MLton (and also variants) since `myFun` will not be generalized. 

Also local function definitions will not be generalized.

## Alternative 3

This does also not work:
```fun makeFun () =
  (fn a => 1 + a,
   fn b => fn c =>
    if b then (#2 (makeFun ())) b c else c);

val myFun = makeFun ();

print (Int.toString ((#2 myFun) false 1));
```

Due to let generalization failing on `myFun`. Annotating explicitly gives:
```
Error: out/experiment.sml 6.5-6.9.
  Type of variable cannot be generalized in expansive declaration: myFun.
    type: _ * (_ -> ['a] -> ['a])
    in: val 'a myFun: ((int -> int) * (bo  ...  > 'a))) = makeFun ()
```
`makeFun ()` is not a value and does not follow the value restriction! It does not know that it is pure, which would be an alternative to the value restriction..

## Summary
So in the end, it looks like we can only go with Alternative 1 which is implemented in this PR.

Here is a very small and preliminary nano benchmark to check that this encoding does not massively lead to performance problems:

https://gist.github.com/b-studios/59d48fb4873341d7c64cc4f57ded953d