### PR TITLE
Directly forward execution output to stdout

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -54,11 +54,10 @@ trait Runner[Executable] {
   /**
    * Runs the executable (e.g. the main file) by calling the build function.
    */
-  def eval(executable: Executable)(using Context): Unit = {
+  def eval(executable: Executable)(using C: Context): Unit = {
     val execFile = build(executable)
-    val exitCode = Process(execFile).!<
-    if(exitCode != 0) {
-      Context.error(s"Process exited with exit code ${exitCode}.")
+    Process(execFile).lazyLines.foreach{ line =>
+      C.config.output().emitln(line)
     }
   }
 

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -54,8 +54,13 @@ trait Runner[Executable] {
   /**
    * Runs the executable (e.g. the main file) by calling the build function.
    */
-  def eval(executable: Executable)(using Context): Unit =
-    exec(build(executable))
+  def eval(executable: Executable)(using Context): Unit = {
+    val execFile = build(executable)
+    val exitCode = Process(execFile).!<
+    if(exitCode != 0) {
+      Context.error(s"Process exited with exit code ${exitCode}.")
+    }
+  }
 
   def canRunExecutable(command: String*): Boolean =
     try {

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -61,7 +61,6 @@ trait Runner[Executable] {
 
       override def out(s: => String): Unit = {
         C.config.output().emitln(s)
-        System.out.flush()
       }
 
       override def err(s: => String): Unit = System.err.println(s)

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -70,7 +70,7 @@ trait Runner[Executable] {
 
     }, connectInput = true).exitValue()
 
-    if(exitCode != 0) {
+    if (exitCode != 0) {
       C.error(s"Process exited with non-zero exit code ${exitCode}.")
     }
   }


### PR DESCRIPTION
Fixes #336 (since I was looking into the Process API r.n. anyway).

Issue #336 is caused by the Process being started using `.!!` which:
```
Starts the process represented by this builder, blocks until it exits, and returns the output as a String. Standard error is sent to the console. If the exit code is non-zero, an exception is thrown.
```

We now use a custom `ProcessLogger` and also connect stdin.
This makes this mostly work, apart from potential race conditions between input and output. (Note: `.!<` would work well in that regard but breaks the tests.)