### PR TITLE
Fix Renamer to conform to contract given in docs

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
@@ -150,28 +150,27 @@ class RenamerTests extends CoreTests {
 
     assertRenamedTo(input, expected)
   }
-  // TODO this needs to be fixed
-  //  test("shadowing let bindings"){
-  //    val input =
-  //      """ module main
-  //        |
-  //        | def main = { () =>
-  //        |   let x = 1
-  //        |   let x = 2
-  //        |   return x:Int
-  //        | }
-  //        |""".stripMargin
-  //
-  //    val expected =
-  //      """ module main
-  //        |
-  //        | def main = { () =>
-  //        |   let renamed1 = 1
-  //        |   let renamed2 = 2
-  //        |   return renamed2:Int
-  //        | }
-  //        |""".stripMargin
-  //
-  //    assertRenamedTo(input, expected)
-  //  }
+  test("shadowing let bindings"){
+    val input =
+      """ module main
+        |
+        | def main = { () =>
+        |   let x = 1
+        |   let x = 2
+        |   return x:Int
+        | }
+        |""".stripMargin
+
+    val expected =
+      """ module main
+        |
+        | def main = { () =>
+        |   let renamed1 = 1
+        |   let renamed2 = 2
+        |   return renamed2:Int
+        | }
+        |""".stripMargin
+
+    assertRenamedTo(input, expected)
+  }
 }


### PR DESCRIPTION
Fixes the problem noted in https://github.com/effekt-lang/effekt/pull/316#discussion_r1413046445 ,
and should make the output Barendregt unless the generated names (prefix + number / original name + number) are already in use.

@b-studios .