### PR TITLE
Lexer: match escape sequences in strings

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -730,7 +730,7 @@ class EffektLexers(positions: Positions) extends Parsers(positions) {
    */
   lazy val integerLiteral = "([-+])?(0|[1-9][0-9]*)".r
   lazy val doubleLiteral = "([-+])?(0|[1-9][0-9]*)[.]([0-9]+)".r
-  lazy val stringLiteral = """\"([^\"]*)\"""".r
+  lazy val stringLiteral = """\"(\\.|[^\"])*\"""".r
 
   // Delimiter for multiline strings
   val multi = "\"\"\""


### PR DESCRIPTION
This PR addresses and fixes issue #202.

Of course, I am open to suggestions on how to properly integrate escape sequences into the lexing process as proposed by @b-studios (https://github.com/effekt-lang/effekt/issues/202#issuecomment-1500515704):

> [...] we should actually design strings and escape sequences at some point. 

What changes do you think this entails?