### PR TITLE
Fix highlights for consoles with white text color

### DIFF
--- a/effekt/shared/src/main/scala/effekt/util/ColoredMessaging.scala
+++ b/effekt/shared/src/main/scala/effekt/util/ColoredMessaging.scala
@@ -139,8 +139,8 @@ class AnsiColoredMessaging extends ColoredMessaging {
   def red(s: String): String = Console.RED + s + Console.RESET
   def white(s: String): String = Console.WHITE + s + Console.RESET
   def bold(s: String): String = Console.BOLD + s + Console.RESET
-  def bold_red(s: String): String = Console.RED_B + s + Console.RESET
-  def highlight(s: String): String = Console.WHITE_B + s + Console.RESET
+  def bold_red(s: String): String = Console.BLACK + Console.RED_B + s + Console.RESET
+  def highlight(s: String): String = Console.BLACK + Console.WHITE_B + s + Console.RESET
   def underlined(s: String): String = Console.UNDERLINED + s + Console.RESET
 }
 


### PR DESCRIPTION
On systems with white text color, highlights make the text invisible. This is the default for several of my machines. The issue can be easily fixed by also forcing the text/foreground color to be black using ANSI escape codes.

Before:
![image](https://github.com/effekt-lang/effekt/assets/32108934/900d876b-222a-44bf-82ae-9486606d1af0)

After:
![image](https://github.com/effekt-lang/effekt/assets/32108934/63481fe0-6861-46db-94cd-5320f8a819b0)
