### PR TITLE
Fix "Annotate Captures" feature of the VSCode extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ licenses/
 bin
 .metals/
 .vscode/
+.bloop/
 *.tgz
 
 notes/

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -82,7 +82,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
         }
 
         // we are in one of three exclusive modes: LSPServer, Compile, Run
-        if (config.server()) { compiler.runFrontend(src) }
+        if (config.server()) { compiler.runMiddleend(src) }
         else if (config.interpret()) { compile() foreach runner.eval }
         else if (config.build()) { compile() foreach runner.build }  
         else if (config.compile()) { compile() }

--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -125,13 +125,14 @@ trait Compiler[Executable] {
       mod
     }
 
-  def runMiddleend(source: Source)(using Context): Option[Typechecked] =
-    (Parser andThen
-    Namer andThen
-    BoxUnboxInference andThen
-    Typer andThen
-    Wellformedness andThen
-    AnnotateCaptures)(source)
+  /**
+   * Used by the server to typecheck, report type errors and show
+   * captures at boxes and definitions 
+   */
+  def runMiddleend(source: Source)(using Context): Option[Module] =
+    val typechecked = Frontend(source)
+    typechecked.foreach(res => validate(source, res.mod))
+    typechecked.flatMap(Middleend.run).map(_.mod)
 
   /**
    * Called after running the frontend from editor services.

--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -130,9 +130,10 @@ trait Compiler[Executable] {
    * captures at boxes and definitions 
    */
   def runMiddleend(source: Source)(using Context): Option[Module] =
-    val typechecked = Frontend(source)
-    typechecked.foreach(res => validate(source, res.mod))
-    typechecked.flatMap(Middleend.run).map(_.mod)
+    (Frontend andThen Middleend)(source).map { res => 
+      validate(res.source, res.mod)
+      res.mod
+    }
 
   /**
    * Called after running the frontend from editor services.

--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -125,6 +125,14 @@ trait Compiler[Executable] {
       mod
     }
 
+  def runMiddleend(source: Source)(using Context): Option[Typechecked] =
+    (Parser andThen
+    Namer andThen
+    BoxUnboxInference andThen
+    Typer andThen
+    Wellformedness andThen
+    AnnotateCaptures)(source)
+
   /**
    * Called after running the frontend from editor services.
    *

--- a/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
+++ b/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
@@ -19,6 +19,8 @@ object AnnotateCaptures extends Phase[Typechecked, Typechecked], Query[Unit, Cap
   val phaseName = "annotate-captures"
 
   def run(input: Typechecked)(using C: Context) =
+    // reset allCaptures since multiple runs of this phase may pollute it with outdated information
+    allCaptures = Nil
     annotate(input.tree, input.source)
     Some(input)
 


### PR DESCRIPTION
## Description

The VSCode extension has the feature to annotate the captures of boxes and definitions. Currently, however, the VSCode extension does not show any captures since the relevant phase of the compiler ([AnnotateCaptures](https://github.com/effekt-lang/effekt/blob/c918d0d68e758169be0b2be1bc44971ca90c5167/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala#L17)) is not run. Thus, this PR introduces the following changes:

- Extend the phases run by the language server to also include wellformedness checks and the annotation of captures
- A subtle bug caused old captures information to be shown on previously seen files. Therefore, each time the `AnnotateCaptures` phase is run, the information about the collected captures has to be reset (`allCaptures`).

## Discussion

We may need to keep an eye on the responsiveness of the language server due to increased number of phases run. However, so far I have not noticed any slowdowns. 