### PR TITLE
Rework `--compile` and add a seperate `--build` option

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -84,6 +84,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
         // we are in one of three exclusive modes: LSPServer, Compile, Run
         if (config.server()) { compiler.runFrontend(src) }
         else if (config.interpret()) { compile() foreach runner.eval }
+        else if (config.build()) { compile() foreach runner.build }  
         else if (config.compile()) { compile() }
     }
   } catch {

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -12,8 +12,8 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
 
   val compile: ScallopOption[Boolean] = toggle(
     "compile",
-    descrYes = "Compile the Effekt program",
-    descrNo = "Run the effekt program in the interpreter",
+    descrYes = "Only compile the Effekt program to a backend specific executable",
+    descrNo = "Compile and run the effekt program in the interpreter",
     default = Some(false)
   )
 
@@ -118,6 +118,6 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
 
   validateFilesIsDirectory(includePath)
 
-  // force some other configs manually to intialize them when compiling with native-image
+  // force some other configs manually to initialize them when compiling with native-image
   server; output; filenames
 }

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -15,7 +15,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     descrYes = "Compile the Effekt program to the backend specific representation",
     default = Some(false)
   )
-  
+
   val build: ScallopOption[Boolean] = toggle(
     "build",
     descrYes = "Compile the Effekt program and build a backend specific executable",
@@ -119,7 +119,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
 
   def requiresCompilation(): Boolean = !server()
 
-  def interpret(): Boolean = !server() && !compile()
+  def interpret(): Boolean = !server() && !compile() && !build()
 
   validateFilesIsDirectory(includePath)
 

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -12,8 +12,13 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
 
   val compile: ScallopOption[Boolean] = toggle(
     "compile",
-    descrYes = "Only compile the Effekt program to a backend specific executable",
-    descrNo = "Compile and run the effekt program in the interpreter",
+    descrYes = "Compile the Effekt program to the backend specific representation",
+    default = Some(false)
+  )
+  
+  val build: ScallopOption[Boolean] = toggle(
+    "build",
+    descrYes = "Compile the Effekt program and build a backend specific executable",
     default = Some(false)
   )
 

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -4,9 +4,8 @@ import effekt.context.Context
 import effekt.util.messages.FatalPhaseError
 import effekt.util.paths.{File, file}
 import effekt.util.getOrElseAborting
-import kiama.util.IO
 
-import java.lang.reflect.Executable
+import kiama.util.IO
 
 /**
  * Interface used by [[Driver]] and [[EffektTests]] to run a compiled program.
@@ -103,8 +102,13 @@ object JSRunner extends Runner[String] {
 
   def build(path: String)(using C: Context): String =
     val out = C.config.outputPath()
-    val jsFile = (out / path).unixPath
-    s"require('${jsFile}').main().run()"
+    val jsFilePath = (out / path).unixPath
+    // create "executable" using shebang besides the .js file
+    val jsScriptFilePath = (out / path.stripSuffix(s".$extension")).unixPath
+    val jsScript = s"require('${jsFilePath}').main().run()"
+    val shebang = "#!/usr/bin/env node"
+    IO.createFile(jsScriptFilePath, s"$shebang\n$jsScript")
+    jsScript
 
   def eval(path: String)(using C: Context): Unit =
     val jsScript = build(path)


### PR DESCRIPTION
This issue addresses #254 (and #273). 

# Changes

In the `Runner` we now have two methods, `build` just for building an executable and `eval` for then evaluating (running) said executable. Furthermore, we now have one new flag in addition to the `--compile` flag, which also has been reworked.
- The `--build` flag builds executables when selecting certain backends (LLVM and MLton) instead of only outputting the transpiled code. This option overwrites the `--compile` option, as the transpiled code is needed for building.
- The `--compile` flag only outputs (saves) the transpiled code.

# Discussion

I am not quite sure how to handle the ChezScheme and JS backend in terms of "building" an executable. Prepending a shebang (`#!/usr/bin/env node ...`) only works on UNIX systems. Furthermore, this would require more drastic changes to the current implementation, as I would need to edit the pretty-printed output of `Compiler.compile` in the respective runner, which is currently not available in the `Runner`.