### PR TITLE
Warn if a type parameter shadows a non-parameter

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -126,7 +126,7 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
         case op =>
           InterfaceDef(IdDef(op.id.name) withPositionOf op.id, Nil, List(op), true)
       }
-    | (`effect` | `interface`) ~> idDef ~ maybeTypeParams ~ (`{` ~/> many(`def` ~> effectOp)  <~ `}`) ^^ {
+    | (`effect` | `interface`) ~> idDef ~ maybeTypeParams ~ (`{` ~/> many(`def` ~/> effectOp)  <~ `}`) ^^ {
         case id ~ tps ~ ops => InterfaceDef(id, tps, ops, true)
       }
     )
@@ -424,7 +424,7 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
     )
 
   lazy val implementation: P[Implementation] =
-    ( interfaceType ~ (`{` ~> many(defClause) <~ `}`) ^^ {
+    ( interfaceType ~ (`{` ~/> many(defClause) <~ `}`) ^^ {
       case effect ~ clauses =>
         Implementation(effect, clauses)
       }

--- a/examples/neg/effect_not_part.check
+++ b/examples/neg/effect_not_part.check
@@ -1,3 +1,3 @@
-[error] examples/neg/effect_not_part.effekt:13:26: Operation raise is not part of interface State.
-    try { f(); () } with State {
-                         ^
+[error] examples/neg/effect_not_part.effekt:17:9: Operation raise is not part of interface State.
+        def raise() = ()
+        ^

--- a/examples/neg/namer/shadowing-types.effekt
+++ b/examples/neg/namer/shadowing-types.effekt
@@ -1,0 +1,17 @@
+effect Foo[A](x: A): A
+
+interface Bar {
+  def op[B](b: B): Unit
+}
+
+def bar = new Bar {
+  def op[Int](n) = () // WARN shadows
+}
+
+def main(): Int =
+  try {
+    //...
+    0
+  } with Foo[Int] { // WARN shadows
+    (x: Int) => 12
+  }


### PR DESCRIPTION
This tries to fix #368 by emitting a warning in case a type parameter shadows an outer type, which is _not_ a type parameter (since this sometimes is desired and could lead to too many false negatives).

An example can be seen here:

https://github.com/effekt-lang/effekt/blob/2c43c68d1e45f60573515bb21005d9251c47bb3c/examples/neg/namer/shadowing-types.effekt#L1-L17