### PR TITLE
Feature: tracing/timing of compilation phases

### DIFF
--- a/effekt/js/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/js/src/main/scala/effekt/EffektConfig.scala
@@ -17,4 +17,6 @@ trait EffektConfig {
   def requiresLift(): Boolean = false
 
   def prelude() = List("effekt")
+  
+  def timed() = false
 }

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -68,13 +68,16 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     C.backend match {
 
       case Backend(name, compiler, runner) =>
-        def compile() = compiler.compile(src) map {
-          case (outputFiles, exec) =>
-            outputFiles.foreach {
-              case (filename, doc) =>
-                saveOutput(filename, doc)
-            }
-            exec
+        // measure the total compilation time here
+        def compile() = C.timed("total", source.name) {
+          compiler.compile(src) map {
+            case (outputFiles, exec) =>
+              outputFiles.foreach {
+                case (filename, doc) =>
+                  saveOutput(filename, doc)
+              }
+              exec
+          }
         }
 
         // we are in one of three exclusive modes: LSPServer, Compile, Run

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -104,7 +104,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
    * is written to disk or a plain text message is written to stdout.
    */
   def outputTimes(source: Source, config: EffektConfig)(implicit C: Context): Unit = {
-    if (C.timersActive) config.trace.toOption foreach {
+    if (C.timersActive) config.time.toOption foreach {
       case "json" =>
         // extract source filename and write to given output path
         val out = config.outputPath().getAbsolutePath

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -91,14 +91,19 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
         context.info("  at " + line)
       }
   } finally {
-    outputTracing(source, config)(context)
+    outputTimes(source, config)(context)
     // This reports error messages
     afterCompilation(source, config)(context)
   }
-  
-  def outputTracing(source: Source, config: EffektConfig)(implicit C: Context): Unit = {
-    if (config.trace.isSupplied) config.trace.toOption foreach {
+
+  /**
+   * Outputs the timing information captured in [[effekt.util.Timers]] by [[effekt.context.Context]]. Either a JSON file
+   * is written to disk or a plain text message is written to stdout.
+   */
+  def outputTimes(source: Source, config: EffektConfig)(implicit C: Context): Unit = {
+    if (C.timersActive) config.trace.toOption foreach {
       case "json" =>
+        // extract source filename and write to given output path
         val out = config.outputPath().getAbsolutePath
         val name = s"${source.name.split("/").last.stripSuffix(".effekt")}.json"
         IO.createFile((out / name).unixPath, C.timesToJSON())

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -82,7 +82,6 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
         else if (config.interpret()) { compile() foreach runner.eval }
         else if (config.build()) { compile() foreach runner.build }
         else if (config.compile()) { compile() }
-        Context.showTimes()
     }
   } catch {
     case FatalPhaseError(msg) => context.report(msg)
@@ -100,6 +99,8 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
    * Overridden in [[Server]] to also publish core and js compilation results to VSCode
    */
   def afterCompilation(source: Source, config: EffektConfig)(implicit C: Context): Unit = {
+    // display tracing information if text is given as output format
+    if (config.trace.isSupplied) config.trace.foreach(s => if (s == "text") C.info(C.timesToString()))
     // report messages
     report(source, C.messaging.buffer, config)
 

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -82,6 +82,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
         else if (config.interpret()) { compile() foreach runner.eval }
         else if (config.build()) { compile() foreach runner.build }
         else if (config.compile()) { compile() }
+        Context.showTimes()
     }
   } catch {
     case FatalPhaseError(msg) => context.report(msg)

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -22,10 +22,10 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     default = Some(false)
   )
 
-  val trace: ScallopOption[String] = choice(
+  val time: ScallopOption[String] = choice(
     choices = Seq("text", "json"),
-    name = "trace",
-    descr = "Trace the time spent in each compilation phase.",
+    name = "time",
+    descr = "Measure the time spent in each compilation phase.",
     required = false
   )
 
@@ -136,6 +136,8 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
   def interpret(): Boolean = !server() && !compile() && !build()
 
   def repl(): Boolean = filenames().isEmpty && !server() && !compile()
+  
+  def timed(): Boolean = time.isSupplied && !server()
 
   validateFilesIsDirectory(includePath)
 

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -23,7 +23,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
   )
 
   val trace: ScallopOption[String] = choice(
-    choices = Seq("text", "json", "csv"),
+    choices = Seq("text", "json"),
     name = "trace",
     descr = "Trace the time spent in each compilation phase.",
     default = Some("text"),

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -26,7 +26,6 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     choices = Seq("text", "json"),
     name = "trace",
     descr = "Trace the time spent in each compilation phase.",
-    default = Some("text"),
     required = false
   )
 

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -22,6 +22,14 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     default = Some(false)
   )
 
+  val trace: ScallopOption[String] = choice(
+    choices = Seq("text", "json", "csv"),
+    name = "trace",
+    descr = "Trace the time spent in each compilation phase.",
+    default = Some("text"),
+    required = false
+  )
+
   val outputPath: ScallopOption[File] = opt[File](
     "out",
     descr = "Path to write generated files to (defaults to ./out)",

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -66,7 +66,7 @@ object Namer extends Phase[Parsed, NameResolved] {
         Context.at(im) { importDependency(path) }
     }
 
-    Context.timed(phaseName, src.name)(resolveGeneric(decl))
+    Context.timed(phaseName, src.name) { resolveGeneric(decl) }
 
     // We only want to import each dependency once.
     val allIncludes = (processedPreludes ++ includes).distinct

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -30,7 +30,7 @@ object Parser extends Phase[Source, Parsed] {
     case VirtualSource(decl, _) => Some(decl)
     case source =>
       //println(s"parsing ${source.name}")
-      Context.timed(phaseName, source.name)(parser.parse(source))
+      Context.timed(phaseName, source.name) { parser.parse(source) }
   } map { tree => Parsed(source, tree) }
 }
 

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -30,7 +30,7 @@ object Parser extends Phase[Source, Parsed] {
     case VirtualSource(decl, _) => Some(decl)
     case source =>
       //println(s"parsing ${source.name}")
-      parser.parse(source)
+      Context.timed(phaseName, source.name)(parser.parse(source))
   } map { tree => Parsed(source, tree) }
 }
 

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -49,33 +49,35 @@ object Typer extends Phase[NameResolved, Typechecked] {
 
       Context.initTyperstate()
 
-      Context in {
-        Context.withUnificationScope {
-          // No captures are allowed on the toplevel
-          flowingInto(CaptureSet()) {
-            // bring builtins into scope
-            builtins.rootTerms.values.foreach {
-              case term: BlockParam =>
-                Context.bind(term, term.tpe)
-                Context.bind(term, CaptureSet(term.capture))
-              case term: ExternResource =>
-                Context.bind(term, term.tpe)
-                Context.bind(term, CaptureSet(term.capture))
-              case term: Callable =>
-                Context.bind(term, term.toType)
-              case term => Context.panic(s"Cannot bind builtin term: ${term}")
-            }
+      Context.timed(phaseName, source.name) {
+        Context in {
+          Context.withUnificationScope {
+            // No captures are allowed on the toplevel
+            flowingInto(CaptureSet()) {
+              // bring builtins into scope
+              builtins.rootTerms.values.foreach {
+                case term: BlockParam =>
+                  Context.bind(term, term.tpe)
+                  Context.bind(term, CaptureSet(term.capture))
+                case term: ExternResource =>
+                  Context.bind(term, term.tpe)
+                  Context.bind(term, CaptureSet(term.capture))
+                case term: Callable =>
+                  Context.bind(term, term.toType)
+                case term => Context.panic(s"Cannot bind builtin term: ${term}")
+              }
 
-            // We split the type-checking of definitions into "pre-check" and "check"
-            // to allow mutually recursive defs
-            tree.defs.foreach { d => precheckDef(d) }
-            tree.defs.foreach { d =>
-              val Result(_, effs) = synthDef(d)
-              val unhandled = effs.toEffects
-              if (unhandled.nonEmpty)
-                Context.at(d) {
-                  Context.error(pretty"Unhandled effects ${unhandled}")
-                }
+              // We split the type-checking of definitions into "pre-check" and "check"
+              // to allow mutually recursive defs
+              tree.defs.foreach { d => precheckDef(d) }
+              tree.defs.foreach { d =>
+                val Result(_, effs) = synthDef(d)
+                val unhandled = effs.toEffects
+                if (unhandled.nonEmpty)
+                  Context.at(d) {
+                    Context.error(pretty"Unhandled effects ${unhandled}")
+                  }
+              }
             }
           }
         }
@@ -1219,7 +1221,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
     Result(ret, effs)
   }
 
-  def tryEach[K, R](inputs: List[K])(f: K => R)(using Context): (List[(K, R, TyperState)], List[(K, EffektMessages)]) = {
+  def tryEach[K, R](inputs: List[K])(f: K => R)(using Context): (List[(K, R, TyperState)], List[(K, EffektMessages)]) = Context.timed("overload-resolution", Context.module.source.name) {
     val stateBefore = Context.backupTyperstate()
     val results = inputs.map {
       case input =>

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -1221,7 +1221,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
     Result(ret, effs)
   }
 
-  def tryEach[K, R](inputs: List[K])(f: K => R)(using Context): (List[(K, R, TyperState)], List[(K, EffektMessages)]) = Context.timed("overload-resolution", Context.module.source.name) {
+  def tryEach[K, R](inputs: List[K])(f: K => R)(using Context): (List[(K, R, TyperState)], List[(K, EffektMessages)]) = {
     val stateBefore = Context.backupTyperstate()
     val results = inputs.map {
       case input =>

--- a/effekt/shared/src/main/scala/effekt/context/Context.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Context.scala
@@ -47,6 +47,8 @@ abstract class Context(val positions: Positions)
   // bring the context itself in scope
   implicit val context: Context = this
 
+  var timersActive: Boolean = false
+
   // the currently processed module
   var module: Module = _
 
@@ -67,6 +69,7 @@ abstract class Context(val positions: Positions)
   def setup(cfg: EffektConfig): Unit = {
     messaging.clear()
     _config = cfg
+    timersActive = cfg.trace.isSupplied
   }
 
   def using[T](module: Module = module, focus: Tree = focus)(block: => T): T = this in {

--- a/effekt/shared/src/main/scala/effekt/context/Context.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Context.scala
@@ -6,6 +6,7 @@ import effekt.typer.TyperOps
 import effekt.core.TransformerOps
 import effekt.source.Tree
 import effekt.util.messages.{ ErrorReporter, EffektMessages }
+import effekt.util.Timers
 import effekt.symbols.Module
 
 import kiama.util.Positions
@@ -40,7 +41,8 @@ abstract class Context(val positions: Positions)
     extends NamerOps
     with TyperOps
     with ModuleDB
-    with TransformerOps {
+    with TransformerOps
+    with Timers {
 
   // bring the context itself in scope
   implicit val context: Context = this

--- a/effekt/shared/src/main/scala/effekt/context/Context.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Context.scala
@@ -47,8 +47,6 @@ abstract class Context(val positions: Positions)
   // bring the context itself in scope
   implicit val context: Context = this
 
-  var timersActive: Boolean = false
-
   // the currently processed module
   var module: Module = _
 
@@ -68,10 +66,10 @@ abstract class Context(val positions: Positions)
    */
   def setup(cfg: EffektConfig): Unit = {
     messaging.clear()
-    _config = cfg
     // No timings are captured in server mode to keep the memory footprint small. Since the server is run continuously,
     // the memory claimed by the timing information would increase continuously.
-    timersActive = cfg.timed()
+    clearTimers(cfg.timed())
+    _config = cfg
   }
 
   def using[T](module: Module = module, focus: Tree = focus)(block: => T): T = this in {

--- a/effekt/shared/src/main/scala/effekt/context/Context.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Context.scala
@@ -69,7 +69,9 @@ abstract class Context(val positions: Positions)
   def setup(cfg: EffektConfig): Unit = {
     messaging.clear()
     _config = cfg
-    timersActive = cfg.trace.isSupplied
+    // No timings are captured in server mode to keep the memory footprint small. Since the server is run continuously,
+    // the memory claimed by the timing information would increase continuously.
+    timersActive = cfg.trace.isSupplied && !cfg.server()
   }
 
   def using[T](module: Module = module, focus: Tree = focus)(block: => T): T = this in {

--- a/effekt/shared/src/main/scala/effekt/context/Context.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Context.scala
@@ -71,7 +71,7 @@ abstract class Context(val positions: Positions)
     _config = cfg
     // No timings are captured in server mode to keep the memory footprint small. Since the server is run continuously,
     // the memory claimed by the timing information would increase continuously.
-    timersActive = cfg.trace.isSupplied && !cfg.server()
+    timersActive = cfg.timed()
   }
 
   def using[T](module: Module = module, focus: Tree = focus)(block: => T): T = this in {

--- a/effekt/shared/src/main/scala/effekt/core/DirectStyleMutableState.scala
+++ b/effekt/shared/src/main/scala/effekt/core/DirectStyleMutableState.scala
@@ -24,7 +24,7 @@ object DirectStyleMutableState extends Phase[CoreTransformed, CoreTransformed] {
 
   override def run(input: CoreTransformed)(using Context): Option[CoreTransformed] = input match {
     case CoreTransformed(source, tree, mod, core) =>
-      val direct = directStyle.rewrite(core)
+      val direct = Context.timed(phaseName, source.name)(directStyle.rewrite(core))
       Some(CoreTransformed(source, tree, mod, direct))
   }
 

--- a/effekt/shared/src/main/scala/effekt/core/DirectStyleMutableState.scala
+++ b/effekt/shared/src/main/scala/effekt/core/DirectStyleMutableState.scala
@@ -24,7 +24,7 @@ object DirectStyleMutableState extends Phase[CoreTransformed, CoreTransformed] {
 
   override def run(input: CoreTransformed)(using Context): Option[CoreTransformed] = input match {
     case CoreTransformed(source, tree, mod, core) =>
-      val direct = Context.timed(phaseName, source.name)(directStyle.rewrite(core))
+      val direct = Context.timed(phaseName, source.name) { directStyle.rewrite(core) }
       Some(CoreTransformed(source, tree, mod, direct))
   }
 

--- a/effekt/shared/src/main/scala/effekt/core/LambdaLifting.scala
+++ b/effekt/shared/src/main/scala/effekt/core/LambdaLifting.scala
@@ -108,7 +108,8 @@ object LambdaLifting extends Phase[CoreTransformed, CoreTransformed] {
   def run(input: CoreTransformed)(using Context): Option[CoreTransformed] =
     input match {
       case CoreTransformed(source, tree, mod, core) =>
-        Some(CoreTransformed(source, tree, mod, lift(core)))
+        val lifted = Context.timed(phaseName, source.name)(lift(core))
+        Some(CoreTransformed(source, tree, mod, lifted))
     }
 
   def lift(m: core.ModuleDecl)(using Context): core.ModuleDecl =

--- a/effekt/shared/src/main/scala/effekt/core/LambdaLifting.scala
+++ b/effekt/shared/src/main/scala/effekt/core/LambdaLifting.scala
@@ -108,7 +108,7 @@ object LambdaLifting extends Phase[CoreTransformed, CoreTransformed] {
   def run(input: CoreTransformed)(using Context): Option[CoreTransformed] =
     input match {
       case CoreTransformed(source, tree, mod, core) =>
-        val lifted = Context.timed(phaseName, source.name)(lift(core))
+        val lifted = Context.timed(phaseName, source.name) { lift(core) }
         Some(CoreTransformed(source, tree, mod, lifted))
     }
 

--- a/effekt/shared/src/main/scala/effekt/core/MakeStackSafe.scala
+++ b/effekt/shared/src/main/scala/effekt/core/MakeStackSafe.scala
@@ -21,7 +21,7 @@ object MakeStackSafe extends Phase[CoreTransformed, CoreTransformed] {
 
   override def run(input: CoreTransformed)(using Context): Option[CoreTransformed] = input match {
     case CoreTransformed(source, tree, mod, core) =>
-      val safe = stacksafe.rewrite(core)
+      val safe = Context.timed(phaseName, source.name)(stacksafe.rewrite(core))
       Some(CoreTransformed(source, tree, mod, safe))
   }
 

--- a/effekt/shared/src/main/scala/effekt/core/MakeStackSafe.scala
+++ b/effekt/shared/src/main/scala/effekt/core/MakeStackSafe.scala
@@ -21,7 +21,7 @@ object MakeStackSafe extends Phase[CoreTransformed, CoreTransformed] {
 
   override def run(input: CoreTransformed)(using Context): Option[CoreTransformed] = input match {
     case CoreTransformed(source, tree, mod, core) =>
-      val safe = Context.timed(phaseName, source.name)(stacksafe.rewrite(core))
+      val safe = Context.timed(phaseName, source.name) { stacksafe.rewrite(core) }
       Some(CoreTransformed(source, tree, mod, safe))
   }
 

--- a/effekt/shared/src/main/scala/effekt/core/Optimizer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Optimizer.scala
@@ -11,7 +11,9 @@ object Optimizer extends Phase[CoreTransformed, CoreTransformed] {
   def run(input: CoreTransformed)(using Context): Option[CoreTransformed] =
     input match {
       case CoreTransformed(source, tree, mod, core) =>
-        Some(CoreTransformed(source, tree, mod, optimize(Context.checkMain(mod), core)))
+        val term = Context.checkMain(mod)
+        val optimized = Context.timed(phaseName, source.name)(optimize(term, core))
+        Some(CoreTransformed(source, tree, mod, optimized))
     }
 
   def optimize(mainSymbol: symbols.Symbol, core: ModuleDecl)(using Context): ModuleDecl =

--- a/effekt/shared/src/main/scala/effekt/core/Optimizer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Optimizer.scala
@@ -12,7 +12,7 @@ object Optimizer extends Phase[CoreTransformed, CoreTransformed] {
     input match {
       case CoreTransformed(source, tree, mod, core) =>
         val term = Context.checkMain(mod)
-        val optimized = Context.timed(phaseName, source.name)(optimize(term, core))
+        val optimized = Context.timed(phaseName, source.name) { optimize(term, core) }
         Some(CoreTransformed(source, tree, mod, optimized))
     }
 

--- a/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
@@ -93,7 +93,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
     case CoreTransformed(source, tree, mod, core) => {
       implicit val pctx: PContext = new PContext(core.declarations)
       Context.module = mod
-      val transformed = Context.timed(phaseName, source.name)(transform(core))
+      val transformed = Context.timed(phaseName, source.name) { transform(core) }
       Some(CoreTransformed(source, tree, mod, transformed))
     }
   }

--- a/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
@@ -93,7 +93,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
     case CoreTransformed(source, tree, mod, core) => {
       implicit val pctx: PContext = new PContext(core.declarations)
       Context.module = mod
-      val transformed = transform(core)
+      val transformed = Context.timed(phaseName, source.name)(transform(core))
       Some(CoreTransformed(source, tree, mod, transformed))
     }
   }

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -23,7 +23,8 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     if (Context.messaging.hasErrors) {
       None
     } else {
-      Some(CoreTransformed(source, tree, mod, transform(mod, tree)))
+      val transformed = Context.timed(phaseName, source.name)(transform(mod, tree))
+      Some(CoreTransformed(source, tree, mod, transformed))
     }
 
 

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -23,7 +23,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     if (Context.messaging.hasErrors) {
       None
     } else {
-      val transformed = Context.timed(phaseName, source.name)(transform(mod, tree))
+      val transformed = Context.timed(phaseName, source.name) { transform(mod, tree) }
       Some(CoreTransformed(source, tree, mod, transformed))
     }
 

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -19,7 +19,7 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
 
   def run(input: CoreTransformed)(using Context): Option[CoreLifted] =
     given Environment = Environment(Map.empty)
-    val transformed = transform(input.core)
+    val transformed = Context.timed(phaseName, input.source.name)(transform(input.core))
     Some(CoreLifted(input.source, input.tree, input.mod, transformed))
 
   // TODO either resolve and bind imports or use the knowledge that they are toplevel!

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -19,7 +19,7 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
 
   def run(input: CoreTransformed)(using Context): Option[CoreLifted] =
     given Environment = Environment(Map.empty)
-    val transformed = Context.timed(phaseName, input.source.name)(transform(input.core))
+    val transformed = Context.timed(phaseName, input.source.name) { transform(input.core) }
     Some(CoreLifted(input.source, input.tree, input.mod, transformed))
 
   // TODO either resolve and bind imports or use the knowledge that they are toplevel!

--- a/effekt/shared/src/main/scala/effekt/lifted/Monomorphize.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/Monomorphize.scala
@@ -22,7 +22,9 @@ object Monomorphize extends Phase[CoreLifted, CoreLifted] {
   val phaseName = "lift-inference"
 
   def run(lifted: CoreLifted)(using Context): Option[CoreLifted] =
-    run(lifted.core).map { mono => lifted.copy(core = mono) }
+    Context.timed(phaseName, lifted.source.name) {
+      run(lifted.core).map { mono => lifted.copy(core = mono) }
+    }
 
   def run(mod: ModuleDecl)(using C: Context): Option[ModuleDecl] = {
     given analysis: FlowAnalysis()

--- a/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
+++ b/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
@@ -21,7 +21,7 @@ object AnnotateCaptures extends Phase[Typechecked, Typechecked], Query[Unit, Cap
   def run(input: Typechecked)(using C: Context) =
     // reset allCaptures since multiple runs of this phase may pollute it with outdated information
     allCaptures = Nil
-    Context.timed(phaseName, input.source.name)(annotate(input.tree, input.source))
+    Context.timed(phaseName, input.source.name) { annotate(input.tree, input.source) }
     Some(input)
 
   // We collect all captures while traversing the tree.

--- a/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
+++ b/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
@@ -21,7 +21,7 @@ object AnnotateCaptures extends Phase[Typechecked, Typechecked], Query[Unit, Cap
   def run(input: Typechecked)(using C: Context) =
     // reset allCaptures since multiple runs of this phase may pollute it with outdated information
     allCaptures = Nil
-    annotate(input.tree, input.source)
+    Context.timed(phaseName, input.source.name)(annotate(input.tree, input.source))
     Some(input)
 
   // We collect all captures while traversing the tree.

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -25,9 +25,9 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
   val phaseName = "explicit-capabilities"
 
   def run(input: Typechecked)(using C: Context) =
-    val x = rewrite(input.tree)
+    val rewritten = C.timed(phaseName, input.source.name)(rewrite(input.tree))
 
-    Some(input.copy(tree = x))
+    Some(input.copy(tree = rewritten))
 
   override def defn(using Context) = {
     case f @ FunDef(id, tps, vps, bps, ret, body) =>

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -25,7 +25,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
   val phaseName = "explicit-capabilities"
 
   def run(input: Typechecked)(using C: Context) =
-    val rewritten = C.timed(phaseName, input.source.name)(rewrite(input.tree))
+    val rewritten = C.timed(phaseName, input.source.name) { rewrite(input.tree) }
 
     Some(input.copy(tree = rewritten))
 

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -11,7 +11,7 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
   val phaseName = "box-unbox"
 
   def run(input: NameResolved)(using Context) = {
-    val transformedTree = Context.timed(phaseName, input.source.name)(rewrite(input.tree))
+    val transformedTree = Context.timed(phaseName, input.source.name) { rewrite(input.tree) }
 
     if (Context.messaging.hasErrors) { None }
     else { Some(input.copy(tree = transformedTree)) }

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -11,7 +11,7 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
   val phaseName = "box-unbox"
 
   def run(input: NameResolved)(using Context) = {
-    val transformedTree = rewrite(input.tree)
+    val transformedTree = Context.timed(phaseName, input.source.name)(rewrite(input.tree))
 
     if (Context.messaging.hasErrors) { None }
     else { Some(input.copy(tree = transformedTree)) }

--- a/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
@@ -26,9 +26,9 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
 
   val phaseName = "wellformedness"
 
-  def run(input: Typechecked)(implicit C: Context) =
+  def run(input: Typechecked)(using C: Context) =
     val Typechecked(source, tree, mod) = input
-    check(mod, tree)
+    C.timed(phaseName, source.name)(check(mod, tree))
 
     if (Context.messaging.hasErrors) { None }
     else { Some(input) }

--- a/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
@@ -28,7 +28,7 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
 
   def run(input: Typechecked)(using C: Context) =
     val Typechecked(source, tree, mod) = input
-    C.timed(phaseName, source.name)(check(mod, tree))
+    C.timed(phaseName, source.name) { check(mod, tree) }
 
     if (Context.messaging.hasErrors) { None }
     else { Some(input) }

--- a/effekt/shared/src/main/scala/effekt/util/Timer.scala
+++ b/effekt/shared/src/main/scala/effekt/util/Timer.scala
@@ -9,13 +9,16 @@ case class Timed(name: String, time: Double)
  * The result is saved in map under a specified category with a unique identifier.
  */
 trait Timers {
-  /** Saves measured times under a "category" (e.g. "parser" - a phase name) together with a unique
+  /** 
+   * Saves measured times under a "category" (e.g. "parser" - a phase name) together with a unique
    * identifier, e.g., a filename. This is meant to be append only.
    */
   val times: mutable.LinkedHashMap[String, mutable.ListBuffer[Timed]] = mutable.LinkedHashMap.empty
 
   /** Whether the `timed` function is NOP or actual takes and saves the time. */
   var timersActive: Boolean
+  
+  def totalTime: Option[Double] = times.get("total").map(_.head.time)
 
   /**
    * Time the execution of `f` and save the result in the times database under the "category" `timerName`
@@ -28,7 +31,9 @@ trait Timers {
     res
   }
 
-  /// Convenience function for timing the execution of a given function.
+  /**
+   * Convenience function for timing the execution of a given function. 
+   */
   private def timed[A](f: => A): (A, Double) = {
     val start = System.nanoTime()
     val res = f
@@ -38,11 +43,13 @@ trait Timers {
 
   def timesToString(): String = {
     val buffer = StringBuilder()
-    val totalTimeSpent = times.foldLeft(0d) { (acc, values) =>
-      acc + values._2.foldLeft(0d)((acc, timed) => acc + timed.time)
+    val totalTimeSpent = totalTime.getOrElse {
+      times.foldLeft(0d) { (acc, values) =>
+        acc + values._2.foldLeft(0d)((acc, timed) => acc + timed.time)
+      }
     }
     for (((name, ts), i) <- times.zipWithIndex) {
-      buffer ++= s"$UNDERLINED$BOLD$i. $name$RESET:\n"
+      buffer ++= s"$UNDERLINED$BOLD${i + 1}. $name$RESET:\n"
       val totalsubtime = ts.foldLeft(0d)((acc, timed) => acc + timed.time)
       for (Timed(id, time) <- ts) {
         val id1 = if (id.isEmpty) "<repl>" else id

--- a/effekt/shared/src/main/scala/effekt/util/Timer.scala
+++ b/effekt/shared/src/main/scala/effekt/util/Timer.scala
@@ -10,10 +10,10 @@ case class Timed(name: String, time: Double)
  */
 trait Timers {
   /** Saves measured times under a "category" (e.g. "parser" - a phase name) together with a unique
-   * identifier, e.g., a filename. This is meant to be append only. 
+   * identifier, e.g., a filename. This is meant to be append only.
    */
   val times: mutable.LinkedHashMap[String, mutable.ListBuffer[Timed]] = mutable.LinkedHashMap.empty
-  
+
   /** Whether the `timed` function is NOP or actual takes and saves the time. */
   var timersActive: Boolean
 
@@ -47,14 +47,14 @@ trait Timers {
       for (Timed(id, time) <- ts) {
         val id1 = if (id.isEmpty) "<repl>" else id
         buffer ++= s"${" ".repeat(4)}"
-        buffer ++= s"$id1: ${time}%.2f ms\n"
+        buffer ++= f"$id1: ${time}%.2f ms\n"
       }
       buffer ++= s"\n${" ".repeat(4)}"
       buffer ++= f"${UNDERLINED}Total$RESET: $totalsubtime%.2f ms\n"
       buffer ++= " ".repeat(4)
-      buffer ++= s"${UNDERLINED}Percentage$RESET: ${(totalsubtime / totalTimeSpent)}%.2f %\n\n"
+      buffer ++= f"${UNDERLINED}Percentage$RESET: ${(totalsubtime / totalTimeSpent) * 100}%.2f %%\n\n"
     }
-    buffer ++= s"$BOLD${totalTimeSpent} ms$RESET\n"
+    buffer ++= f"$BOLD${totalTimeSpent}%.2f ms$RESET\n"
     buffer.toString()
   }
 

--- a/effekt/shared/src/main/scala/effekt/util/Timer.scala
+++ b/effekt/shared/src/main/scala/effekt/util/Timer.scala
@@ -2,86 +2,73 @@ package effekt.util
 
 import scala.collection.mutable
 import scala.io.AnsiColor.*
+case class Timed(name: String, time: Double)
 
 /**
- * A timed event.
+ * Trait for timing events. Using the `timed` function, a new event can be timed.
+ * The result is saved in map under a specified category with a unique identifier.
  */
-case class Timed(name: String, time: Long)
-
 trait Timers {
-  val times: mutable.Map[String, mutable.ListBuffer[Timed]] = mutable.Map.empty
-
-  def showTimes(): Unit = {
-    val totalTimeSpent: Long = times.foldLeft(0: Long) { (acc, values) =>
-      acc + values._2.foldLeft(0: Long)((acc, timed) => acc + timed.time)
-    }
-    for ((name, ts) <- times) {
-      println(s"$UNDERLINED$BOLD$name$RESET:")
-      val totalsubtime = ts.foldLeft(0: Long)((acc, timed) => acc + timed.time)
-      for (Timed(id, time) <- ts) {
-        val id1 = if (id.isEmpty) "<repl>" else id
-        print(" ".repeat(4))
-        println(s"$id1: ${time * 1e-6} ms")
-      }
-      print(" ".repeat(4))
-      println(s"${UNDERLINED}Total$RESET: ${totalsubtime * 1e-6} ms")
-      print(" ".repeat(4))
-      println(s"${UNDERLINED}Percentage$RESET: ${(totalsubtime.toDouble / totalTimeSpent) * 100} %")
-      println()
-    }
-    println(s"$BOLD${totalTimeSpent * 1e-6} ms$RESET")
-  }
-
-  /// Convenience function for timing the execution of a given function.
-  private def timed[A](f: => A): (A, Long) = {
-    val start = System.nanoTime()
-    val res = f
-    val duration = System.nanoTime() - start
-    (res, duration)
-  }
+  /** Saves measured times under a "category" (e.g. "parser" - a phase name) together with a unique
+   * identifier, e.g., a filename. This is meant to be append only. 
+   */
+  val times: mutable.LinkedHashMap[String, mutable.ListBuffer[Timed]] = mutable.LinkedHashMap.empty
+  
+  /** Whether the `timed` function is NOP or actual takes and saves the time. */
+  var timersActive: Boolean
 
   /**
    * Time the execution of `f` and save the result in the times database under the "category" `timerName`
    * and the event `id`.
    */
   def timed[A](timerName: String, id: String)(f: => A): A = {
+    if (!timersActive) return f
     val (res, duration) = timed(f)
     times.update(timerName, times.getOrElse(timerName, mutable.ListBuffer.empty).prepend(Timed(id, duration)))
     res
   }
-}
 
-case class Stopwatch() {
-  /// stopwatch start time in nano seconds.
-  private var startTime: Option[Long] = None
-  /// stopwatch end time in nano seconds
-  private var endTime: Option[Long] = None
-
-  def start(): Long = {
-    val timestamp = System.nanoTime()
-    startTime = Some(timestamp)
-    endTime = None
-    timestamp
-  }
-
-  def stop(): Long = {
-    val timestamp = System.nanoTime()
-    endTime = Some(timestamp)
-    startTime.map(t => timestamp - t).getOrElse(0)
-  }
-
-  def duration: Long =
-    (for {
-      start <- startTime
-      end <- endTime
-    } yield end - start).getOrElse(0)
-}
-
-case object Stopwatch {
-  def timed[A](f: => A): (A, Long) = {
-    val s = Stopwatch()
-    s.start()
+  /// Convenience function for timing the execution of a given function.
+  private def timed[A](f: => A): (A, Double) = {
+    val start = System.nanoTime()
     val res = f
-    (res, s.stop())
-  } 
+    val duration = (System.nanoTime() - start) * 1e-6
+    (res, duration)
+  }
+
+  def timesToString(): String = {
+    val buffer = StringBuilder()
+    val totalTimeSpent = times.foldLeft(0d) { (acc, values) =>
+      acc + values._2.foldLeft(0d)((acc, timed) => acc + timed.time)
+    }
+    for (((name, ts), i) <- times.zipWithIndex) {
+      buffer ++= s"$UNDERLINED$BOLD$i. $name$RESET:\n"
+      val totalsubtime = ts.foldLeft(0d)((acc, timed) => acc + timed.time)
+      for (Timed(id, time) <- ts) {
+        val id1 = if (id.isEmpty) "<repl>" else id
+        buffer ++= s"${" ".repeat(4)}"
+        buffer ++= s"$id1: ${time}%.2f ms\n"
+      }
+      buffer ++= s"\n${" ".repeat(4)}"
+      buffer ++= f"${UNDERLINED}Total$RESET: $totalsubtime%.2f ms\n"
+      buffer ++= " ".repeat(4)
+      buffer ++= s"${UNDERLINED}Percentage$RESET: ${(totalsubtime / totalTimeSpent)}%.2f %\n\n"
+    }
+    buffer ++= s"$BOLD${totalTimeSpent} ms$RESET\n"
+    buffer.toString()
+  }
+
+  def timesToJSON(): String = {
+    val buffer = StringBuilder("{\n")
+    for ((name, ts) <- times) {
+      buffer ++= s"${" ".repeat(4)}\"$name\": {\n"
+      for (Timed(name, time) <- ts) {
+        val name1 = if (name.isEmpty) "<repl>" else name
+        buffer ++= s"${" ".repeat(8)}\"$name1\": $time,\n"
+      }
+      buffer ++= s"${" ".repeat(4)}},\n"
+    }
+    buffer ++= "}"
+    buffer.toString()
+  }
 }

--- a/effekt/shared/src/main/scala/effekt/util/Timer.scala
+++ b/effekt/shared/src/main/scala/effekt/util/Timer.scala
@@ -1,0 +1,87 @@
+package effekt.util
+
+import scala.collection.mutable
+import scala.io.AnsiColor.*
+
+/**
+ * A timed event.
+ */
+case class Timed(name: String, time: Long)
+
+trait Timers {
+  val times: mutable.Map[String, mutable.ListBuffer[Timed]] = mutable.Map.empty
+
+  def showTimes(): Unit = {
+    val totalTimeSpent: Long = times.foldLeft(0: Long) { (acc, values) =>
+      acc + values._2.foldLeft(0: Long)((acc, timed) => acc + timed.time)
+    }
+    for ((name, ts) <- times) {
+      println(s"$UNDERLINED$BOLD$name$RESET:")
+      val totalsubtime = ts.foldLeft(0: Long)((acc, timed) => acc + timed.time)
+      for (Timed(id, time) <- ts) {
+        val id1 = if (id.isEmpty) "<repl>" else id
+        print(" ".repeat(4))
+        println(s"$id1: ${time * 1e-6} ms")
+      }
+      print(" ".repeat(4))
+      println(s"${UNDERLINED}Total$RESET: ${totalsubtime * 1e-6} ms")
+      print(" ".repeat(4))
+      println(s"${UNDERLINED}Percentage$RESET: ${(totalsubtime.toDouble / totalTimeSpent) * 100} %")
+      println()
+    }
+    println(s"$BOLD${totalTimeSpent * 1e-6} ms$RESET")
+  }
+
+  /// Convenience function for timing the execution of a given function.
+  private def timed[A](f: => A): (A, Long) = {
+    val start = System.nanoTime()
+    val res = f
+    val duration = System.nanoTime() - start
+    (res, duration)
+  }
+
+  /**
+   * Time the execution of `f` and save the result in the times database under the "category" `timerName`
+   * and the event `id`.
+   */
+  def timed[A](timerName: String, id: String)(f: => A): A = {
+    val (res, duration) = timed(f)
+    times.update(timerName, times.getOrElse(timerName, mutable.ListBuffer.empty).prepend(Timed(id, duration)))
+    res
+  }
+}
+
+case class Stopwatch() {
+  /// stopwatch start time in nano seconds.
+  private var startTime: Option[Long] = None
+  /// stopwatch end time in nano seconds
+  private var endTime: Option[Long] = None
+
+  def start(): Long = {
+    val timestamp = System.nanoTime()
+    startTime = Some(timestamp)
+    endTime = None
+    timestamp
+  }
+
+  def stop(): Long = {
+    val timestamp = System.nanoTime()
+    endTime = Some(timestamp)
+    startTime.map(t => timestamp - t).getOrElse(0)
+  }
+
+  def duration: Long =
+    (for {
+      start <- startTime
+      end <- endTime
+    } yield end - start).getOrElse(0)
+}
+
+case object Stopwatch {
+  def timed[A](f: => A): (A, Long) = {
+    val s = Stopwatch()
+    s.start()
+    val res = f
+    (res, s.stop())
+  } 
+}


### PR DESCRIPTION
This PR closes #403 by adding timing capabilities to the context.

- I am not really happy with the way the measurements are serialised (`timesToString`, `timesToJSON`). It feels a bit inelegant to do raw string manipulation.
- No timing information is captured in server mode to avoid "memory leaks", i.e., since the map in which the timing information is saved is append only, multiple runs of the server would claim continuously more memory. Also, timing information across multiple runs without clearing the information of the previous is worthless.
- *Every* phase needs to manually add the `Context.timed` function if it is to be measured. This is an implicit invariant that needs to be upheld by the programmer. This comes with the benefit of increased flexibility. For example, in `namer` we can ignore subsequent runs of the frontend for dependencies. Furthermore, `Context.timed` can not only be used for timing phases, but also "subphases", for example, only one function in the `typer`.
- The JSON output is saved the given (or default) output directory and has the same name as the input source file with `.json` append to it.

## Showcase

<details>
<summary>Plain text output</summary>

```
$  effekt -t text examples/casestudies/prettyprinter.effekt.md  
...
[info] 1. parser:
    /Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt: 173.77 ms
    /Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt: 50.64 ms
    /Users/david/Develop/effekt/effekt/libraries/js/io/args.effekt: 3.64 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt: 599.75 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt: 38.35 ms
    /Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt: 192.39 ms
    examples/benchmarks/nqueens.effekt: 211.32 ms

    Total: 1269.85 ms
    Percentage: 61.82 %

2. namer:
    examples/benchmarks/nqueens.effekt: 4.30 ms
    /Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt: 4.13 ms
    /Users/david/Develop/effekt/effekt/libraries/js/io/args.effekt: 0.20 ms
    /Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt: 2.90 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt: 17.63 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt: 4.11 ms
    /Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt: 36.09 ms

    Total: 69.35 ms
    Percentage: 3.38 %

3. box-unbox:
    examples/benchmarks/nqueens.effekt: 0.80 ms
    /Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt: 1.31 ms
    /Users/david/Develop/effekt/effekt/libraries/js/io/args.effekt: 0.04 ms
    /Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt: 6.13 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt: 3.51 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt: 1.12 ms
    /Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt: 3.19 ms

    Total: 16.11 ms
    Percentage: 0.78 %

4. typer:
    examples/benchmarks/nqueens.effekt: 6.98 ms
    /Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt: 3.87 ms
    /Users/david/Develop/effekt/effekt/libraries/js/io/args.effekt: 0.25 ms
    /Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt: 9.85 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt: 272.56 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt: 13.22 ms
    /Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt: 73.58 ms

    Total: 380.33 ms
    Percentage: 18.52 %

5. wellformedness:
    examples/benchmarks/nqueens.effekt: 0.92 ms
    /Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt: 0.36 ms
    /Users/david/Develop/effekt/effekt/libraries/js/io/args.effekt: 0.05 ms
    /Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt: 0.50 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt: 3.24 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt: 2.81 ms
    /Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt: 8.08 ms

    Total: 15.97 ms
    Percentage: 0.78 %

6. explicit-capabilities:
    /Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt: 3.09 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt: 0.64 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt: 3.20 ms
    /Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt: 1.07 ms
    /Users/david/Develop/effekt/effekt/libraries/js/io/args.effekt: 0.08 ms
    /Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt: 0.63 ms
    examples/benchmarks/nqueens.effekt: 4.24 ms

    Total: 12.95 ms
    Percentage: 0.63 %

7. annotate-captures:
    /Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt: 2.31 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt: 0.34 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt: 3.02 ms
    /Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt: 1.25 ms
    /Users/david/Develop/effekt/effekt/libraries/js/io/args.effekt: 0.07 ms
    /Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt: 0.50 ms
    examples/benchmarks/nqueens.effekt: 111.72 ms

    Total: 119.20 ms
    Percentage: 5.80 %

8. transformer:
    /Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt: 3.10 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt: 5.82 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt: 19.29 ms
    /Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt: 2.93 ms
    /Users/david/Develop/effekt/effekt/libraries/js/io/args.effekt: 0.09 ms
    /Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt: 1.64 ms
    examples/benchmarks/nqueens.effekt: 23.25 ms

    Total: 56.13 ms
    Percentage: 2.73 %

9. direct style mutable state:
    /Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt: 0.46 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt: 0.28 ms
    /Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt: 7.83 ms
    /Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt: 0.86 ms
    /Users/david/Develop/effekt/effekt/libraries/js/io/args.effekt: 0.04 ms
    /Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt: 0.17 ms
    examples/benchmarks/nqueens.effekt: 4.19 ms

    Total: 13.82 ms
    Percentage: 0.67 %

10. core-optimizer:
    examples/benchmarks/nqueens.effekt: 4.15 ms

    Total: 4.15 ms
    Percentage: 0.20 %

11. stacksafe:
    examples/benchmarks/nqueens.effekt: 1.63 ms

    Total: 1.63 ms
    Percentage: 0.08 %

12. core-lambdalifting:
    examples/benchmarks/nqueens.effekt: 94.55 ms

    Total: 94.55 ms
    Percentage: 4.60 %

2054.03 ms
```

</details>

<details>
<summary>JSON output</summary>

```
$ effekt -t json examples/casestudies/prettyprinter.effekt.md
$ cat out/prettyprinter.effekt.md.json
{
    "parser": {
        "/Users/david/Develop/effekt/effekt/libraries/js/text/regex.effekt": 7.970790999999999,
        "/Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt": 36.601625,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt": 34.576875,
        "./examples/casestudies/lexer.effekt.md": 79.106375,
        "./examples/casestudies/parser.effekt.md": 103.629125,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt": 601.6922079999999,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt": 46.664541,
        "/Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt": 190.03466699999998,
        "examples/casestudies/prettyprinter.effekt.md": 436.063042,
    },
    "namer": {
        "examples/casestudies/prettyprinter.effekt.md": 5.067082999999999,
        "./examples/casestudies/parser.effekt.md": 4.919125,
        "./examples/casestudies/lexer.effekt.md": 7.566624999999999,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/regex.effekt": 3.027333,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt": 1.13675,
        "/Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt": 2.7069579999999998,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt": 18.390957999999998,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt": 4.48875,
        "/Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt": 34.233540999999995,
    },
    "box-unbox": {
        "examples/casestudies/prettyprinter.effekt.md": 3.1925,
        "./examples/casestudies/parser.effekt.md": 0.9613339999999999,
        "./examples/casestudies/lexer.effekt.md": 0.888791,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/regex.effekt": 0.09766599999999999,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt": 0.227125,
        "/Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt": 0.622459,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt": 7.826124999999999,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt": 0.935125,
        "/Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt": 3.393833,
    },
    "typer": {
        "examples/casestudies/prettyprinter.effekt.md": 68.665667,
        "./examples/casestudies/parser.effekt.md": 52.690915999999994,
        "./examples/casestudies/lexer.effekt.md": 137.186792,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/regex.effekt": 1.026958,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt": 2.660166,
        "/Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt": 10.263874999999999,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt": 159.53295799999998,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt": 13.217417,
        "/Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt": 72.84075,
    },
    "wellformedness": {
        "examples/casestudies/prettyprinter.effekt.md": 1.772459,
        "./examples/casestudies/parser.effekt.md": 1.618334,
        "./examples/casestudies/lexer.effekt.md": 0.938333,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/regex.effekt": 0.175709,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt": 0.354916,
        "/Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt": 0.507084,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt": 3.039625,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt": 2.7631669999999997,
        "/Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt": 8.616875,
    },
    "explicit-capabilities": {
        "/Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt": 0.6916249999999999,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt": 0.329458,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt": 1.891541,
        "/Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt": 0.7284999999999999,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt": 0.623333,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/regex.effekt": 0.25504099999999996,
        "./examples/casestudies/lexer.effekt.md": 11.769833,
        "./examples/casestudies/parser.effekt.md": 2.82875,
        "examples/casestudies/prettyprinter.effekt.md": 8.84325,
    },
    "annotate-captures": {
        "/Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt": 1.814416,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt": 1.593125,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt": 1.531667,
        "/Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt": 0.574458,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt": 0.275458,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/regex.effekt": 0.155417,
        "./examples/casestudies/lexer.effekt.md": 1.564667,
        "./examples/casestudies/parser.effekt.md": 2.0008749999999997,
        "examples/casestudies/prettyprinter.effekt.md": 7.052083,
    },
    "transformer": {
        "/Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt": 2.247333,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt": 0.954417,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt": 47.414167,
        "/Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt": 1.473917,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt": 0.930125,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/regex.effekt": 3.2304169999999996,
        "./examples/casestudies/lexer.effekt.md": 3.029083,
        "./examples/casestudies/parser.effekt.md": 21.610416999999998,
        "examples/casestudies/prettyprinter.effekt.md": 50.337333,
    },
    "direct style mutable state": {
        "/Users/david/Develop/effekt/effekt/libraries/js/effekt.effekt": 0.402833,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/option.effekt": 0.21095799999999998,
        "/Users/david/Develop/effekt/effekt/libraries/js/immutable/list.effekt": 2.132792,
        "/Users/david/Develop/effekt/effekt/libraries/js/mutable/array.effekt": 0.39299999999999996,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/string.effekt": 0.117958,
        "/Users/david/Develop/effekt/effekt/libraries/js/text/regex.effekt": 0.09716699999999999,
        "./examples/casestudies/lexer.effekt.md": 0.994417,
        "./examples/casestudies/parser.effekt.md": 1.4269589999999999,
        "examples/casestudies/prettyprinter.effekt.md": 17.259999999999998,
    },
    "core-optimizer": {
        "examples/casestudies/prettyprinter.effekt.md": 13.316374999999999,
    },
    "stacksafe": {
        "examples/casestudies/prettyprinter.effekt.md": 8.87175,
    },
    "core-lambdalifting": {
        "examples/casestudies/prettyprinter.effekt.md": 47.739999999999995,
    },
}
```

</details>