### PR TITLE
Do not ignore type parameters of receiver in method calls

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/ConstraintTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ConstraintTests.scala
@@ -33,7 +33,7 @@ abstract class ConstraintTests extends munit.FunSuite {
 
 
   def freshTypeVar(name: String) =
-    scope.fresh(TypeParam(Name.local(name)), NoSource)
+    scope.freshTypeVar(TypeParam(Name.local(name)), NoSource)
 
   def freshCaptVar(name: String) =
     scope.freshCaptVar(CaptUnificationVar.VariableInstantiation(CaptureParam(Name.local(name)), NoSource))

--- a/effekt/shared/src/main/scala/effekt/typer/Unification.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Unification.scala
@@ -49,7 +49,7 @@ class Unification(using C: ErrorReporter) extends TypeUnifier, TypeMerger, TypeI
 
   // Creating fresh unification variables
   // ------------------------------------
-  def fresh(underlying: TypeVar.TypeParam, call: source.Tree): UnificationVar = scope match {
+  def freshTypeVar(underlying: TypeVar.TypeParam, call: source.Tree): UnificationVar = scope match {
     case GlobalScope => sys error "Cannot add unification variables to global scope"
     case s : LocalScope =>
       val x = new UnificationVar(underlying, call)
@@ -200,7 +200,7 @@ class Unification(using C: ErrorReporter) extends TypeUnifier, TypeMerger, TypeI
 
     val typeRigids =
       if (targs.size == tparams.size) targs
-      else tparams map { t => ValueTypeRef(fresh(t, position)) }
+      else tparams map { t => ValueTypeRef(freshTypeVar(t, position)) }
 
     if (cparams.size != (bparams.size + eff.canonical.size)) {
       sys error pp"Capture param count ${cparams.size} is not equal to bparam ${bparams.size} + controleffects ${eff.canonical.size}.\n  ${tpe}"

--- a/examples/neg/issue373/existentials.check
+++ b/examples/neg/issue373/existentials.check
@@ -1,0 +1,6 @@
+[error] examples/neg/issue373/existentials.effekt:7:46: Expected Int but got String.
+  with eff: Eff[Int] { def op[C](x) = resume(x ++ "") }
+                                             ^^^^^^^
+[error] examples/neg/issue373/existentials.effekt:7:46: Expected String but got C.
+  with eff: Eff[Int] { def op[C](x) = resume(x ++ "") }
+                                             ^

--- a/examples/neg/issue373/existentials.effekt
+++ b/examples/neg/issue373/existentials.effekt
@@ -1,0 +1,7 @@
+interface Eff[A] {
+  def op[B](x: B): A
+}
+
+def main() =
+  try { println(eff.op("hello")) }
+  with eff: Eff[Int] { def op[C](x) = resume(x ++ "") }

--- a/examples/neg/issue373/existentials_wrong_arity.check
+++ b/examples/neg/issue373/existentials_wrong_arity.check
@@ -1,0 +1,3 @@
+[error] examples/neg/issue373/existentials_wrong_arity.effekt:6:17: Wrong number of type arguments, given 1 but expected 2
+  try { println(eff.op[Int]("hello")) }
+                ^^^^^^^^^^^^^^^^^^^^

--- a/examples/neg/issue373/existentials_wrong_arity.effekt
+++ b/examples/neg/issue373/existentials_wrong_arity.effekt
@@ -1,0 +1,7 @@
+interface Eff[A] {
+  def op[B](x: A): A
+}
+
+def main() =
+  try { println(eff.op[Int]("hello")) }
+  with eff: Eff[Int] { def op[B](x) = resume(x / 1) }

--- a/examples/neg/issue373/handler_correct_annotation.check
+++ b/examples/neg/issue373/handler_correct_annotation.check
@@ -1,0 +1,3 @@
+[error] examples/neg/issue373/handler_correct_annotation.effekt:6:29: Expected Int but got String.
+  try { println(eff.op[Int]("hello")) }
+                            ^^^^^^^

--- a/examples/neg/issue373/handler_correct_annotation.effekt
+++ b/examples/neg/issue373/handler_correct_annotation.effekt
@@ -1,0 +1,7 @@
+interface Eff[A] {
+  def op(x: A): A
+}
+
+def main() =
+  try { println(eff.op[Int]("hello")) }
+  with eff: Eff[Int] { def op(x) = resume(x / 1) }

--- a/examples/neg/issue373/handler_no_annotation.check
+++ b/examples/neg/issue373/handler_no_annotation.check
@@ -1,0 +1,3 @@
+[error] examples/neg/issue373/handler_no_annotation.effekt:6:24: Expected Int but got String.
+  try { println(eff.op("hello")) }
+                       ^^^^^^^

--- a/examples/neg/issue373/handler_no_annotation.effekt
+++ b/examples/neg/issue373/handler_no_annotation.effekt
@@ -1,0 +1,7 @@
+interface Eff[A] {
+  def op(x: A): A
+}
+
+def main() =
+  try { println(eff.op("hello")) }
+  with eff: Eff[Int] { def op(x) = resume(x / 1) }

--- a/examples/neg/issue373/object_no_annotation.check
+++ b/examples/neg/issue373/object_no_annotation.check
@@ -1,0 +1,3 @@
+[error] examples/neg/issue373/object_no_annotation.effekt:9:29: Expected Int but got String.
+def main() = println(eff.op("hello"))
+                            ^^^^^^^

--- a/examples/neg/issue373/object_no_annotation.effekt
+++ b/examples/neg/issue373/object_no_annotation.effekt
@@ -1,0 +1,9 @@
+interface Eff[A] {
+  def op(x: A): A
+}
+
+def eff = new Eff[Int] {
+  def op(x) = x / 1
+}
+
+def main() = println(eff.op("hello"))

--- a/examples/neg/issue373/wrong_type_argument.check
+++ b/examples/neg/issue373/wrong_type_argument.check
@@ -1,0 +1,6 @@
+[error] examples/neg/issue373/wrong_type_argument.effekt:6:17: Expected Boolean but got Int.
+  try { println(eff.op[Boolean]("hello")) }
+                ^^^^^^^^^^^^^^^^^^^^^^^^
+[error] examples/neg/issue373/wrong_type_argument.effekt:6:33: Expected Boolean but got String.
+  try { println(eff.op[Boolean]("hello")) }
+                                ^^^^^^^

--- a/examples/neg/issue373/wrong_type_argument.effekt
+++ b/examples/neg/issue373/wrong_type_argument.effekt
@@ -1,0 +1,7 @@
+interface Eff[A] {
+  def op(x: A): A
+}
+
+def main() =
+  try { println(eff.op[Boolean]("hello")) }
+  with eff: Eff[Int] { def op(x) = resume(x / 1) }

--- a/examples/neg/issue373/wrong_type_argument_arity.check
+++ b/examples/neg/issue373/wrong_type_argument_arity.check
@@ -1,0 +1,3 @@
+[error] examples/neg/issue373/wrong_type_argument_arity.effekt:6:17: Wrong number of type arguments, given 2 but expected 1
+  try { println(eff.op[Boolean, Int]("hello")) }
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/neg/issue373/wrong_type_argument_arity.effekt
+++ b/examples/neg/issue373/wrong_type_argument_arity.effekt
@@ -1,0 +1,7 @@
+interface Eff[A] {
+  def op(x: A): A
+}
+
+def main() =
+  try { println(eff.op[Boolean, Int]("hello")) }
+  with eff: Eff[Int] { def op(x) = resume(x / 1) }


### PR DESCRIPTION
For now I am special casing the treatment of method calls to fix #373. What I do not like about this solution:

- previously there was no `freshTypeVar` in `Typer`--it all was encapsulated behind `instantiate`.
- now the treatment of method and function calls is not entirely uniform and slightly differs.