### PR TITLE
Improve Test Runner

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/ChezSchemeTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ChezSchemeTests.scala
@@ -9,7 +9,7 @@ import scala.language.implicitConversions
 
 abstract class ChezSchemeTests extends EffektTests {
 
-  override def included: List[File] = List(
+  override def positives: List[File] = List(
     examplesDir / "pos",
     examplesDir / "casestudies",
     examplesDir / "chez",

--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -128,14 +128,13 @@ trait EffektTests extends munit.FunSuite {
 
     assert(messages.nonEmpty)
 
-
   def foreachFileIn(dirs: List[File])(test: (File, Option[String]) => Unit): Unit =
     dirs.foreach(foreachFileIn(_)(test))
 
   def foreachFileIn(dir: File)(test: (File, Option[String]) => Unit): Unit = //describe(dir.getName) {
     dir.listFiles.foreach {
       case f if f.isDirectory && !ignored.contains(f) =>
-        runPositiveTestsIn(f)
+        foreachFileIn(f)(test)
       case f if f.getName.endsWith(".effekt") || f.getName.endsWith(".effekt.md") =>
         val path = f.getParentFile
         val baseName = f.getName.stripSuffix(".md").stripSuffix(".effekt")

--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -95,7 +95,7 @@ trait EffektTests extends munit.FunSuite {
     val messaging = new PlainMessaging
     val messageWithFormat = messages.map { msg => (msg, messaging.formatContent(msg)) }
 
-    assert(messages.nonEmpty)
+    assert(messages.nonEmpty, s"File ${f} is supposed to report at least one error.")
 
     val rx = """//\s*(ERROR|WARN)\s*(.*)$""".r
 

--- a/effekt/jvm/src/test/scala/effekt/JavaScriptTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/JavaScriptTests.scala
@@ -14,11 +14,14 @@ class JavaScriptTests extends EffektTests {
 
   def backendName = "js"
 
-  override def included: List[File] = List(
+  override def positives: List[File] = List(
     examplesDir / "pos",
-    examplesDir / "neg",
     examplesDir / "casestudies",
     examplesDir / "benchmarks"
+  )
+
+  override def negatives: List[File] = List(
+    examplesDir / "neg"
   )
 
   override def ignored: List[File] = List(

--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -10,7 +10,7 @@ class LLVMTests extends EffektTests {
 
   def backendName = "llvm"
 
-  override lazy val included: List[File] = List(
+  override lazy val positives: List[File] = List(
     examplesDir / "llvm",
     examplesDir / "pos" / "list",
   )

--- a/effekt/jvm/src/test/scala/effekt/MLTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/MLTests.scala
@@ -10,7 +10,7 @@ class MLTests extends EffektTests {
 
   def backendName: String = "ml"
 
-  override lazy val included: List[File] = List(
+  override lazy val positives: List[File] = List(
     examplesDir / "ml",
     examplesDir / "benchmarks",
     examplesDir / "pos",

--- a/examples/neg/blocks_wrong_arguments.check
+++ b/examples/neg/blocks_wrong_arguments.check
@@ -1,3 +1,0 @@
-[error] examples/neg/blocks_wrong_arguments.effekt:7:3: Wrong number of value arguments, given 3, but f expects 2.
-  f(2, true, 4)
-  ^

--- a/examples/neg/blocks_wrong_arguments.effekt
+++ b/examples/neg/blocks_wrong_arguments.effekt
@@ -4,7 +4,7 @@ def foo { f : Int => Int } =
   f(2)
 
 def bar { f : (Int, Boolean) => Unit } =
-  f(2, true, 4)
+  f(2, true, 4) // ERROR Wrong number of value arguments
 
 def main() = {
   val r = foo { (x: Int, y: Boolean) =>
@@ -16,4 +16,3 @@ def main() = {
     ()
   }
 }
-


### PR DESCRIPTION
This PR addresses  #375 and supports the following formats:

Running tests in `examples/neg` depends on whether there is a check file or not:

1. `.check` file exists: `.effekt` program will be compiled and run; output is compared against `.check`
2. `.check` file does not exist: `.effekt` program will be compiled. The following checks will be performed
  - if no line has an error annotation, then it is checked whether an error exists at all.
  - for each line that ends in either `// ERROR` or `// WARN` a corresponding error or warning is searched for.

Additionally each `// ERROR` and `// WARN` comment can be followed by an excerpt of the error message that is expected. 

https://github.com/effekt-lang/effekt/blob/a103be8e5fcfafebf1c55e95a3648329ae211a25/examples/neg/blocks_wrong_arguments.effekt#L1-L18

The trailing message will be searched **verbatim** in the error messages.

_Additional_ errors that are not marked with a comment are currently ignored.