### PR TITLE
Add Existentials

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/MLTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/MLTests.scala
@@ -54,6 +54,7 @@ class MLTests extends EffektTests {
     //    examplesDir / "pos" / "lambdas" / "localstate.effekt",
     //    examplesDir / "pos" / "lambdas" / "simpleclosure.effekt",
 
+
     // region-based memory management is not yet supported (monomorphization would only work for type monomorphic regions)
     examplesDir / "pos" / "recursiveobject.effekt",
 
@@ -68,6 +69,7 @@ class MLTests extends EffektTests {
     examplesDir / "pos" / "dequeue.effekt",
     examplesDir / "pos" / "matchblock.effekt",
     examplesDir / "pos" / "polymorphic" / "exceptions.effekt",
+    examplesDir / "pos" / "exists.effekt", // now show instance for existentials
 
     // polymorphic effect operation not supported
     examplesDir / "pos" / "existentials.effekt",

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -369,7 +369,7 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
     )
 
   lazy val constructor: P[Constructor] =
-    idDef ~ valueParams ^^ Constructor.apply
+    idDef ~ maybeTypeParams ~ valueParams ^^ Constructor.apply
 
   /**
    * Expressions

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -546,21 +546,24 @@ object Typer extends Phase[NameResolved, Typechecked] {
       // symbol of the constructor we match against
       val sym: Constructor = p.definition
 
+      val universals   = sym.tparams.take(sym.tpe.tparams.size)
+      val existentials = sym.tparams.drop(sym.tpe.tparams.size)
+
+      // create fresh unification variables
+      val freshUniversals   = universals.map { t => Context.freshTypeVar(t, pattern) }
+      // create fresh **bound** variables
+      val freshExistentials = existentials.map { t => TypeVar.TypeParam(t.name) }
+
+      val targs = (freshUniversals ++ freshExistentials).map { t => ValueTypeRef(t) }
+
       // (4) Compute blocktype of this constructor with rigid type vars
       // i.e. Cons : `(?t1, List[?t1]) => List[?t1]`
-      val (trigids, crigids, FunctionType(_, _, vps, _, ret, _)) = Context.instantiateFresh(sym.toType)
+      val FunctionType(_, _, vps, _, ret, _) = Context.instantiate(sym.toType, targs, Nil)
 
       // (5) given a scrutinee of `List[Int]`, we learn `?t1 -> Int`
       matchPattern(sc, ret, p)
 
-      // (6) check for existential type variables
-      // at the moment we do not allow existential type parameters on constructors, so this is not necessary.
-      //      val skolems = Context.skolems(rigids)
-      //      if (skolems.nonEmpty) {
-      //        Context.error(s"Unbound type variables in constructor ${id}: ${skolems.map(_.underlying).mkString(", ")}")
-      //      }
-
-      // (8) check nested patterns
+      // (6) check nested patterns
       var bindings = Map.empty[Symbol, ValueType]
 
       if (patterns.size != vps.size)

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -364,9 +364,8 @@ export CallTarget.*
 
 // Declarations
 // ------------
-case class Constructor(id: IdDef, params: List[ValueParam]) extends Definition
+case class Constructor(id: IdDef, tparams: List[Id], params: List[ValueParam]) extends Definition
 case class Operation(id: IdDef, tparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: Effectful) extends Definition
-
 
 // Implementations
 // ---------------

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -264,15 +264,15 @@ case class Constructor(name: Name, tparams: List[TypeParam], var fields: List[Fi
   lazy val vparams: List[ValueParam] = fields.map { f => f.param }
   val bparams: List[BlockParam] = Nil
 
-  val returnType: ValueType = ValueTypeApp(tpe, tparams map ValueTypeRef.apply)
-  def annotatedResult: Option[ValueType] = Some(returnType)
+  val appliedDatatype: ValueType = ValueTypeApp(tpe, tpe.tparams map ValueTypeRef.apply)
+  def annotatedResult: Option[ValueType] = Some(appliedDatatype)
   def annotatedEffects: Option[Effects] = Some(Effects.Pure)
 }
 
 // TODO maybe split into Field (the symbol) and Selector (the synthetic function)
 case class Field(name: Name, param: ValueParam, constructor: Constructor) extends Callable {
   val tparams: List[TypeParam] = constructor.tparams
-  val vparams = List(ValueParam(constructor.name, Some(constructor.returnType)))
+  val vparams = List(ValueParam(constructor.name, Some(constructor.appliedDatatype)))
   val bparams = List.empty[BlockParam]
 
   val returnType = param.tpe.get

--- a/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
@@ -292,7 +292,7 @@ object ExhaustivityChecker {
       // matched against.
       patterns.head match {
         case (sc, Pattern.Tag(constructor, ps)) =>
-          checkScrutinee(sc, constructor.returnType, head :: alternatives)
+          checkScrutinee(sc, constructor.appliedDatatype, head :: alternatives)
         case (sc, Pattern.Literal(lit, tpe)) =>
           checkScrutinee(sc, tpe, head :: alternatives)
         case (sc, Pattern.Any()) =>

--- a/examples/neg/exists_extrudes.effekt
+++ b/examples/neg/exists_extrudes.effekt
@@ -1,0 +1,15 @@
+type Exists {
+  Op[Z](el: Z, combine: (Z, Z) => Z at {})
+}
+
+def test2extruding() = {
+  val intBox = Op(1, box { (x, y) => x + y });
+
+  val x = intBox match {
+    case Op(el, combine) => el
+  }
+  x + 2 // ERROR Cannot typecheck
+}
+
+
+def main() = test2extruding()

--- a/examples/neg/exists_fresh.effekt
+++ b/examples/neg/exists_fresh.effekt
@@ -1,0 +1,16 @@
+type Exists {
+  Op[Z](el: Z, combine: (Z, Z) => Z at {})
+}
+
+def test2fresh() = {
+  val intBox = Op(1, box { (x, y) => x + y });
+
+  def twoBoxes(b1: Exists, b2: Exists) = (b1, b2) match {
+    case (Op(el1, combine1), Op(el2, combine2)) =>
+      combine2(el2, el1) // ERROR Expected Z but got Z
+  }
+  twoBoxes(intBox, intBox)
+}
+
+
+def main() = test2fresh()

--- a/examples/pos/exists.check
+++ b/examples/pos/exists.check
@@ -1,0 +1,2 @@
+2
+hello!hello!

--- a/examples/pos/exists.check
+++ b/examples/pos/exists.check
@@ -1,2 +1,4 @@
 2
 hello!hello!
+2
+hello!hello!

--- a/examples/pos/exists.effekt
+++ b/examples/pos/exists.effekt
@@ -15,5 +15,25 @@ def test1() = {
   combineAndPrint(stringBox)
 }
 
+def test2() = {
+  val intBox = Op(1, box { (x, y) => x + y });
+  val stringBox = Op("hello!", box { (x, y) => x ++ y });
 
-def main() = test1()
+  def repack(op: Exists): Exists = op match {
+    case Op(el, combine) => Op(el, combine)
+  }
+
+  def combineAndPrint(op: Exists): Unit = op match {
+    case Op(el, combine) => println(combine(el, el))
+  }
+
+  combineAndPrint(repack(intBox))
+  combineAndPrint(repack(stringBox))
+}
+
+
+
+def main() = {
+  test1();
+  test2()
+}

--- a/examples/pos/exists.effekt
+++ b/examples/pos/exists.effekt
@@ -1,0 +1,28 @@
+type Exists {
+  Op[Z](el: Z, combine: (Z, Z) => Z at {})
+}
+
+
+def test1() = {
+  val intBox = Op(1, box { (x, y) => x + y });
+  val stringBox = Op("hello!", box { (x, y) => x ++ y });
+
+  def combineAndPrint(op: Exists): Unit = op match {
+    case Op(el, combine) => println(combine(el, el))
+  }
+
+  combineAndPrint(intBox)
+  combineAndPrint(stringBox)
+}
+
+// def test2extruding() = {
+//   val intBox = Op(1, box { (x, y) => x + y });
+
+//   val x = intBox match {
+//     case Op(el, combine) => el
+//   }
+//   x + 2 // ERROR Cannot typecheck
+// }
+
+
+def main() = test1()

--- a/examples/pos/exists.effekt
+++ b/examples/pos/exists.effekt
@@ -15,14 +15,5 @@ def test1() = {
   combineAndPrint(stringBox)
 }
 
-// def test2extruding() = {
-//   val intBox = Op(1, box { (x, y) => x + y });
-
-//   val x = intBox match {
-//     case Op(el, combine) => el
-//   }
-//   x + 2 // ERROR Cannot typecheck
-// }
-
 
 def main() = test1()


### PR DESCRIPTION
On popular demand, this PR brings existentials back (fixes #245)

However, there are still a few things that need to be done. 


### Before Merging
 - [ ] More extensive testing. Maybe someone can help with this?

### After Merging
In follow up PRs we could
- [ ] check scope extrusion (see the neg test for how this looks like at the moment) and report better errors
- [ ] allow annotating type parameters on matches to bind them in the pattern (and actually in guards). This is somewhat related to what @dvdvgt is working on right now.