### PR TITLE
Add shortcutting for boolean operations

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -617,6 +617,7 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
   private def binaryOp(lhs: Term, op: String, rhs: Term): Term =
      Call(IdTarget(IdRef(Nil, opName(op))), Nil, List(lhs, rhs), Nil)
 
+  // thunkedBinaryOp(lhs, op, rhs) = op { lhs } { rhs }
   private def thunkedBinaryOp(lhs: Term, op: String, rhs: Term): Term =
      Call(IdTarget(IdRef(Nil, thunkedOpName(op))), Nil, Nil, List(BlockLiteral(Nil, Nil, Nil, Return(lhs)), BlockLiteral(Nil, Nil, Nil, Return(rhs))))
 

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -375,8 +375,8 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
    * Expressions
    */
   lazy val expr:    P[Term] = matchExpr | assignExpr | orExpr | failure("Expected an expression")
-  lazy val orExpr:  P[Term] = orExpr  ~ "||" ~/ andExpr ^^ liftedBinaryOp | andExpr
-  lazy val andExpr: P[Term] = andExpr ~ "&&" ~/ eqExpr ^^ liftedBinaryOp | eqExpr
+  lazy val orExpr:  P[Term] = orExpr  ~ "||" ~/ andExpr ^^ thunkedBinaryOp | andExpr
+  lazy val andExpr: P[Term] = andExpr ~ "&&" ~/ eqExpr ^^ thunkedBinaryOp | eqExpr
   lazy val eqExpr:  P[Term] = eqExpr  ~ oneof("==", "!=") ~/ relExpr ^^ binaryOp | relExpr
   lazy val relExpr: P[Term] = relExpr ~ oneof("<=", ">=", "<", ">") ~/ addExpr ^^ binaryOp | addExpr
   lazy val addExpr: P[Term] = addExpr ~ oneof("++", "+", "-") ~/ mulExpr ^^ binaryOp | mulExpr
@@ -617,10 +617,10 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
   private def binaryOp(lhs: Term, op: String, rhs: Term): Term =
      Call(IdTarget(IdRef(Nil, opName(op))), Nil, List(lhs, rhs), Nil)
 
-  private def liftedBinaryOp(lhs: Term, op: String, rhs: Term): Term =
-     Call(IdTarget(IdRef(Nil, liftedOpName(op))), Nil, Nil, List(BlockLiteral(Nil, Nil, Nil, Return(lhs)), BlockLiteral(Nil, Nil, Nil, Return(rhs))))
+  private def thunkedBinaryOp(lhs: Term, op: String, rhs: Term): Term =
+     Call(IdTarget(IdRef(Nil, thunkedOpName(op))), Nil, Nil, List(BlockLiteral(Nil, Nil, Nil, Return(lhs)), BlockLiteral(Nil, Nil, Nil, Return(rhs))))
 
-  private def liftedOpName(op: String): String = op match {
+  private def thunkedOpName(op: String): String = op match {
     case "||" => "infixOr"
     case "&&" => "infixAnd"
   }

--- a/examples/pos/shortcutting_bool_ops.check
+++ b/examples/pos/shortcutting_bool_ops.check
@@ -1,0 +1,9 @@
+hello
+
+hello
+bye
+
+bye
+hello
+
+bye

--- a/examples/pos/shortcutting_bool_ops.effekt
+++ b/examples/pos/shortcutting_bool_ops.effekt
@@ -1,0 +1,19 @@
+def foo(): Bool = {
+  println("hello")
+  false
+}
+
+def bar(): Bool = {
+  println("bye")
+  true
+}
+
+def main() = {
+  foo() && bar()
+  println("")
+  foo() || bar()
+  println("")
+  bar() && foo()
+  println("")
+  bar() || foo()
+}

--- a/libraries/chez/callcc/effekt.effekt
+++ b/libraries/chez/callcc/effekt.effekt
@@ -141,11 +141,11 @@ extern pure def infixGte(x: Double, y: Double): Bool =
 extern pure def not(b: Bool): Bool =
   "(not ${b})"
 
-extern pure def infixOr(x: Bool, y: Bool): Bool =
-  "(or ${x} ${y})"
+def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) true else second()
 
-extern pure def infixAnd(x: Bool, y: Bool): Bool =
-  "(and ${x} ${y})"
+def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) second() else false
 
 // Should only be used internally since values in Effekt should not be undefined
 extern pure def isUndefined[A](value: A): Bool =

--- a/libraries/chez/callcc/effekt.effekt
+++ b/libraries/chez/callcc/effekt.effekt
@@ -141,10 +141,10 @@ extern pure def infixGte(x: Double, y: Double): Bool =
 extern pure def not(b: Bool): Bool =
   "(not ${b})"
 
-def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixOr { first: => Bool } { second: => Bool }: Bool = 
   if (first()) true else second()
 
-def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixAnd { first: => Bool } { second: => Bool }: Bool = 
   if (first()) second() else false
 
 // Should only be used internally since values in Effekt should not be undefined

--- a/libraries/chez/lift/effekt.effekt
+++ b/libraries/chez/lift/effekt.effekt
@@ -137,10 +137,10 @@ extern pure def infixGte(x: Double, y: Double): Bool =
 extern pure def not(b: Bool): Bool =
   "(not ${b})"
 
-def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixOr { first: => Bool } { second: => Bool }: Bool = 
   if (first()) true else second()
 
-def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixAnd { first: => Bool } { second: => Bool }: Bool = 
   if (first()) second() else false
 
 // Should only be used internally since values in Effekt should not be undefined

--- a/libraries/chez/lift/effekt.effekt
+++ b/libraries/chez/lift/effekt.effekt
@@ -137,11 +137,11 @@ extern pure def infixGte(x: Double, y: Double): Bool =
 extern pure def not(b: Bool): Bool =
   "(not ${b})"
 
-extern pure def infixOr(x: Bool, y: Bool): Bool =
-  "(or ${x} ${y})"
+def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) true else second()
 
-extern pure def infixAnd(x: Bool, y: Bool): Bool =
-  "(and ${x} ${y})"
+def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) second() else false
 
 // Should only be used internally since values in Effekt should not be undefined
 extern pure def isUndefined[A](value: A): Bool =

--- a/libraries/chez/monadic/effekt.effekt
+++ b/libraries/chez/monadic/effekt.effekt
@@ -138,11 +138,11 @@ extern pure def infixGte(x: Double, y: Double): Bool =
 extern pure def not(b: Bool): Bool =
   "(not ${b})"
 
-extern pure def infixOr(x: Bool, y: Bool): Bool =
-  "(or ${x} ${y})"
+def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) true else second()
 
-extern pure def infixAnd(x: Bool, y: Bool): Bool =
-  "(and ${x} ${y})"
+def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) second() else false
 
 // Should only be used internally since values in Effekt should not be undefined
 extern pure def isUndefined[A](value: A): Bool =

--- a/libraries/chez/monadic/effekt.effekt
+++ b/libraries/chez/monadic/effekt.effekt
@@ -138,10 +138,10 @@ extern pure def infixGte(x: Double, y: Double): Bool =
 extern pure def not(b: Bool): Bool =
   "(not ${b})"
 
-def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixOr { first: => Bool } { second: => Bool }: Bool = 
   if (first()) true else second()
 
-def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixAnd { first: => Bool } { second: => Bool }: Bool = 
   if (first()) second() else false
 
 // Should only be used internally since values in Effekt should not be undefined

--- a/libraries/js/effekt.effekt
+++ b/libraries/js/effekt.effekt
@@ -193,11 +193,11 @@ extern pure def infixGte(x: String, y: String): Bool =
 extern pure def not(b: Bool): Bool =
   "!${b}"
 
-extern pure def infixOr(x: Bool, y: Bool): Bool =
-  "(${x} || ${y})"
+def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) true else second()
 
-extern pure def infixAnd(x: Bool, y: Bool): Bool =
-  "(${x} && ${y})"
+def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) second() else false
 
 // Undefined and Null
 // ==================

--- a/libraries/js/effekt.effekt
+++ b/libraries/js/effekt.effekt
@@ -193,10 +193,10 @@ extern pure def infixGte(x: String, y: String): Bool =
 extern pure def not(b: Bool): Bool =
   "!${b}"
 
-def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixOr { first: => Bool } { second: => Bool }: Bool = 
   if (first()) true else second()
 
-def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixAnd { first: => Bool } { second: => Bool }: Bool = 
   if (first()) second() else false
 
 // Undefined and Null

--- a/libraries/llvm/effekt.effekt
+++ b/libraries/llvm/effekt.effekt
@@ -150,21 +150,11 @@ extern pure def not(adt_p: Bool): Bool = """
     ret %Pos %adt_q
 """
 
-extern pure def infixOr(adt_p: Bool, adt_q: Bool): Bool = """
-    %p = extractvalue %Pos %adt_p, 0
-    %q = extractvalue %Pos %adt_q, 0
-    %r = or i64 %p, %q
-    %adt_r = insertvalue %Pos zeroinitializer, i64 %r, 0
-    ret %Pos %adt_r
-"""
+def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) true else second()
 
-extern pure def infixAnd(adt_p: Bool, adt_q: Bool): Bool = """
-    %p = extractvalue %Pos %adt_p, 0
-    %q = extractvalue %Pos %adt_q, 0
-    %r = and i64 %p, %q
-    %adt_r = insertvalue %Pos zeroinitializer, i64 %r, 0
-    ret %Pos %adt_r
-"""
+def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) second() else false
 
 // show
 extern pure def show(i: Int): String = """

--- a/libraries/llvm/effekt.effekt
+++ b/libraries/llvm/effekt.effekt
@@ -150,10 +150,10 @@ extern pure def not(adt_p: Bool): Bool = """
     ret %Pos %adt_q
 """
 
-def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixOr { first: => Bool } { second: => Bool }: Bool = 
   if (first()) true else second()
 
-def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixAnd { first: => Bool } { second: => Bool }: Bool = 
   if (first()) second() else false
 
 // show

--- a/libraries/ml/effekt.effekt
+++ b/libraries/ml/effekt.effekt
@@ -172,11 +172,11 @@ extern pure def infixGte(x: String, y: String): Bool =
 extern pure def not(b: Bool): Bool =
   "not ${b}"
 
-extern pure def infixOr(x: Bool, y: Bool): Bool =
-  "${x} orelse ${y}"
+def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) true else second()
 
-extern pure def infixAnd(x: Bool, y: Bool): Bool =
-  "${x} andalso ${y}"
+def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+  if (first()) second() else false
 
 // Pairs
 // =====

--- a/libraries/ml/effekt.effekt
+++ b/libraries/ml/effekt.effekt
@@ -172,10 +172,10 @@ extern pure def infixGte(x: String, y: String): Bool =
 extern pure def not(b: Bool): Bool =
   "not ${b}"
 
-def infixOr { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixOr { first: => Bool } { second: => Bool }: Bool = 
   if (first()) true else second()
 
-def infixAnd { first:  () => Bool } { second: () => Bool }: Bool = 
+def infixAnd { first: => Bool } { second: => Bool }: Bool = 
   if (first()) second() else false
 
 // Pairs


### PR DESCRIPTION
This PR closes #387. For now I've implemented it directly in the parser.
There might be bugs left, so please try it out if the CI passes.

---

CI did not pass. LLVM has obvious errors that could be fixed by improving the inliner.