### PR TITLE
Improve parser performance by not copying strings all of the time

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -889,8 +889,9 @@ class EffektLexers(positions: Positions) extends Parsers(positions) {
   val multi = "\"\"\""
 
   // multi-line strings `(?s)` sets multi-line mode.
-  lazy val multilineString: P[String] = matchRegex(s"(?s)${ multi }[\t\n\r ]*(.*?)[\t\n\r ]*${ multi }".r) ^^ { m => m.group(1) }
-
+  lazy val multilineString: P[String] = regex(s"(?s)${ multi }[\t\n\r ]*(.*?)[\t\n\r ]*${ multi }".r) ^^ {
+    contents => contents.strip().stripPrefix(multi).stripSuffix(multi)
+  }
 
   // === Utils ===
   def many[T](p: => Parser[T]): Parser[List[T]] =


### PR DESCRIPTION
This is complementary to #435, discovered by @dvdvgt.