### PR TITLE
Implement LSP autocomplete

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -185,6 +185,7 @@ trait LSPServer extends kiama.util.Server[Tree, EffektConfig, EffektError] with 
         None
     }
 
+  // for custom icons and intelligence of autocomplete
   def getCompletionKind(sym: Symbol): CompletionItemKind =
     sym match {
       case _: Module =>
@@ -201,6 +202,8 @@ trait LSPServer extends kiama.util.Server[Tree, EffektConfig, EffektError] with 
         CompletionItemKind.TypeParameter
       case _: KeywordSymbol =>
         CompletionItemKind.Keyword
+      case _: ASTSymbol =>
+        CompletionItemKind.Property // TODO
       case _ =>
         CompletionItemKind.Text
     }

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -10,7 +10,7 @@ import effekt.util.messages.EffektError
 import kiama.util.{ Filenames, Position, Services, Source }
 import kiama.output.PrettyPrinterTypes.Document
 
-import org.eclipse.lsp4j.{ Diagnostic, DocumentSymbol, SymbolKind, ExecuteCommandParams }
+import org.eclipse.lsp4j.{ Diagnostic, DocumentSymbol, CompletionItem, CompletionItemKind, InsertTextFormat, SymbolKind, ExecuteCommandParams }
 
 /**
  * effekt.Intelligence <--- gathers information -- LSPServer --- provides LSP interface ---> kiama.Server
@@ -132,7 +132,6 @@ trait LSPServer extends kiama.util.Server[Tree, EffektConfig, EffektError] with 
   }
 
   override def getSymbols(source: Source): Option[Vector[DocumentSymbol]] =
-
     context.compiler.runFrontend(source)(using context)
 
     val documentSymbols = for {
@@ -151,6 +150,14 @@ trait LSPServer extends kiama.util.Server[Tree, EffektConfig, EffektError] with 
       refs = context.distinctReferencesTo(sym)
       allRefs = if (includeDecl) tree :: refs else refs
     } yield allRefs.toVector
+
+  override def getCompletion(position: Position): Option[Vector[CompletionItem]] = {
+    val test = CompletionItem()
+    test.setLabel("test")
+    test.setKind(CompletionItemKind.Text)
+    test.setInsertTextFormat(InsertTextFormat.PlainText)
+    Some(Vector(test))
+  }
 
   // settings might be null
   override def setSettings(settings: Object): Unit = {

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -197,6 +197,8 @@ trait LSPServer extends kiama.util.Server[Tree, EffektConfig, EffektError] with 
         CompletionItemKind.Method
       case _: Param | _: ValBinder | _: VarBinder =>
         CompletionItemKind.Variable
+      case _: TypeSymbol =>
+        CompletionItemKind.TypeParameter
       case _: KeywordSymbol =>
         CompletionItemKind.Keyword
       case _ =>

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -2,7 +2,7 @@ package effekt
 
 import effekt.context.{ Annotations, Context }
 import effekt.source.{ FunDef, ModuleDecl, Tree }
-import kiama.util.{ Position, Source }
+import kiama.util.{ Position, Positions, Source }
 
 trait Intelligence {
 
@@ -79,6 +79,21 @@ trait Intelligence {
     case a: Anon         => Some(a.decl)
     case u => C.definitionTreeOption(u)
   }
+
+  // TODO: Move this somewhere else or find better solution
+  class KeywordSymbol(val keyword: String) extends Symbol { val name = Name.local(keyword) }
+
+  def getPrefixSymbols(prefix: String, position: Position)(implicit C: Context): Option[Vector[Symbol]] = {
+    val keywords = EffektLexers(new Positions).keywordStrings.filter { _.startsWith(prefix) }.map { keyword =>
+      KeywordSymbol(keyword)
+    }
+    Some(keywords.toVector)
+  }
+
+  def getCompletionsAt(position: Position)(implicit C: Context): Option[Vector[Symbol]] = for {
+    prefix <- position.optWord
+    syms <- getPrefixSymbols(prefix, position)
+  } yield syms
 
   // For now, only show the first call target
   def resolveCallTarget(sym: Symbol): Symbol = sym match {


### PR DESCRIPTION
This PR closes #367 Together with #... and #..., this should result in first steps towards more intelligent LSP intelligence.

Main things still missing:

- Better symbol selection; for now all suggested completion items are selected by prefix of the currently typed word
- Only suggest symbols in AST within the scope of the current position; this is especially hard since the tree often has syntax errors while completing; for now *all* symbols in the AST get suggested
- Be much more smart about completion suggestions, e.g. dot notation should only suggest relevant sub items, `else` should only be shown if within `if`, effect handlers could be autocompleted (LSP can write entire snippets) etc. This is probably too much for this initial PR.

I very much welcome criticism and suggestions for elegant solutions. I'm still unfamiliar with Scala and the code base.
