### PR TITLE
JS backend: Do not drop first element for Array.toList (fixes #319)

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/ChezSchemeTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ChezSchemeTests.scala
@@ -23,6 +23,7 @@ abstract class ChezSchemeTests extends EffektTests {
     examplesDir / "ml",
 
     examplesDir / "pos" / "arrays.effekt",
+    examplesDir / "pos" / "issue319.effekt",
     examplesDir / "pos" / "maps.effekt",
 
     // bidirectional effects are not yet supported in our Chez backend

--- a/effekt/jvm/src/test/scala/effekt/MLTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/MLTests.scala
@@ -92,6 +92,7 @@ class MLTests extends EffektTests {
 
     // array api
     examplesDir / "pos" / "raytracer.effekt",
+    examplesDir / "pos" / "issue319.effekt",
 
     // async
     examplesDir / "pos" / "io" / "async_file_io.effekt",

--- a/examples/pos/issue319.check
+++ b/examples/pos/issue319.check
@@ -1,0 +1,1 @@
+Cons(1, Cons(2, Cons(3, Nil())))

--- a/examples/pos/issue319.effekt
+++ b/examples/pos/issue319.effekt
@@ -1,0 +1,6 @@
+import mutable/array
+
+def main() = {
+  val array = arrayFromList([1,2,3]);
+  println(array.toList)
+}

--- a/libraries/js/mutable/array.effekt
+++ b/libraries/js/mutable/array.effekt
@@ -52,7 +52,7 @@ extern pure def copy[T](arr: Array[T]): Array[T] =
 def toList[T](arr: Array[T]): List[T] = {
   var i = arr.size - 1;
   var l = Nil[T]()
-  while (i > 0) {
+  while (i >= 0) {
     l = Cons(unsafeGet(arr, i), l)
     i = i - 1
   }


### PR DESCRIPTION
Fixes #319.