### PR TITLE
Feature/core constructor

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/MLTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/MLTests.scala
@@ -84,6 +84,7 @@ class MLTests extends EffektTests {
     examplesDir / "casestudies" / "lexer.effekt.md",
     examplesDir / "casestudies" / "parser.effekt.md",
     examplesDir / "casestudies" / "prettyprinter.effekt.md",
+    examplesDir / "benchmarks" / "pretty.effekt",
     examplesDir / "pos" / "simpleparser.effekt",
 
     // cont

--- a/effekt/jvm/src/test/scala/effekt/core/PolymorphismBoxingTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/PolymorphismBoxingTests.scala
@@ -42,7 +42,6 @@ abstract class AbstractPolymorphismBoxingTests extends CorePhaseTests(Polymorphi
   )
 }
 class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
-
   test("simple non-polymorphic code should stay the same"){
     val code =
       """module main
@@ -87,7 +86,7 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
       """module main
         |
         |def id = { ['A](a: 'A) => return a: 'A }
-        |def idInt = { (x: Int) => return (id: ['A]('A) => 'A @ {})[BoxedInt]((MkBoxedInt: (Int) => BoxedInt @ {})(x: Int)).unboxInt: Int }
+        |def idInt = { (x: Int) => return (id: ['A]('A) => 'A @ {})[BoxedInt](make BoxedInt MkBoxedInt(x: Int)).unboxInt: Int }
         |""".stripMargin
     assertTransformsTo(from, to)
   }
@@ -103,7 +102,7 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
       """module main
         |
         |def id = { ['A](a: 'A) => return a: 'A }
-        |def idInt = { (x: Int) => val tmp = (id: ['A]('A) => 'A @ {})[BoxedInt]((MkBoxedInt: (Int) => BoxedInt @ {})(x: Int)) ; return tmp:BoxedInt.unboxInt: Int }
+        |def idInt = { (x: Int) => val tmp = (id: ['A]('A) => 'A @ {})[BoxedInt](make BoxedInt MkBoxedInt(x: Int)) ; return tmp:BoxedInt.unboxInt: Int }
         |""".stripMargin
     assertTransformsTo(from, to)
   }
@@ -127,7 +126,7 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
         |def idInt = { (x: Int) =>
         |    {
         |        let res = run {
-        |            let boxedRes = !(id: ['A]('A) => 'A @ {})[BoxedInt]((MkBoxedInt: (Int) => BoxedInt @ {})(x: Int))
+        |            let boxedRes = !(id: ['A]('A) => 'A @ {})[BoxedInt](make BoxedInt MkBoxedInt(x: Int))
         |            return boxedRes:BoxedInt.unboxInt: Int
         |        }
         |        return res: Int
@@ -151,7 +150,7 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
         |      {
         |         def originalFn = { (x: Int) => return x: Int }
         |         val result = (originalFn: (Int) => Int @ {})(boxedX: BoxedInt.unboxInt: Int);
-        |         return (MkBoxedInt: (Int) => BoxedInt @ {})(result: Int)
+        |         return make BoxedInt MkBoxedInt(result: Int)
         |      }
         |    };
         |    return r:BoxedInt.unboxInt: Int
@@ -182,11 +181,11 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
         |                  (hhofargarg: Int) =>
         |                      {
         |                        def tmp = hhofargB: ('A) => 'A @ {}
-        |                        val rres = (tmp: ('A) => 'A @ {})((MkBoxedInt: (Int) => BoxedInt @ {})(hhofargarg: Int));
+        |                        val rres = (tmp: ('A) => 'A @ {})(make BoxedInt MkBoxedInt(hhofargarg: Int));
         |                        return rres:BoxedInt.unboxInt: Int
         |                      }
         |              };
-        |              return (MkBoxedInt: (Int) => BoxedInt @ {})(res:Int)
+        |              return make BoxedInt MkBoxedInt(res:Int)
         |          }
         |    };
         |    return result:BoxedInt.unboxInt: Int

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -1237,32 +1237,6 @@ object Typer extends Phase[NameResolved, Typechecked] {
       Context.annotateInferredEffects(t, effs.toEffects)
       Result(got, effs)
     }
-
-  /**
-   * Helper methods on function symbols to retreive its type
-   * either from being annotated or by looking it up (if already typechecked...)
-   */
-  extension (fun: Callable)(using Context) {
-    // invariant: only works if ret is defined!
-    def toType: FunctionType =
-      annotatedType.get
-    def toType(ret: ValueType, effects: Effects, capabilityParams: List[Capture]): FunctionType =
-      val bcapt = fun.bparams.map { p => p.capture }
-      val tps = fun.tparams
-      val vps = fun.vparams.map { p => p.tpe.get }
-      val bps = fun.bparams.map { p => p.tpe }
-      FunctionType(tps, bcapt ++ capabilityParams, vps, bps, ret, effects)
-
-    def annotatedType: Option[FunctionType] =
-      for {
-        ret <- fun.annotatedResult;
-        effs <- fun.annotatedEffects
-        effects = effs.distinct
-        // TODO currently the return type cannot refer to the annotated effects, so we can make up capabilities
-        //   in the future namer needs to annotate the function with the capture parameters it introduced.
-        capt = effects.canonical.map { tpe => CaptureParam(tpe.name) }
-      } yield toType(ret, effects, capt)
-  }
   //</editor-fold>
 
 }

--- a/effekt/shared/src/main/scala/effekt/core/Deadcode.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Deadcode.scala
@@ -138,7 +138,7 @@ class Reachable(
     case Pure.ValueVar(id, annotatedType) => process(id)
     case Pure.Literal(value, annotatedType) => ()
     case Pure.PureApp(b, targs, vargs) => process(b); vargs.foreach(process)
-    case Pure.Make(id, tpe, targs, vargs) => process(id); vargs.foreach(process)
+    case Pure.Make(data, tag, vargs) => process(tag); vargs.foreach(process)
     case Pure.Select(target, field, annotatedType) => process(target)
     case Pure.Box(b, annotatedCapture) => process(b)
   }

--- a/effekt/shared/src/main/scala/effekt/core/Deadcode.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Deadcode.scala
@@ -138,6 +138,7 @@ class Reachable(
     case Pure.ValueVar(id, annotatedType) => process(id)
     case Pure.Literal(value, annotatedType) => ()
     case Pure.PureApp(b, targs, vargs) => process(b); vargs.foreach(process)
+    case Pure.Make(id, tpe, targs, vargs) => process(id); vargs.foreach(process)
     case Pure.Select(target, field, annotatedType) => process(target)
     case Pure.Box(b, annotatedCapture) => process(b)
   }

--- a/effekt/shared/src/main/scala/effekt/core/Inline.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Inline.scala
@@ -159,6 +159,7 @@ object Inline {
 
   def rewrite(p: Pure)(using InlineContext): Pure = p match {
     case Pure.PureApp(b, targs, vargs) => pureApp(rewrite(b), targs, vargs.map(rewrite))
+    case Pure.Make(id, tpe, targs, vargs) => make(id, tpe, targs, vargs.map(rewrite))
     // currently, we don't inline values, but we can dealias them
     case x @ Pure.ValueVar(id, annotatedType) => dealias(x)
 

--- a/effekt/shared/src/main/scala/effekt/core/Inline.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Inline.scala
@@ -159,7 +159,7 @@ object Inline {
 
   def rewrite(p: Pure)(using InlineContext): Pure = p match {
     case Pure.PureApp(b, targs, vargs) => pureApp(rewrite(b), targs, vargs.map(rewrite))
-    case Pure.Make(id, tpe, targs, vargs) => make(id, tpe, targs, vargs.map(rewrite))
+    case Pure.Make(data, tag, vargs) => make(data, tag, vargs.map(rewrite))
     // currently, we don't inline values, but we can dealias them
     case x @ Pure.ValueVar(id, annotatedType) => dealias(x)
 

--- a/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
@@ -308,7 +308,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
   class FunctionIdentityCoercer[Ty <: BlockType, Te <: Block](
       from: Ty, to: Ty, targs: List[ValueType]) extends IdentityCoercer[Ty, Te](from, to) with FunctionCoercer[Ty, Te] {
     override def call(block: Te, vargs: List[Pure], bargs: List[Block])(using PContext): Stmt =
-      Stmt.App(block, targs map transformArg, vargs.map(transform(_)), bargs map transform)
+      Stmt.App(block, targs map transformArg, vargs.map(transform), bargs map transform)
     override def callPure(block: Te, vargs: List[Pure])(using PContext): Pure =
       Pure.PureApp(block, targs map transformArg, vargs map transform)
     override def callDirect(block: Te, vargs: List[Pure], bargs: List[Block])(using PContext): Expr =

--- a/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
@@ -204,8 +204,8 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
   def transform(pure: Pure)(using PContext): Pure = pure match {
     case Pure.ValueVar(id, annotatedType) => Pure.ValueVar(id, transform(annotatedType))
     case Pure.Literal(value, annotatedType) => Pure.Literal(value, transform(annotatedType))
-    case Pure.PureApp(b, targs, vargs) =>
-      instantiate(b, targs).callPure(b, vargs map transform)
+    case Pure.PureApp(b, targs, vargs) => instantiate(b, targs).callPure(b, vargs map transform)
+    case m : Pure.Make => ???
     case Pure.Select(target, field, annotatedType) => {
       val (symbol, targs) = target.tpe match {
         case ValueType.Data(symbol, targs) => (symbol, targs)

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -84,8 +84,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Literal(value, _)         => value.toString
     case ValueVar(id, _)           => toDoc(id)
 
-    case PureApp(b, targs, vargs)   => toDoc(b) <> argsToDoc(targs, vargs, Nil)
-    case Make(b, tpe, targs, vargs)   => toDoc(b) <> argsToDoc(targs, vargs, Nil)
+    case PureApp(b, targs, vargs)  => toDoc(b) <> argsToDoc(targs, vargs, Nil)
+    case Make(data, tag, vargs)    => "make" <+> toDoc(data) <+> toDoc(tag) <> argsToDoc(Nil, vargs, Nil)
     case DirectApp(b, targs, vargs, bargs) => toDoc(b) <> argsToDoc(targs, vargs, bargs)
 
     case Select(b, field, tpe) => toDoc(b) <> "." <> toDoc(field)

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -85,6 +85,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case ValueVar(id, _)           => toDoc(id)
 
     case PureApp(b, targs, vargs)   => toDoc(b) <> argsToDoc(targs, vargs, Nil)
+    case Make(b, tpe, targs, vargs)   => toDoc(b) <> argsToDoc(targs, vargs, Nil)
     case DirectApp(b, targs, vargs, bargs) => toDoc(b) <> argsToDoc(targs, vargs, bargs)
 
     case Select(b, field, tpe) => toDoc(b) <> "." <> toDoc(field)

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -504,7 +504,9 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
         DirectApp(BlockVar(f), targs, vargsT, bargsT)
       case r: Constructor =>
         if (bargs.nonEmpty) Context.abort("Constructors cannot take block arguments.")
-        PureApp(BlockVar(r), targs, vargsT)
+        // TODO how robust is this?
+        val tpe = transform(Context.inferredTypeOf(call))
+        Make(r, tpe, targs, vargsT)
       case f: Operation =>
         Context.panic("Should have been translated to a method call!")
       case f: Field =>

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -245,7 +245,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
             assert(effects.isEmpty)
             assert(cparams.isEmpty)
             BlockLit(tparams, Nil, vparams, Nil,
-              Stmt.Return(Make(b, core.ValueType.Data(b.tpe, targs), targs, vargs)))
+              Stmt.Return(Make(core.ValueType.Data(b.tpe, targs), b, vargs)))
           }
 
           // [[ f ]] = { (x){g} => let r = f(x){g}; return r }
@@ -486,7 +486,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
         val substitution = Substitutions((tparams zip targs).toMap, Map.empty)
         val remainingTypeParams = tparams.drop(targs.size)
         val bparams = Nil
-        // TODO this is exactly like in [[Typer.toType]] -- TODO repeated here:
+        // TODO this is exactly like in [[Callable.toType]] -- TODO repeated here:
         // TODO currently the return type cannot refer to the annotated effects, so we can make up capabilities
         //   in the future namer needs to annotate the function with the capture parameters it introduced.
         val cparams = effects.canonical.map { tpe => symbols.CaptureParam(tpe.name) }
@@ -513,9 +513,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
         DirectApp(BlockVar(f), targs, vargsT, bargsT)
       case r: Constructor =>
         if (bargs.nonEmpty) Context.abort("Constructors cannot take block arguments.")
-        // TODO how robust is this?
-        val tpe = transform(Context.inferredTypeOf(call))
-        Make(r, tpe, targs, vargsT)
+        Make(core.ValueType.Data(r.tpe, targs), r, vargsT)
       case f: Operation =>
         Context.panic("Should have been translated to a method call!")
       case f: Field =>

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -25,6 +25,10 @@ import effekt.util.messages.INTERNAL_ERROR
  *     │  │─ [[ Def ]]
  *     │  │─ [[ Include ]]
  *     │
+ *     │─ [[ Definition ]]
+ *     │  │─ [[ Def ]]
+ *     │  │─ [[ Let ]]
+ *     │
  *     │─ [[ Expr ]]
  *     │  │─ [[ DirectApp ]]
  *     │  │─ [[ Run ]]
@@ -163,6 +167,7 @@ case class Run(s: Stmt) extends Expr
  *     │─ [[ ValueVar ]]
  *     │─ [[ Literal ]]
  *     │─ [[ PureApp ]]
+ *     │─ [[ Make ]]
  *     │─ [[ Select ]]
  *     │─ [[ Box ]]
  *

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -206,6 +206,7 @@ object Type {
     case Pure.ValueVar(id, tpe) => tpe
     case Pure.Literal(value, tpe) => tpe
     case Pure.PureApp(callee, targs, args) => instantiate(callee.functionType, targs, Nil).result
+    case Pure.Make(id, tpe, targs, args) => tpe
     case Pure.Select(target, field, annotatedType) => annotatedType
     case Pure.Box(block, capt) => ValueType.Boxed(block.tpe, capt)
   }

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -206,7 +206,7 @@ object Type {
     case Pure.ValueVar(id, tpe) => tpe
     case Pure.Literal(value, tpe) => tpe
     case Pure.PureApp(callee, targs, args) => instantiate(callee.functionType, targs, Nil).result
-    case Pure.Make(id, tpe, targs, args) => tpe
+    case Pure.Make(tpe, tag, args) => tpe
     case Pure.Select(target, field, annotatedType) => annotatedType
     case Pure.Box(block, capt) => ValueType.Boxed(block.tpe, capt)
   }

--- a/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
@@ -203,7 +203,7 @@ trait Transformer {
 
     case DirectApp(b, targs, vargs, bargs) => chez.Call(toChez(b), vargs.map(toChez) ++ bargs.map(toChez))
     case PureApp(b, targs, args) => chez.Call(toChez(b), args map toChez)
-    case Make(id, tpe, targs, args) => chez.Call(chez.Variable(nameRef(id)), args map toChez)
+    case Make(data, tag, args) => chez.Call(chez.Variable(nameRef(tag)), args map toChez)
 
     case Select(b, field, _) =>
       chez.Call(nameRef(field), toChez(b))

--- a/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
@@ -203,6 +203,7 @@ trait Transformer {
 
     case DirectApp(b, targs, vargs, bargs) => chez.Call(toChez(b), vargs.map(toChez) ++ bargs.map(toChez))
     case PureApp(b, targs, args) => chez.Call(toChez(b), args map toChez)
+    case Make(id, tpe, targs, args) => chez.Call(chez.Variable(nameRef(id)), args map toChez)
 
     case Select(b, field, _) =>
       chez.Call(nameRef(field), toChez(b))

--- a/effekt/shared/src/main/scala/effekt/generator/chez/TransformerLift.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/TransformerLift.scala
@@ -287,7 +287,7 @@ object TransformerLift {
     case Literal(b: Boolean, _) => if (b) chez.RawValue("#t") else chez.RawValue("#f")
     case l: Literal => chez.RawValue(l.value.toString)
     case ValueVar(id, _)  => chez.Variable(nameRef(id))
-
+    case Make(data, tag, args) => chez.Call(nameRef(tag), args map toChez)
     case PureApp(b, targs, args) => chez.Call(toChez(b), args map {
       case e: Expr  => toChez(e)
       case b: Block => toChez(b)

--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -16,6 +16,9 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def format(stmts: List[Stmt]): Document =
     pretty(vsep(stmts map toDoc, line))
 
+  val show: PartialFunction[Any, String] = {
+    case m: js.Module  => format(m.stmts).layout
+  }
 
   def toDoc(expr: Expr): Doc = expr match {
     case Call(callee, args)           => toDocParens(callee) <> parens(args map toDoc)

--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -16,9 +16,11 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def format(stmts: List[Stmt]): Document =
     pretty(vsep(stmts map toDoc, line))
 
+
   def toDoc(expr: Expr): Doc = expr match {
     case Call(callee, args)           => toDocParens(callee) <> parens(args map toDoc)
-    case RawExpr(raw)                 => string(raw)
+    case New(callee, args)            => "new" <+> toDocParens(callee) <> parens(args map toDoc)
+    case RawExpr(strings, args)       => hcat(intercalate(strings.map(string), args.map(toDoc)))
     case Member(callee, selection)    => toDocParens(callee) <> "." <> toDoc(selection)
     case IfExpr(cond, thn, els)       => parens(parens(toDoc(cond)) <+> "?" <+> toDoc(thn) <+> ":" <+> toDoc(els))
     case Lambda(params, Return(expr)) => parens(params map toDoc) <+> "=>" <> nested(toDoc(expr))
@@ -46,6 +48,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Destruct(ids, expr)           => "const" <+> braces(hsep(ids.map(toDoc), comma)) <+> "=" <+> toDoc(expr) <> ";"
     case Assign(target, expr)          => toDoc(target) <+> "=" <+> toDoc(expr) <> ";"
     case Function(name, params, stmts) => "function" <+> toDoc(name) <> parens(params map toDoc) <+> jsBlock(stmts map toDoc)
+    case Class(name, methods)          => "class" <+> toDoc(name) <+> jsBlock(methods.map(jsMethod))
+    case If(cond, thn, Block(Nil))     => "if" <+> parens(toDoc(cond)) <+> toDoc(thn)
     case If(cond, thn, els)            => "if" <+> parens(toDoc(cond)) <+> toDoc(thn) <+> "else" <+> toDoc(els)
     case Try(prog, id, handler, Nil)   => "try" <+> jsBlock(prog.map(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.map(toDoc))
     case Try(prog, id, handler, fin)    => "try" <+> jsBlock(prog.map(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.map(toDoc)) <+> "finally" <+> jsBlock(fin.map(toDoc))
@@ -61,6 +65,11 @@ object PrettyPrinter extends ParenPrettyPrinter {
     } ++ default.toList.map { stmts => "default:" <+> nested(stmts map toDoc) })
   }
 
+  def jsMethod(c: js.Function): Doc = c match {
+    case js.Function(name, params, stmts) =>
+      toDoc(name) <> parens(params map toDoc) <+> jsBlock(stmts.map(toDoc))
+  }
+
   def toDoc(pattern: Pattern): Doc = pattern match {
     case Pattern.Variable(name) => toDoc(name)
     case Pattern.Array(ps) => brackets(ps map toDoc)
@@ -69,6 +78,11 @@ object PrettyPrinter extends ParenPrettyPrinter {
   // some helpers
 
   val emptyline: Doc = line <> line
+
+  def intercalate[A](a : List[A], b : List[A]): List[A] = a match {
+    case first :: rest => first :: intercalate(b, rest)
+    case _             => b
+  }
 
   def nested(content: Doc): Doc = group(nest(line <> content))
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
@@ -87,15 +87,38 @@ trait Transformer {
 
   def generateConstructor(constructor: Constructor, tagValue: Int): js.Stmt = {
     val fields = constructor.fields
-    js.Function(
-      nameDef(constructor.id),
-      fields.map { f => nameDef(f.id) },
-      List(js.Return(js.Object(List(
-        `tag`  -> js.RawExpr(tagValue.toString),
-        `name` -> JsString(constructor.id.name.name),
-        `data` -> js.ArrayLiteral(fields map { f => js.Variable(nameDef(f.id)) })
-      ) ++ fields.map { f => (nameDef(f.id), js.Variable(nameDef(f.id))) })))
-    )
+    // class Id {
+    //   constructor(param...) { this.param = param; ...  }
+    //   __reflect() { return { name: "NAME", data: [this.param...] }
+    //   __equals(other) { ... }
+    // }
+    val params = fields.map { f => nameDef(f.id) }
+
+    def set(field: JSName, value: js.Expr): js.Stmt = js.Assign(js.Member(js"this", field), value)
+    def get(field: JSName): js.Expr = js.Member(js"this", field)
+
+    val initParams = params.map { param => set(param, js.Variable(param))  }
+    val initTag    = set(`tag`, js.RawExpr(tagValue.toString))
+    val jsConstructor: js.Function = js.Function(JSName("constructor"), params, initTag :: initParams)
+
+    val jsReflect: js.Function = js.Function(`reflect`, Nil, List(js.Return(js.Object(List(
+      `tag`  -> js.RawExpr(tagValue.toString),
+      `name` -> JsString(constructor.id.name.name),
+      `data` -> js.ArrayLiteral(fields map { f => get(memberNameRef(f.id)) }))))))
+
+    val other = freshName("other")
+    def otherGet(field: JSName): js.Expr = js.Member(js.Variable(other), field)
+    def compare(field: JSName): js.Expr = js"${get(field)} !== ${otherGet(field)}"
+    val noop    = js.Block(Nil)
+    val abort   = js.Return(js"false")
+    val succeed = js.Return(js"true")
+    val otherExists   = js.If(js"!${js.Variable(other)}", abort, noop)
+    val compareTags   = js.If(compare(`tag`), abort, noop)
+    val compareFields = params.map(f => js.If(compare(f), abort, noop))
+
+    val jsEquals: js.Function = js.Function(`equals`, List(other), otherExists :: compareTags :: compareFields ::: List(succeed))
+
+    js.Class(nameDef(constructor.id), List(jsConstructor, jsReflect, jsEquals))
   }
 
   // const $getOp = "get$1234"
@@ -140,6 +163,8 @@ trait Transformer {
   val `tag`   = JSName("__tag")
   val `name`  = JSName("__name")
   val `data`  = JSName("__data")
+  val `reflect`  = JSName("__reflect")
+  val `equals`  = JSName("__equals")
 
   def nameDef(id: Symbol): JSName = uniqueName(id)
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
@@ -204,12 +204,16 @@ trait Transformer {
 
     // Traverse tree once more to find all used symbols, defined in other modules.
     def findUsedDependencies(t: Definition) =
-      Tree.visit(t) {
+      def go(t: Any): Unit = Tree.visit(t) {
         case BlockVar(x, tpe, capt) if publicDependencySymbols.isDefinedAt(x) =>
           register(publicDependencySymbols(x), x)
         case ValueVar(x, tpe) if publicDependencySymbols.isDefinedAt(x) =>
           register(publicDependencySymbols(x), x)
+        case Make(tpe, id, args) if publicDependencySymbols.isDefinedAt(id) =>
+          register(publicDependencySymbols(id), id)
+          args.foreach(go)
       }
+      go(t)
 
     input.core.definitions.foreach(findUsedDependencies)
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
@@ -120,7 +120,8 @@ object TransformerDirect extends Transformer {
     case literal: Literal => js.RawExpr(literal.value.toString)
     case ValueVar(id, tpe) => nameRef(id)
     case DirectApp(b, targs, vargs, bargs) => js.Call(toJS(b), vargs.map(toJS) ++ bargs.map(toJS))
-    case PureApp(b, targs, args) => js.Call(toJS(b), args map toJS)
+    case PureApp(b, targs, vargs) => js.Call(toJS(b), vargs map toJS)
+    case Make(id, tpe, targs, vargs) => js.Call(nameRef(id), vargs map toJS)
     case Select(target, field, _) => js.Member(toJS(target), memberNameRef(field))
     case Box(b, _) => toJS(b)
     case Run(s) => toJS(s)(Continuation.Return) match {

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
@@ -121,7 +121,7 @@ object TransformerDirect extends Transformer {
     case ValueVar(id, tpe) => nameRef(id)
     case DirectApp(b, targs, vargs, bargs) => js.Call(toJS(b), vargs.map(toJS) ++ bargs.map(toJS))
     case PureApp(b, targs, vargs) => js.Call(toJS(b), vargs map toJS)
-    case Make(id, tpe, targs, vargs) => js.Call(nameRef(id), vargs map toJS)
+    case Make(tpe, tag, vargs) => js.Call(nameRef(tag), vargs map toJS)
     case Select(target, field, _) => js.Member(toJS(target), memberNameRef(field))
     case Box(b, _) => toJS(b)
     case Run(s) => toJS(s)(Continuation.Return) match {

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
@@ -79,27 +79,29 @@ object TransformerMonadic extends Transformer {
   def toJS(handler: core.Implementation, prompt: js.Expr)(using DeclarationContext, Context): js.Expr =
     js.Object(
       handler.operations.map {
-      //        // (args...cap...) => $effekt.suspend(prompt, (resume) => { ... body ... resume((cap...) => { ... }) ... })
-      //        case Operation(id, tps, cps, vps, bps,
-      //            Some(BlockParam(resume, core.BlockType.Function(_, _, _, List(core.BlockType.Function(_, _, _, bidirectionalTpes, _)), _), _)),
-      //            body) =>
-      //          // add parameters for bidirectional arguments
-      //          val biParams = bidirectionalTpes.map { _ => freshName("cap") }
-      //          val biArgs   = biParams.map { p => js.Variable(p) }
-      //
-      //          val lambda = js.Lambda((vps ++ bps).map(toJS) ++ biParams,
-      //            js.Return($effekt.call("suspend_bidirectional", js.Variable(prompt), js.ArrayLiteral(biArgs), js.Lambda(List(nameDef(resume)),
-      //              C.clearingScope { js.Block(toJS(body)(Continuation.Return)) }))))
-      //
-      //          nameDef(id) -> lambda
-      //      })
+        // (args...cap...) => $effekt.shift(prompt, (resume) => { ... body ... resume((cap...) => { ... }) ... })
+        case Operation(id, tps, cps, vps, bps,
+            Some(BlockParam(resume, core.BlockType.Function(_, _, _, List(core.BlockType.Function(_, _, _, bidirectionalTpes, _)), _), _)),
+            body) =>
+          // add parameters for bidirectional arguments
+          val biParams = bidirectionalTpes.map { _ => freshName("cap") }
+          val biArgs   = biParams.map { p => js.Variable(p) }
+          val thunk    = freshName("thunk")
+          val force    = monadic.Call(js.Variable(thunk), biArgs)
+
+          val (stmts, ret) = toJSStmt(body)
+          val lambda = monadic.Lambda((vps ++ bps).map(toJS) ++ biParams, Nil,
+            monadic.Bind(monadic.Builtin("shift", prompt,
+              monadic.Lambda(List(nameDef(resume)), stmts, ret)), thunk, force))
+
+          nameDef(id) -> lambda
 
       // (args...) => $effekt.shift(prompt, (resume) => { ... BODY ... resume(v) ... })
       case Operation(id, tps, cps, vps, bps, Some(resume), body) =>
         val (stmts, ret) = toJSStmt(body)
-        val lambda = js.Lambda((vps ++ bps) map toJS,
-          js.Return($effekt.call("shift", prompt,
-            monadic.Lambda(List(toJS(resume)), stmts, ret))))
+        val lambda = monadic.Lambda((vps ++ bps) map toJS, Nil,
+          monadic.Builtin("shift", prompt,
+            monadic.Lambda(List(toJS(resume)), stmts, ret)))
 
         nameDef(id) -> lambda
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
@@ -63,6 +63,7 @@ object TransformerMonadic extends Transformer {
     case ValueVar(id, tpe) => nameRef(id)
     case DirectApp(b, targs, vargs, bargs) => js.Call(toJS(b), vargs.map(toJS) ++ bargs.map(toJS))
     case PureApp(b, targs, args) => js.Call(toJS(b), args map toJS)
+    case Make(id, tpe, targs, vargs) => js.Call(nameRef(id), vargs map toJS)
     case Select(target, field, _) => js.Member(toJS(target), memberNameRef(field))
     case Box(b, _) => toJS(b)
     case Run(s) => monadic.Run(toJSMonadic(s))

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
@@ -63,7 +63,7 @@ object TransformerMonadic extends Transformer {
     case ValueVar(id, tpe) => nameRef(id)
     case DirectApp(b, targs, vargs, bargs) => js.Call(toJS(b), vargs.map(toJS) ++ bargs.map(toJS))
     case PureApp(b, targs, args) => js.Call(toJS(b), args map toJS)
-    case Make(id, tpe, targs, vargs) => js.New(nameRef(id), vargs map toJS)
+    case Make(data, tag, vargs) => js.New(nameRef(tag), vargs map toJS)
     case Select(target, field, _) => js.Member(toJS(target), memberNameRef(field))
     case Box(b, _) => toJS(b)
     case Run(s) => monadic.Run(toJSMonadic(s))

--- a/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
@@ -2,11 +2,18 @@ package effekt
 package generator
 package js
 
+import scala.collection.immutable.{ AbstractSeq, LinearSeq }
+
 // TODO choose appropriate representation and apply conversions
 case class JSName(name: String)
 
-val $effekt = Variable(JSName("$effekt"))
-def builtin(name: String, args: Expr*): js.Expr = js.MethodCall($effekt, JSName(name), args: _*)
+object $effekt {
+  val namespace = Variable(JSName("$effekt"))
+  def field(name: String): js.Expr =
+    js.Member(namespace, JSName(name))
+  def call(name: String, args: js.Expr*): js.Expr =
+    js.MethodCall(namespace, JSName(name), args: _*)
+}
 
 enum Import {
   // import * as <name> from "<file>";
@@ -219,9 +226,9 @@ object monadic {
 
   def Call(callee: Expr, args: List[Expr]): Control = js.Call(callee, args)
   def If(cond: Expr, thn: Control, els: Control): Control = js.IfExpr(cond, thn, els)
-  def Handle(handlers: List[Expr], body: Expr): Control = js.Call(Builtin("handleMonadic", js.ArrayLiteral(handlers)), List(body))
+  def Handle(body: Expr): Control = Builtin("handleMonadic", body)
 
-  def Builtin(name: String, args: Expr*): Control = js.MethodCall($effekt, JSName(name), args: _*)
+  def Builtin(name: String, args: Expr*): Control = $effekt.call(name, args: _*)
 
   def Lambda(params: List[JSName], stmts: List[Stmt], ret: Control): Expr =
     js.Lambda(params, js.Block(stmts :+ js.Return(ret)))

--- a/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/ml/Transformer.scala
@@ -426,20 +426,16 @@ object Transformer {
       }
     case ValueVar(id, _) => ml.Variable(name(id))
 
+    case Make(data, tag, vargs) =>
+      ml.Expr.Make(name(tag), expsToTupleIsh(vargs map toML))
+
     case PureApp(b, _, args) =>
       val mlArgs = args map {
         case e: Expr => toML(e)
         case b: Block => toML(b)
         case e: Evidence => toML(e)
       }
-      b match {
-        // TODO do not use symbols here, but look up in module declaration
-        case BlockVar(id@symbols.Constructor(_, _, _, symbols.TypeConstructor.DataType(_, _, _)), _) =>
-          ml.Expr.Make(name(id), expsToTupleIsh(mlArgs))
-        case BlockVar(id@symbols.Constructor(_, _, _, symbols.TypeConstructor.Record(_, _, _)), _) =>
-          ml.Expr.Make(name(id), expsToTupleIsh(mlArgs))
-        case _ => ml.Call(toML(b), mlArgs)
-      }
+      ml.Call(toML(b), mlArgs)
 
     case Select(b, field, _) =>
       ml.Call(name(field))(toML(b))

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -233,8 +233,14 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
     case core.ValueVar(sym, tpe) =>
       ValueVar(sym, transform(tpe))
 
-    case core.PureApp(b: core.Block, targs, args: List[core.Expr]) =>
+    case core.PureApp(b, targs, args: List[core.Expr]) =>
       PureApp(transform(b), targs.map(transform), args map transform)
+
+    case core.Make(id, tpe, targs, args: List[core.Expr]) =>
+      // we need to rediscover the type of the constructor:
+      // we probably do not need a polymorphic type, though.
+      val constructorType = core.BlockType.Function(Nil, Nil, args.map(_.tpe), Nil, tpe)
+      PureApp(BlockVar(id, transform(constructorType)), targs.map(transform), args map transform)
 
     case core.Select(target, field, tpe) =>
       Select(transform(target), field, transform(tpe))

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -240,7 +240,7 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
       // we need to rediscover the type of the constructor:
       // we probably do not need a polymorphic type, though.
       val constructorType = core.BlockType.Function(Nil, Nil, args.map(_.tpe), Nil, tpe)
-      PureApp(BlockVar(id, transform(constructorType)), targs.map(transform), args map transform)
+      PureApp(BlockVar(id, transform(constructorType)), Nil, args map transform)
 
     case core.Select(target, field, tpe) =>
       Select(transform(target), field, transform(tpe))

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -236,11 +236,8 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
     case core.PureApp(b, targs, args: List[core.Expr]) =>
       PureApp(transform(b), targs.map(transform), args map transform)
 
-    case core.Make(id, tpe, targs, args: List[core.Expr]) =>
-      // we need to rediscover the type of the constructor:
-      // we probably do not need a polymorphic type, though.
-      val constructorType = core.BlockType.Function(Nil, Nil, args.map(_.tpe), Nil, tpe)
-      PureApp(BlockVar(id, transform(constructorType)), Nil, args map transform)
+    case core.Make(data, tag, args: List[core.Expr]) =>
+      Make(transform(data).asInstanceOf, tag, args map transform)
 
     case core.Select(target, field, tpe) =>
       Select(transform(target), field, transform(tpe))

--- a/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
@@ -67,6 +67,9 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case l: Literal              => l.value.toString
     case ValueVar(id, _)         => id.name.toString
 
+    case Make(data, tag, args) =>
+      "make" <+> toDoc(data) <+> toDoc(tag) <> parens(hsep(args map argToDoc, comma))
+
     case PureApp(b, targs, args) =>
       val ts = if targs.isEmpty then emptyDoc else brackets(targs.map(toDoc))
       toDoc(b) <> ts <> parens(hsep(args map argToDoc, comma))

--- a/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
@@ -21,6 +21,13 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def format(defs: List[Definition]): String =
     pretty(toDoc(defs), 60).layout
 
+  val show: PartialFunction[Any, String] = {
+    case m: ModuleDecl => format(m).layout
+    case d: Definition  => format(List(d))
+    case s: Stmt       => format(s)
+    case x: Id         => x.show
+  }
+
   val emptyline: Doc = line <> line
 
   def toDoc(m: ModuleDecl): Doc = {

--- a/effekt/shared/src/main/scala/effekt/lifted/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/Type.scala
@@ -151,6 +151,7 @@ object Type {
     case Expr.Run(s) => s.tpe
     case Expr.ValueVar(id, tpe) => tpe
     case Expr.Literal(value, tpe) => tpe
+    case Expr.Make(data, tag, args) => data
     case Expr.PureApp(callee, targs, args) => instantiate(callee.functionType, targs).result
     case Expr.Select(target, field, annotatedType) => annotatedType
     case Expr.Box(block) => ValueType.Boxed(block.tpe)

--- a/effekt/shared/src/main/scala/effekt/lifted/mono/Analyzer.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/mono/Analyzer.scala
@@ -322,6 +322,7 @@ def analyze(e: Expr)(using C: ErrorReporter, F: FlowAnalysis): Unit = e match {
   // this also means we do not need to bind externs and constructors (at the moment).
   // TODO what is with control externs?
   case Expr.PureApp(b, targs, args) => args.foreach(analyze)
+  case Expr.Make(data, tag, args) => args.foreach(analyze)
 
   case Expr.Select(target, field, annotatedType) => analyze(target)
   case Expr.Box(b) => analyze(b)

--- a/effekt/shared/src/main/scala/effekt/lifted/mono/Elaborator.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/mono/Elaborator.scala
@@ -441,6 +441,7 @@ def elaborate(e: Expr)(using T: TransformationContext): Expr = e match {
   case Expr.ValueVar(id, annotatedType) => e
   case Expr.Literal(value, annotatedType) => e
   case Expr.PureApp(b, targs, args) => e // we do not touch pure applications
+  case Expr.Make(data, tag, args) => e
   case Expr.Select(target, field, annotatedType) => Expr.Select(elaborate(target), field, annotatedType)
   case Expr.Box(b) => Expr.Box(elaborate(b))
   case Expr.Run(s) => Expr.Run(elaborate(s))

--- a/effekt/shared/src/main/scala/effekt/util/Debug.scala
+++ b/effekt/shared/src/main/scala/effekt/util/Debug.scala
@@ -9,7 +9,7 @@ val showGeneric: PartialFunction[Any, String] = {
 }
 
 val show: PartialFunction[Any, String] =
-  TypePrinter.show orElse core.PrettyPrinter.show orElse showGeneric
+  TypePrinter.show orElse core.PrettyPrinter.show orElse lifted.PrettyPrinter.show orElse showGeneric
 
 inline def debug[A](inline value: A): A =
   ${ debugMacros.debugCode('value) }

--- a/effekt/shared/src/main/scala/effekt/util/Debug.scala
+++ b/effekt/shared/src/main/scala/effekt/util/Debug.scala
@@ -9,7 +9,11 @@ val showGeneric: PartialFunction[Any, String] = {
 }
 
 val show: PartialFunction[Any, String] =
-  TypePrinter.show orElse core.PrettyPrinter.show orElse lifted.PrettyPrinter.show orElse showGeneric
+  TypePrinter.show orElse
+    core.PrettyPrinter.show orElse
+    lifted.PrettyPrinter.show orElse
+    generator.js.PrettyPrinter.show orElse
+    showGeneric
 
 inline def debug[A](inline value: A): A =
   ${ debugMacros.debugCode('value) }

--- a/examples/pos/pure_block_parameter.effekt
+++ b/examples/pos/pure_block_parameter.effekt
@@ -1,7 +1,10 @@
-type Foo { A() }
+type Mono { ConstructMono(n: Int) }
+type Poly[A] { ConstructPoly(a: A) }
 
-def hof{ a : () => Foo }: Foo = a()
+def hofMono { f : (Int) => Mono }: Mono = f(42)
+def hofPoly { f : [A](A) => Poly[A] }: Poly[Int] = f(42)
 
 def main() = {
-   hof{A}
+   hofMono {ConstructMono};
+   hofPoly {ConstructPoly}
 }

--- a/libraries/js/effekt.effekt
+++ b/libraries/js/effekt.effekt
@@ -6,9 +6,6 @@ extern include "effekt_runtime.js"
 // Builtins
 extern include "effekt_builtins.js"
 
-// Pattern Matching
-extern include "effekt_matching.js"
-
 def locally[R] { f: => R }: R = f()
 
 // Side effecting ops

--- a/libraries/js/effekt_builtins.js
+++ b/libraries/js/effekt_builtins.js
@@ -1,7 +1,9 @@
 function show$impl(obj) {
-  if (!!obj && !!obj.__name) {
-    return obj.__name + "(" + obj.__data.map(show$impl).join(", ") + ")"
-  } else if (!!obj && obj.__unit) {
+  if (!!obj && !!obj.__reflect) {
+    const meta = obj.__reflect()
+    return meta.__name + "(" + meta.__data.map(show$impl).join(", ") + ")"
+  }
+  else if (!!obj && obj.__unit) {
     return "()";
   } else {
     return "" + obj;
@@ -9,13 +11,8 @@ function show$impl(obj) {
 }
 
 function equals$impl(obj1, obj2) {
-  if (!!obj1 && !!obj2 && obj1.__data && !!obj2.__data) {
-    if (obj1.__tag != obj2.__tag) return false;
-
-    for (var i = 0; i < obj1.__data.length; i++) {
-      if (!equals$impl(obj1.__data[i], obj2.__data[i])) return false;
-    }
-    return true;
+  if (!!obj1.__equals) {
+    return obj1.__equals(obj2)
   } else {
     return (obj1.__unit && obj2.__unit) || (obj1 === obj2);
   }


### PR DESCRIPTION
This PR special cases constructors in core. This way, it is trivial for backends to detect whether a `PureApp` is a constructor call or not. In consequence, all remaining `PureApp`s are FFI calls, which nicely stratifies things.