### PR TITLE
Improve field access syntax

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -383,9 +383,9 @@ class EffektParsers(positions: Positions) extends EffektLexers(positions) {
   lazy val mulExpr: P[Term] = mulExpr ~ oneof("*", "/") ~/ accessExpr ^^ binaryOp | accessExpr
 
   lazy val accessExpr: P[Term] =
-    callExpr ~ many(`.` ~>
-      ( idRef ~ maybeTypeArgs ~ maybeValueArgs ~ maybeBlockArgs ^^ Left.apply
-      | idRef ^^ Right.apply
+    callExpr ~ many(
+      ( `.` ~> idRef ~ maybeTypeArgs ~ maybeValueArgs ~ maybeBlockArgs ^^ Left.apply
+      | `'s` ~> idRef ^^ Right.apply
       )
     ) ^^ {
       case firstTarget ~ accesses => accesses.foldLeft(firstTarget) {
@@ -817,6 +817,8 @@ class EffektLexers(positions: Positions) extends Parsers(positions) {
   lazy val `}>` = literal("}>")
   lazy val `!` = literal("!")
   lazy val `|` = literal("|")
+
+  lazy val `'s` = literal("'s")
 
   lazy val `let` = keyword("let")
   lazy val `true` = keyword("true")

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -71,11 +71,8 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
     case Match(sc, clauses, default) =>
       Match(rewriteAsExpr(sc), clauses.map(rewrite), default.map(rewrite))
 
-    case s @ Select(recv, name) if s.definition.isInstanceOf[Field] =>
-      Select(rewriteAsExpr(recv), name)
-
     case s @ Select(recv, name) =>
-      C.abort("selection on blocks not supported yet.")
+      Select(rewriteAsExpr(recv), name)
 
     case Do(effect, id, targs, vargs, bargs) =>
       Do(effect, id, targs, vargs.map(rewriteAsExpr), bargs.map(rewriteAsBlock))

--- a/examples/pos/field_access.check
+++ b/examples/pos/field_access.check
@@ -1,0 +1,3 @@
+Maxine
+Car(Wartburg 353)
+Wartburg 353

--- a/examples/pos/field_access.effekt
+++ b/examples/pos/field_access.effekt
@@ -1,0 +1,14 @@
+module field_access
+
+record Car(model: String)
+record Person(name: String, car: Car)
+
+def showCar(c: Car) = "Car(" ++ show(c's model) ++ ")"
+
+def main() = {
+  val Maxine = Person("Maxine", Car("Wartburg 353"))
+
+  println(Maxine's name)
+  println(showCar(Maxine's car))
+  println(Maxine's car's model)
+}


### PR DESCRIPTION
### Motivation

**Certainly** the most severe usability problem in Effekt is rooted in the inability of distinguishing method calls from field access. This is a problem since method calls act on codata but field access acts on data — a distinction that must be made in the mind of the user (values are, computations do!). 
In order to make Effekt more usable, it is imperative to distinguish these two constructs clearly so that the language is user-friendly to all its many users.

### Description

Our inspiration for the syntax of field accesses is from user `@judofyr` on Twitter  (https://twitter.com/judofyr/status/1685580152565055488) who suggested the natural use of `’s`. This pull request implements this field access syntax and adds the necessary tests.

#### Example

Here’s an example of the new field access syntax:
```scala
record Car(model: String)
record Person(name: String, car: Car)

def main() = {
  val Maxine = Person("Maxine", Car("Wartburg 353"))

  println(Maxine’s name)
  println(Maxine’s car)
  println(Maxine’s car’s model)
}
```

Note that it’s naturally nestable: `Maxine’s car’s model` gets parsed as `(Maxine’s car)’s model`.

### Future work

We should allow to use only the apostrophe `’` for instances where the identifier already ends with an `s` in order to allow a more properer and correcter English syntax:
```scala
// currently
Hans’s wife’s name

// in the future
Hans’ wife’s name
```

We also might want to think if we want to use `'` or `’` for the apostrophe -- the former is probably familiar to programmers and thus easier to type, but the latter is slightly nicer.

---

Enjoy the Assyrian New Year!