### PR TITLE
Enable inlining of small block definitions

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/SizeTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/SizeTests.scala
@@ -1,0 +1,34 @@
+package effekt.core
+
+class SizeTests extends CoreTests {
+
+  def assertSized(size: Int)(input: String)(using munit.Location): Unit = {
+    val tree = parse(input, "input", Names(defaultNames))
+    assertEquals(tree.size, size, "Wrong number of nodes")
+  }
+
+  test("Small program"){
+    assertSized(7) {
+      """module main
+        |
+        |def foo = { () =>
+        |  return (bar: (Int) => Int @ {})(baz:Int)
+        |}
+        |""".stripMargin
+    }
+  }
+
+  test("Nested definitions") {
+    assertSized(18) {
+      """ module main
+        |
+        | def bar = { () => return 1 }
+        | def main = { () =>
+        |   def renamed1 = { () => (bar : () => Unit @ {})() }
+        |   def renamed2 = { () => return 2 }
+        |   (renamed1 : () => Unit @ {})()
+        | }
+        |""".stripMargin
+    }
+  }
+}

--- a/effekt/shared/src/main/scala/effekt/core/Optimizer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Optimizer.scala
@@ -21,6 +21,5 @@ object Optimizer extends Phase[CoreTransformed, CoreTransformed] {
     val tree = Deadcode.remove(mainSymbol, core)
 
     // (2) inline unique block definitions
-    //Inline.full(Set(mainSymbol), tree)
-    tree
+    Inline.full(Set(mainSymbol), tree)
 }

--- a/effekt/shared/src/main/scala/effekt/core/Renamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Renamer.scala
@@ -81,6 +81,19 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
       }
   }
 
+  override def rewrite(o: Operation): Operation = o match {
+    case Operation(name, tparams, cparams, vparams, bparams, resume, body) =>
+      withBindings(tparams ++ cparams ++ vparams.map(_.id) ++ bparams.map(_.id) ++ resume.map(_.id).toList) {
+        Operation(name,
+          tparams map rewrite,
+          cparams map rewrite,
+          vparams map rewrite,
+          bparams map rewrite,
+          resume map rewrite,
+          rewrite(body))
+      }
+  }
+
   def apply(m: core.ModuleDecl): core.ModuleDecl =
     suffix = 0
     m match {

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -64,7 +64,25 @@ import effekt.util.messages.INTERNAL_ERROR
  *
  * -------------------------------------------
  */
-sealed trait Tree
+sealed trait Tree extends Product {
+  /**
+   * The number of nodes of this tree (potentially used by inlining heuristics)
+   */
+  lazy val size: Int = {
+    var nodeCount = 1
+
+    def all(t: IterableOnce[_]): Unit = t.iterator.foreach(one)
+    def one(obj: Any): Unit = obj match {
+      case t: Tree => nodeCount += t.size
+      case s: effekt.symbols.Symbol => ()
+      case p: Product => all(p.productIterator)
+      case t: Iterable[t] => all(t)
+      case leaf           => ()
+    }
+    this.productIterator.foreach(one)
+    nodeCount
+  }
+}
 
 /**
  * In core, all symbols are supposed to be "just" names.

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -54,7 +54,7 @@ object Transformer {
         // for now, in machine we do not pass evidence to externs
         case lifted.EvidenceParam(id) => None // Variable(id.name.name, builtins.Evidence)
       }
-      noteBlockParams(name, params map transform, List.empty)
+      noteDefinition(name, params map transform, Nil)
       Extern(transform(name), transformedParams, transform(ret), Template(strings, args map {
         case lifted.ValueVar(id, tpe) => Variable(id.name.name, transform(tpe))
         case _ => ErrorReporter.abort("In the LLVM backend, only variables are allowed in templates")
@@ -70,24 +70,31 @@ object Transformer {
 
         definitions.foreach {
           case Definition.Def(id,  block @ lifted.BlockLit(tparams, params, body)) =>
+
+            params.collect { case lifted.BlockParam(id, tpe) => noteParameter(id) }
+
             // TODO does not work for mutually recursive local definitions
             val freeParams = lifted.freeVariables(block).toList.toSet.flatMap {
               case lifted.ValueParam(id, tpe) => Set(Variable(transform(id), transform(tpe)))
+              case lifted.EvidenceParam(id) => Set(Variable(transform(id), builtins.Evidence))
+
+              // TODO is this necessary???
               case lifted.BlockParam(pid, lifted.BlockType.Interface(tpe, List(stTpe))) if tpe == symbols.builtins.TState.interface =>
                 Set(Variable(transform(pid), Type.Reference(transform(stTpe))))
-              case lifted.BlockParam(resume: symbols.TrackedParam.ResumeParam, _) =>
-                // resume parameters are represented as Stacks in machine
-                // TODO How can we not match on the symbol here?
-                Set(Variable(transform(resume), Type.Stack()))
-              case lifted.BlockParam(pid, tpe)
-                if !BPC.blockParams.contains(pid) && id != pid && DC.findConstructor(pid).isEmpty =>
-                Set(Variable(transform(pid), transform(tpe)))
-              case lifted.BlockParam(pid, tpe) if BPC.freeParams.contains(pid) && id != pid =>
-                BPC.freeParams(pid).toSet
-              case lifted.EvidenceParam(id) => Set(Variable(transform(id), builtins.Evidence))
+
+              case lifted.BlockParam(pid, tpe) if pid != id => BPC.info.get(pid).map {
+                  case BlockInfo.Definition(freeParams, blockParams) =>
+                    BPC.freeParams(pid).toSet
+                  case BlockInfo.BlockParameter =>
+                    Set(Variable(transform(pid), transform(tpe)))
+                  case BlockInfo.Resumption =>
+                    Set(Variable(transform(pid), Type.Stack()))
+                }.getOrElse { Set.empty }
+
               case _ => Set.empty
             }
-            noteBlockParams(id, params.map(transform), freeParams.toList)
+
+            noteDefinition(id, params.map(transform), freeParams.toList)
           case _ => ()
         }
 
@@ -133,15 +140,21 @@ object Transformer {
           Clause(List(transform(lifted.ValueParam(id, binding.tpe))), transform(rest)),
             transform(binding)
         )
+
+      // TODO deal with BlockLit
       case lifted.App(lifted.BlockVar(id, tpe), targs, args) =>
         if(targs.exists(requiresBoxing)){ ErrorReporter.abort(s"Types ${targs} are used as type parameters but would require boxing.") }
-        // TODO deal with BlockLit
-        id match {
-          case symbols.BlockParam(_, _) =>
+
+        BPC.info(id) match {
+
+          // Unknown Jump
+          case BlockInfo.BlockParameter =>
             transform(args).run { values =>
               Invoke(Variable(transform(id), transform(tpe)), builtins.Apply, values)
             }
-          case symbols.ResumeParam(_) =>
+
+          // Continuation Call
+          case BlockInfo.Resumption =>
             // TODO currently only scoped resumptions are supported
             // TODO assuming first parameter is evidence TODO actually use evidence?
             transform(args).run { values =>
@@ -149,8 +162,10 @@ object Transformer {
               PushStack(Variable(transform(id), Type.Stack()),
                 Return(returnedValues))
             }
-          case other =>
-            val environment = getBlocksParams(id)
+
+          // Known Jump
+          case BlockInfo.Definition(freeParams, blockParams) =>
+            val environment = blockParams ++ freeParams
             transform(args).run { values =>
               // Here we actually need a substitution to prepare the environment for the jump
               Substitute(environment.zip(values), Jump(Label(transform(id), environment)))
@@ -227,6 +242,7 @@ object Transformer {
 
       // TODO what about the evidence passed to resume?
       case lifted.Shift(ev, lifted.Block.BlockLit(tparams, List(kparam), body)) =>
+        noteContinuation(kparam.id)
         transform(ev).run { evValue =>
           PopStacks(Variable(transform(kparam).name, Type.Stack()), evValue,
             transform(body))
@@ -333,7 +349,7 @@ object Transformer {
   }
 
   def transform(block: lifted.Block)(using BPC: BlocksParamsContext, DC: DeclarationContext, E: ErrorReporter): Binding[Variable] = block match {
-    case lifted.BlockVar(id, tpe) if BPC.blockParams.contains(id) =>
+    case lifted.BlockVar(id, tpe) if isDefinition(id) =>
       // passing a function directly, so we need to eta-expand
       // TODO cache the closure somehow to prevent it from being created on every call
       val parameters = BPC.blockParams(id)
@@ -405,7 +421,6 @@ object Transformer {
         }
       }
 
-
     case lifted.Make(data, constructor, args) =>
       val variable = Variable(freshName("x"), transform(data));
       val tag = DeclarationContext.getConstructorTag(constructor)
@@ -455,11 +470,12 @@ object Transformer {
       Clause(params.map(transform), transform(body))
   }
 
-  def transform(param: lifted.Param)(using ErrorReporter): Variable =
+  def transform(param: lifted.Param)(using BlocksParamsContext, ErrorReporter): Variable =
     param match {
       case lifted.ValueParam(name, tpe) =>
         Variable(transform(name), transform(tpe))
       case lifted.BlockParam(name, tpe) =>
+        noteParameter(name)
         Variable(transform(name), transform(tpe))
       case lifted.EvidenceParam(name) =>
         Variable(transform(name), builtins.Evidence)
@@ -498,7 +514,7 @@ object Transformer {
   def findToplevelBlocksParams(definitions: List[lifted.Definition])(using BlocksParamsContext, ErrorReporter): Unit =
     definitions.foreach {
       case Definition.Def(blockName, lifted.BlockLit(tparams, params, body)) =>
-        noteBlockParams(blockName, params.map(transform), Nil)
+        noteDefinition(blockName, params.map(transform), Nil)
       case _ => ()
     }
 
@@ -508,21 +524,48 @@ object Transformer {
    */
 
   class BlocksParamsContext() {
-    var freeParams: Map[Symbol, Environment] = Map()
-    var blockParams: Map[Symbol, Environment] = Map()
+    var info: Map[Symbol, BlockInfo] = Map()
+
+    def definition(id: Symbol): BlockInfo.Definition = info(id) match {
+      case d : BlockInfo.Definition => d
+      case BlockInfo.BlockParameter => sys error s"Expected a function definition, but got a block parameter: ${id}"
+      case BlockInfo.Resumption => sys error s"Expected a function definition, but got a continuation: ${id}"
+    }
+    def blockParams(id: Symbol): Environment = definition(id).blockParams
+    def freeParams(id: Symbol): Environment = definition(id).freeParams
+  }
+  enum BlockInfo {
+    case Definition(freeParams: Environment, blockParams: Environment)
+    case BlockParameter
+    case Resumption
   }
 
   def DeclarationContext(using DC: DeclarationContext): DeclarationContext = DC
 
-  def noteBlockParams(id: Symbol, blockParams: Environment, freeParams: Environment)(using BC: BlocksParamsContext): Unit = {
-    BC.blockParams = BC.blockParams + (id -> blockParams)
-    BC.freeParams = BC.freeParams + (id -> freeParams)
+  def noteDefinition(id: Symbol, blockParams: Environment, freeParams: Environment)(using BC: BlocksParamsContext): Unit =
+    BC.info += (id -> BlockInfo.Definition(freeParams, blockParams))
+
+  def noteContinuation(id: Symbol)(using BC: BlocksParamsContext): Unit =
+    BC.info += (id -> BlockInfo.Resumption)
+
+  def noteParameter(id: Symbol)(using BC: BlocksParamsContext): Unit =
+    BC.info += (id -> BlockInfo.BlockParameter)
+
+  def getBlocksParams(id: Symbol)(using BC: BlocksParamsContext): Environment = BC.definition(id) match {
+    case BlockInfo.Definition(freeParams, blockParams) => blockParams ++ freeParams
   }
 
-  def getBlocksParams(id: Symbol)(using BC: BlocksParamsContext): Environment = {
-    // TODO what if this is not found?
-    BC.blockParams(id) ++ BC.freeParams(id)
-  }
+  def isResumption(id: Symbol)(using BC: BlocksParamsContext): Boolean =
+    BC.info(id) match {
+      case BlockInfo.Resumption => true
+      case _ => false
+    }
+
+  def isDefinition(id: Symbol)(using BC: BlocksParamsContext): Boolean =
+    BC.info(id) match {
+      case d: BlockInfo.Definition => true
+      case _ => false
+    }
 
   case class Binding[A](run: (A => Statement) => Statement) {
     def flatMap[B](rest: A => Binding[B]): Binding[B] = {


### PR DESCRIPTION
This PR reenables the inliner (see #425) and also enables inlining of small definitions.

Right now the inlining threshold is set arbitrary to `20`:

https://github.com/effekt-lang/effekt/pull/438/files#diff-bc7040e8ee95a824eba8f56e3bfc6a8c47fe30cf6e0422baeaf52e7521496717R26

Also, higher-order functions are currently inlined, regardless of the size. 

Neither of these two decisions is founded on actual benchmarks or other good sources, which would be important to investigate in the future. 