### PR TITLE
Fix #354 by not exporting extern resources

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -128,13 +128,10 @@ trait EffektTests extends munit.FunSuite {
 
     assert(messages.nonEmpty)
 
-  def foreachFileIn(dirs: List[File])(test: (File, Option[String]) => Unit): Unit =
-    dirs.foreach(foreachFileIn(_)(test))
-
-  def foreachFileIn(dir: File)(test: (File, Option[String]) => Unit): Unit = //describe(dir.getName) {
-    dir.listFiles.foreach {
+  def foreachFileIn(file: File)(test: (File, Option[String]) => Unit): Unit =
+    file match {
       case f if f.isDirectory && !ignored.contains(f) =>
-        foreachFileIn(f)(test)
+        f.listFiles.foreach(foreachFileIn(_)(test))
       case f if f.getName.endsWith(".effekt") || f.getName.endsWith(".effekt.md") =>
         val path = f.getParentFile
         val baseName = f.getName.stripSuffix(".md").stripSuffix(".effekt")

--- a/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
@@ -20,14 +20,7 @@ trait Transformer {
 
   def run(body: js.Expr): js.Stmt
 
-  def shouldExport(id: Id)(using D: DeclarationContext): Boolean = id match {
-    // do not export fields, since they are no defined functions
-    case fld if D.findField(fld).isDefined => false
-    // do not export effect operations, since they are translated to field selection as well.
-    case op if D.findProperty(op).isDefined => false
-    // all others are fine
-    case _ => true
-  }
+  def shouldExport(id: Id)(using D: DeclarationContext): Boolean = true
 
   // Representation of Data / Codata
   // ----

--- a/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
@@ -20,7 +20,7 @@ trait Transformer {
 
   def run(body: js.Expr): js.Stmt
 
-  def shouldExport(sym: Symbol)(using D: DeclarationContext): Boolean = sym match {
+  def shouldExport(id: Id)(using D: DeclarationContext): Boolean = id match {
     // do not export fields, since they are no defined functions
     case fld if D.findField(fld).isDefined => false
     // do not export effect operations, since they are translated to field selection as well.

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
@@ -92,7 +92,7 @@ object TransformerMonadicSeparate extends TransformerMonadic {
         js.Import.Selective(syms.filter(shouldExport).toList.map(uniqueName), jsModuleFile(mod.path))
     }
 
-    val provided = module.terms.values.flatten.toList.distinct
+    val provided = mainModuleDecl.exports
     val exports = allMains.lastOption.toList ++ provided.collect {
       case sym if shouldExport(sym) => js.Export(nameDef(sym), nameRef(sym))
     }

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
@@ -25,7 +25,7 @@ object TransformerMonadicWhole extends TransformerMonadic {
    * In whole-program, however, we should only export those symbols that we have not inlined away, already.
    */
   override def shouldExport(id: Id)(using D: DeclarationContext): Boolean =
-    super.shouldExport(id) && D.findExternDef(id).forall { d => !canInline(d) }
+    D.findExternDef(id).forall { d => !canInline(d) }
 
   /**
    * We only inline non-control effecting externs without block parameters


### PR DESCRIPTION
The problem underlying the error 

> ReferenceError: my_resource_1396 is not defined

observed by @phischu in #354 was that extern resources have been "exported" in the separate-compilation-based Javascript backends. That is, JS code like

```javascript
module.export = {
  // ...
  my_resource_1396: my_resource_1396
}
```
was generated, but extern resources don't have a term-level representation so the right-hand side of `my_resource_1396` was unbound.

#### Solution Attempt

First attempt to solve #354 the problem was
```diff
  def shouldExport(sym: Symbol)(using D: DeclarationContext): Boolean = sym match {
    // do not export fields, since they are no defined functions
    case fld if D.findField(fld).isDefined => false
    // do not export effect operations, since they are translated to field selection as well.
    case op if D.findProperty(op).isDefined => false
+   // do not export extern resources, since they do not exist on the term-level
+   case r: symbols.ExternResource => false
    // all others are fine
    case _ => true
  }
```
However, after `core` we should not match on symbols anymore; so this is not a good solution, since it is not stable under renaming.

In particular, we currently do not include extern resources in the core representation:
https://github.com/effekt-lang/effekt/blob/3aa78e8795b8adb1d347827a3f2b004c2b783be2/effekt/shared/src/main/scala/effekt/core/Transformer.scala#L111-L112

Same holds for `ExternType`, `ExternResource`, `ExternInterface`

#### Chosen Solution

Instead, now I do not use `module.exports` on the symbol, anymore. We should try to avoid this after going to `core`, anyways.

This also helped simplifying the separate compilation aspect of JS a bit (3c26361) since now we do not need to filter twice. I am a little bit afraid that this might introduce a regression, but checked that the tests actually caught this before performing the refactoring.

