### PR TITLE
fix currentTimeNanos to return nanos, not micros

### DIFF
--- a/libraries/js/effekt.effekt
+++ b/libraries/js/effekt.effekt
@@ -239,7 +239,7 @@ def repeat(n: Int) { action: () => Unit } = each(0, n) { n => action() }
 // Current time in nanoseconds
 // TODO use a better timer
 extern control def currentTimeNanos(): Int =
-  "$effekt.delayed(() => new Date().getTime() * 1000)"
+  "$effekt.delayed(() => new Date().getTime() * 1000000)"
 
 extern io def setTimeout(callback: () => Unit at {}, timeout: Int): Unit =
   "(function() { window.setTimeout(() => callback().run(), timeout); return $effekt.unit; })()"


### PR DESCRIPTION
tested locally with:
```scala
def main() = {
    var time = currentTimeNanos();
    var timeMillis = time / 1000000;
    println("time millis: " ++ show(timeMillis))
}
```
and checked returned millis at https://currentmillis.com/

fixes #301 