### PR TITLE
Add sbt task for building the JS file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val deploy = taskKey[Unit]("Builds the jar and moves it to the bin folder")
 lazy val generateLicenses = taskKey[Unit]("Analyses dependencies and downloads all licenses")
 lazy val updateVersions = taskKey[Unit]("Update version in package.json and pom.xml")
 lazy val install = taskKey[Unit]("Installs the current version locally")
+lazy val assembleJS = taskKey[Unit]("Assemble the JS file in out/effekt.js")
 lazy val assembleBinary = taskKey[Unit]("Assembles the effekt binary in bin/effekt")
 lazy val generateDocumentation = taskKey[Unit]("Generates some documentation.")
 
@@ -166,6 +167,15 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
     bench             := benchmarks.measure.value
   )
   .jsSettings(
+
+    assembleJS := {
+      (Compile / clean).value
+      (Compile / compile).value
+      val resultDir = (Compile / fastLinkJSOutput).value
+      val jsFile = IO.listFiles(resultDir, "main.js")(0)
+      val outputFile = (ThisBuild / baseDirectory).value / "out" / "effekt.js"
+      IO.copyFile(jsFile, outputFile)
+    },
 
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
 


### PR DESCRIPTION
This PR adds a sbt task for building the JS file conveniently. The resulting file is saved under `out/effekt.js` and is to be used by the [website's](https://github.com/effekt-lang/effekt-website) "update compiler" workflow so that we can get rid of this hacky part [here](https://github.com/effekt-lang/effekt-website/blob/26493b1a1063dea79c33df9f3e45be789118c37c/.github/workflows/update-compiler.yml#L30).