### PR TITLE
Fix missing code snippet ending

### DIFF
--- a/examples/casestudies/anf.effekt.md
+++ b/examples/casestudies/anf.effekt.md
@@ -185,3 +185,4 @@ def main() = {
   println("----")
   println(pipeline("let x = (let y = f(42) in 1) in 42"))
 }
+```


### PR DESCRIPTION
The code snippet in the anf casestudy was missing a final code snippet ending (` ``` `). The error can also be seen at the bottom of the corresponding [website page](https://effekt-lang.org/docs/casestudies/anf).