### PR TITLE
Website breaks to missing extern definitions

### DIFF
--- a/effekt/js/src/main/scala/effekt/LanguageServer.scala
+++ b/effekt/js/src/main/scala/effekt/LanguageServer.scala
@@ -1,7 +1,7 @@
 package effekt
 
 import effekt.context.{ Context, VirtualFileSource, VirtualModuleDB }
-import effekt.generator.js.TransformerMonadic
+import effekt.generator.js.TransformerMonadicSeparate
 import effekt.lifted.LiftInference
 import effekt.util.{ PlainMessaging, getOrElseAborting }
 import effekt.util.messages.{ BufferedMessaging, EffektError, EffektMessaging, FatalPhaseError }
@@ -190,7 +190,7 @@ class LanguageServer extends Intelligence {
   }
 
   private def path(m: symbols.Module)(using C: Context): String =
-    (C.config.outputPath() / TransformerMonadic.jsModuleFile(m.path)).unixPath
+    (C.config.outputPath() / TransformerMonadicSeparate.jsModuleFile(m.path)).unixPath
 }
 
 @JSExportTopLevel("effekt")

--- a/effekt/js/src/test/scala/effekt/WebTests.scala
+++ b/effekt/js/src/test/scala/effekt/WebTests.scala
@@ -49,8 +49,7 @@ object WebTests extends TestSuite {
     }
 
     test("Evaluate expressions that uses a builtin which relies on an extern literal") {
-      val result = evaluate[Unit](List(), "println(42)")
-      assert(result == ())
+      evaluate(List(), "println(42)")
     }
 
     test("Evaluate expressions using stdlib in REPL") {

--- a/effekt/js/src/test/scala/effekt/WebTests.scala
+++ b/effekt/js/src/test/scala/effekt/WebTests.scala
@@ -48,6 +48,11 @@ object WebTests extends TestSuite {
       assert(result == 3)
     }
 
+    test("Evaluate expressions that uses a builtin which relies on an extern literal") {
+      val result = evaluate[Unit](List(), "println(42)")
+      assert(result == ())
+    }
+
     test("Evaluate expressions using stdlib in REPL") {
       val result = evaluate[Int](List("immutable/list"), "Cons(1, Cons(2, Nil())).size")
       assert(result == 2)

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -270,7 +270,7 @@ object Namer extends Phase[Parsed, NameResolved] {
       resolveGeneric(binding)
       Context.define(id, DefBinder(Context.nameFor(id), tpe, d))
 
-    // FunDef and EffDef have already been resolved as part of the module declaration
+    // FunDef and InterfaceDef have already been resolved as part of the module declaration
     case f @ source.FunDef(id, tparams, vparams, bparams, ret, body) =>
       val sym = f.symbol
       Context scoped {

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -46,7 +46,7 @@ class JavaScript extends Compiler[String] {
     case input @ CoreTransformed(source, tree, mod, core) =>
       val mainSymbol = Context.checkMain(mod)
       val mainFile = path(mod)
-      val doc = pretty(TransformerMonadic.compile(input, mainSymbol).commonjs)
+      val doc = pretty(TransformerMonadicWhole.compile(input, mainSymbol).commonjs)
       (Map(mainFile -> doc.layout), mainFile)
   }
 
@@ -54,7 +54,7 @@ class JavaScript extends Compiler[String] {
   // -----------------------------------
   lazy val Separate:  Phase[Source, (CoreTransformed, Module)] =
     allToCore(Core) map { in =>
-        (in.main, TransformerMonadic.compileSeparate(in))
+      (in.main, TransformerMonadicSeparate.compileSeparate(in))
     }
 
   private def pretty(stmts: List[js.Stmt]): Document =


### PR DESCRIPTION
All examples on the website output

> println$impl is not defined

The reason is that recently introduced inlining of extern definitions #350 will inline definitions like `println`

https://github.com/effekt-lang/effekt/blob/5dffce2c7f61b03c5038ddfe9d3c1f0fc0ae2ae1/libraries/js/effekt.effekt#L14-L15

which in turn rely on extern includes or literals, such as

https://github.com/effekt-lang/effekt/blob/5dffce2c7f61b03c5038ddfe9d3c1f0fc0ae2ae1/libraries/js/effekt.effekt#L8

The problem now is that the website uses separate compiling, where the extern includes are only visible to the one module including them. Previously, `println` would simply **close over** the extern includes. But now, since we inline it, it cannot anymore.

## Solution implemented in this hotfix

Inlining externs now differs (in JS) between separate and whole program compilation.
- When compiling whole-program, we inline extern defs.
- When compiling separate, we do **not** inline extern defs, since:
       
## Drawback

- it adds complexity in the implementation of the javascript Transformer
- the hotfix looses some code-sharing with the direct-style backend, which currently is not used (neither in tests, nor on the website), since I moved some code into the "Monadic..." variants to easier control inlining. 