### PR TITLE
Extern warnings only if they reach code generation

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -299,6 +299,7 @@ object Namer extends Phase[Parsed, NameResolved] {
         bodies.foreach {
           case source.ExternBody.StringExternBody(ff, body) => body.args.foreach(resolveGeneric)
           case source.ExternBody.EffektExternBody(ff, body) => resolveGeneric(body)
+          case u: source.ExternBody.Unsupported => u
         }
       }
 

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -291,18 +291,6 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
 
     case f @ source.ExternDef(capture, id, tparams, vparams, bparams, ret, bodies) =>
-      if (!bodies.supportedByFeatureFlags(Context.compiler.supportedFeatureFlags)) {
-        val featureFlags = bodies.map(_.featureFlag)
-        Context.warning(pp"Extern definition ${id} is not supported as it is only defined for feature flags ${featureFlags.mkString(", ")}," +
-          pp"but the current backend only supports ${Context.compiler.supportedFeatureFlags.mkString(", ")}.")
-      }
-      bodies.foreach {
-        case source.ExternBody.StringExternBody(ff, _) if ff.isDefault =>
-          Context.warning(pp"Extern definition ${id} contains extern string without feature flag. This will likely not work in other backends, "
-            + pp"please annotate it with a feature flag (Supported by the current backend: ${Context.compiler.supportedFeatureFlags.mkString(", ")})")
-        case _ => ()
-      }
-
       val sym = f.symbol
       Context scoped {
         sym.tparams.foreach { p => Context.bind(p) }
@@ -381,13 +369,7 @@ object Namer extends Phase[Parsed, NameResolved] {
     case source.ExternType(id, tparams) => ()
     case source.ExternInterface(id, tparams) => ()
     case source.ExternResource(id, tpe) => ()
-    case source.ExternInclude(ff, path, _, _) =>
-      if (ff.isDefault) {
-        val supported = Context.compiler.supportedFeatureFlags.mkString(", ")
-        Context.warning("Found extern include without feature flag. It is likely that this will fail in other backends, "
-          + s"please annotate it with a feature flag (Supported in current backend: ${supported})")
-      }
-      ()
+    case source.ExternInclude(ff, path, _, _) => ()
 
     case source.If(guards, thn, els) =>
       Context scoped { guards.foreach(resolve); resolveGeneric(thn) }

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -844,6 +844,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
               body.args.foreach { arg => checkExpr(arg, None) }
             case source.ExternBody.EffektExternBody(ff, body) =>
               checkStmt(body, Some(expectedReturnType))
+            case u: source.ExternBody.Unsupported => u
           }
 
         }

--- a/effekt/shared/src/main/scala/effekt/core/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Parser.scala
@@ -73,7 +73,7 @@ class CoreParsers(positions: Positions, names: Names) extends EffektLexers(posit
       case captures ~ (id, tparams, cparams, vparams, bparams, result) ~ body =>
         Extern.Def(id, tparams, cparams, vparams, bparams, result, captures, body match {
           case ff ~ (body: String) =>
-            ExternBody(ff, Template(List(body), Nil))
+            ExternBody.StringExternBody(ff, Template(List(body), Nil))
         })
     })
 

--- a/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
@@ -126,7 +126,8 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
     case Extern.Def(id, tparams, cparams, vparams, bparams, ret, annotatedCapture, body) =>
       Extern.Def(id, tparams, cparams, vparams map transform, bparams map transform, transform(ret),
         annotatedCapture, body match {
-          case ExternBody(ff, bbody) => ExternBody(ff, Template(bbody.strings, bbody.args map transform))
+          case ExternBody.StringExternBody(ff, bbody) => ExternBody.StringExternBody(ff, Template(bbody.strings, bbody.args map transform))
+          case e @ ExternBody.Unsupported(_) => e
         } )
     case Extern.Include(ff, contents) => Extern.Include(ff, contents)
   }

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -62,7 +62,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def toDoc(e: Extern): Doc = e match {
     case Extern.Def(id, tps, cps, vps, bps, ret, capt, bodies) =>
       "extern" <+> toDoc(capt) <+> "def" <+> toDoc(id) <+> "=" <+> paramsToDoc(tps, vps, bps) <> ":" <+> toDoc(ret) <+> "=" <+> (bodies match {
-        case ExternBody(ff, body) => toDoc(ff) <+> toDoc(body)
+        case ExternBody.StringExternBody(ff, body) => toDoc(ff) <+> toDoc(body)
+        case ExternBody.Unsupported(err) => s"unsupported(${err.toString})"
       })
     case Extern.Include(ff, contents) => emptyDoc // right now, do not print includes.
   }

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -124,7 +124,9 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
             case p: Pure => p: Pure
             case _ => Context.abort("Spliced arguments need to be pure expressions.")
           }
-          ExternBody(ff, Template(body.strings, args))
+          ExternBody.StringExternBody(ff, Template(body.strings, args))
+        case source.ExternBody.Unsupported(err) :: Nil =>
+          ExternBody.Unsupported(err)
         case _ =>
           Context.abort("Externs should be resolved and desugared before core.Transformer")
       }

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -4,11 +4,12 @@ package chez
 
 import effekt.context.Context
 import effekt.symbols.{Module, Symbol}
+import effekt.util.messages.ErrorReporter
 import kiama.output.PrettyPrinterTypes.Document
 import kiama.util.Source
 
 class ChezSchemeMonadic extends ChezScheme {
-  def compilationUnit(mainSymbol: Symbol, mod: Module, decl: core.ModuleDecl): chez.Block =
+  def compilationUnit(mainSymbol: Symbol, mod: Module, decl: core.ModuleDecl)(using ErrorReporter): chez.Block =
     chez.TransformerMonadic.compilationUnit(mainSymbol, mod, decl)
 
   override def supportedFeatureFlags: List[String] = List("chezMonadic", "chez")
@@ -16,7 +17,7 @@ class ChezSchemeMonadic extends ChezScheme {
 
 
 class ChezSchemeCallCC extends ChezScheme {
-  def compilationUnit(mainSymbol: Symbol, mod: Module, decl: core.ModuleDecl): chez.Block =
+  def compilationUnit(mainSymbol: Symbol, mod: Module, decl: core.ModuleDecl)(using ErrorReporter): chez.Block =
     chez.TransformerCallCC.compilationUnit(mainSymbol, mod, decl)
 
   override def supportedFeatureFlags: List[String] =  List("chezCallCC", "chez")
@@ -25,7 +26,7 @@ class ChezSchemeCallCC extends ChezScheme {
 
 trait ChezScheme extends Compiler[String] {
 
-  def compilationUnit(mainSymbol: Symbol, mod: Module, decl: core.ModuleDecl): chez.Block
+  def compilationUnit(mainSymbol: Symbol, mod: Module, decl: core.ModuleDecl)(using ErrorReporter): chez.Block
 
   // Implementation of the Compiler Interface:
   // -----------------------------------------

--- a/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
@@ -6,6 +6,7 @@ import effekt.context.Context
 import effekt.core.*
 import effekt.symbols.{ Module, Symbol, TermSymbol, Wildcard }
 import effekt.util.paths.*
+import effekt.util.messages.ErrorReporter
 import kiama.output.PrettyPrinterTypes.Document
 import util.messages.{ INTERNAL_ERROR, NOT_SUPPORTED }
 
@@ -50,14 +51,14 @@ trait Transformer {
   def state(id: ChezName, init: chez.Expr, body: chez.Block): chez.Expr =
     Builtin("state", init, chez.Lambda(List(id), body))
 
-  def compilationUnit(mainSymbol: Symbol, mod: Module, core: ModuleDecl): chez.Block = {
+  def compilationUnit(mainSymbol: Symbol, mod: Module, core: ModuleDecl)(using ErrorReporter): chez.Block = {
     val definitions = toChez(core)
     chez.Block(generateStateAccessors(pure) ++ definitions, Nil, runMain(nameRef(mainSymbol)))
   }
 
   def toChez(p: Param): ChezName = nameDef(p.id)
 
-  def toChez(module: ModuleDecl): List[chez.Def] = {
+  def toChez(module: ModuleDecl)(using ErrorReporter): List[chez.Def] = {
     val decls = module.declarations.flatMap(toChez)
     val externs = module.externs.map(toChez)
      // TODO FIXME, once there is a let _ = ... in there, we are doomed!
@@ -131,11 +132,17 @@ trait Transformer {
       generateConstructor(id, operations.map(op => op.id))
   }
 
-  def toChez(decl: core.Extern): chez.Def = decl match {
-    case Extern.Def(id, tpe, cps, vps, bps, ret, capt, ExternBody(_, body)) =>
+  def toChez(decl: core.Extern)(using ErrorReporter): chez.Def = decl match {
+    case Extern.Def(id, tpe, cps, vps, bps, ret, capt, body) =>
+      val tBody = body match {
+        case ExternBody.StringExternBody(featureFlag, contents) => toChez(contents)
+        case u: ExternBody.Unsupported =>
+          u.report
+          chez.Builtin("hole")
+      }
       chez.Constant(nameDef(id),
         chez.Lambda((vps ++ bps) map { p => nameDef(p.id) },
-          toChez(body)))
+          tBody))
 
     case Extern.Include(ff, contents) =>
       RawDef(contents)

--- a/effekt/shared/src/main/scala/effekt/generator/chez/TransformerLift.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/TransformerLift.scala
@@ -7,6 +7,7 @@ import effekt.context.Context
 import effekt.lifted.*
 import effekt.symbols.{ Module, Symbol, Wildcard, TermSymbol }
 import effekt.util.paths.*
+import effekt.util.messages.ErrorReporter
 import effekt.symbols.builtins
 
 import kiama.output.PrettyPrinterTypes.Document
@@ -25,7 +26,7 @@ object TransformerLift {
     if (monomorphized) chez.Call(chez.Call(main), List(CPS.id))
     else chez.Call(chez.Call(main, CPS.id), List(CPS.id))
 
-  def compilationUnit(mainSymbol: Symbol, mod: Module, core: ModuleDecl): chez.Block = {
+  def compilationUnit(mainSymbol: Symbol, mod: Module, core: ModuleDecl)(using ErrorReporter): chez.Block = {
     val definitions = toChez(core)
     chez.Block(generateStateAccessors ++ definitions, Nil, runMain(nameRef(mainSymbol)))
   }
@@ -38,7 +39,7 @@ object TransformerLift {
     case e: lifted.Evidence => toChez(e)
   }
 
-  def toChez(module: ModuleDecl): List[chez.Def] = {
+  def toChez(module: ModuleDecl)(using ErrorReporter): List[chez.Def] = {
     val decls = module.decls.flatMap(toChez)
     val externs = module.externs.map(toChez)
     // TODO FIXME, once there is a let _ = ... in there, we are doomed!
@@ -195,13 +196,18 @@ object TransformerLift {
       generateConstructor(id, operations.map(_.id))
   }
 
-  def toChez(decl: lifted.Extern): chez.Def = decl match {
-    case Extern.Def(id, tparams, params, ret, ExternBody(_, body)) =>
+  def toChez(decl: lifted.Extern)(using ErrorReporter): chez.Def = decl match {
+    case Extern.Def(id, tparams, params, ret, body) =>
       chez.Constant(nameDef(id),
         chez.Lambda( params.flatMap {
           case p: Param.EvidenceParam => None
           case p => Some(nameDef(p.id)) },
-          toChez(body)))
+          body match {
+            case ExternBody.StringExternBody(_, contents) => toChez(contents)
+            case u: ExternBody.Unsupported =>
+              u.report
+              chez.Builtin("hole")
+          }))
 
     case Extern.Include(ff, contents) =>
       RawDef(contents)

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
@@ -88,8 +88,14 @@ object TransformerDirect extends Transformer {
   }
 
   def toJS(e: core.Extern)(using TransformerContext): js.Stmt = e match {
-    case Extern.Def(id, tps, cps, vps, bps, ret, capt, ExternBody(featureFlag, contents)) =>
-      js.Function(nameDef(id), (vps ++ bps) map externParams, List(js.Return(toJS(contents))))
+    case Extern.Def(id, tps, cps, vps, bps, ret, capt, body) =>
+      body match {
+        case ExternBody.StringExternBody(featureFlag, contents) =>
+          js.Function(nameDef(id), (vps ++ bps) map externParams, List(js.Return(toJS(contents))))
+        case u: ExternBody.Unsupported =>
+          u.report
+          js.Stmt.Return($effekt.call("hole"))
+      }
 
     case Extern.Include(ff, contents) =>
       js.RawStmt(contents)

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -4,6 +4,7 @@ package llvm
 
 import effekt.machine
 import effekt.util.intercalate
+import effekt.util.messages.ErrorReporter
 import effekt.machine.analysis.*
 
 import scala.collection.mutable
@@ -12,7 +13,7 @@ object Transformer {
 
   val llvmFeatureFlags: List[String] = List("llvm")
 
-  def transform(program: machine.Program): List[Definition] = program match {
+  def transform(program: machine.Program)(using ErrorReporter): List[Definition] = program match {
     case machine.Program(declarations, statement) =>
       given MC: ModuleContext = ModuleContext();
       given FC: FunctionContext = FunctionContext();
@@ -40,12 +41,23 @@ object Transformer {
   private def FC(using FC: FunctionContext): FunctionContext = FC
   private def BC(using BC: BlockContext): BlockContext = BC
 
-  def transform(declaration: machine.Declaration): Definition =
+  def transform(declaration: machine.Declaration)(using ErrorReporter): Definition =
     declaration match {
-      case machine.Extern(functionName, parameters, returnType, machine.ExternBody(_, body)) =>
-        VerbatimFunction(transform(returnType), functionName, parameters.map {
-          case machine.Variable(name, tpe) => Parameter(transform(tpe), name)
-        }, transform(body))
+      case machine.Extern(functionName, parameters, returnType, body ) =>
+        body match {
+          case machine.ExternBody.StringExternBody(_, contents) =>
+            VerbatimFunction(transform(returnType), functionName, parameters.map {
+              case machine.Variable(name, tpe) => Parameter(transform(tpe), name)
+            }, transform(contents))
+          case u: machine.ExternBody.Unsupported =>
+            u.report
+            VerbatimFunction(transform(returnType), functionName, parameters.map {
+                case machine.Variable(name, tpe) => Parameter(transform(tpe), name)
+              },
+              """call void @hole()
+                |unreachable
+                |""".stripMargin)
+        }
       case machine.Include(ff, content) =>
         Verbatim(content)
     }

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -110,11 +110,10 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
       Extern.Def(id, tps, vps.map(transform) ++ bps.map(transform), transform(ret),
         body match {
           case core.ExternBody.StringExternBody(ff, bbody) =>
-            ExternBody(ff, Template(bbody.strings, bbody.args.map(transform)))
-          case u: core.ExternBody.Unsupported =>
+            ExternBody.StringExternBody(ff, Template(bbody.strings, bbody.args.map(transform)))
+          case core.ExternBody.Unsupported(err) =>
             import effekt.source.FeatureFlag.Default
-            u.report
-            ExternBody(Default, util.messages.NOT_SUPPORTED("unsupported externs left over"))
+            ExternBody.Unsupported(err)
         })
     case core.Extern.Include(ff, contents) =>
       Extern.Include(ff, contents)

--- a/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/LiftInference.scala
@@ -109,8 +109,12 @@ object LiftInference extends Phase[CoreTransformed, CoreLifted] {
       }
       Extern.Def(id, tps, vps.map(transform) ++ bps.map(transform), transform(ret),
         body match {
-          case core.ExternBody(ff, bbody) =>
+          case core.ExternBody.StringExternBody(ff, bbody) =>
             ExternBody(ff, Template(bbody.strings, bbody.args.map(transform)))
+          case u: core.ExternBody.Unsupported =>
+            import effekt.source.FeatureFlag.Default
+            u.report
+            ExternBody(Default, util.messages.NOT_SUPPORTED("unsupported externs left over"))
         })
     case core.Extern.Include(ff, contents) =>
       Extern.Include(ff, contents)

--- a/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/PrettyPrinter.scala
@@ -60,7 +60,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def toDoc(e: Extern): Doc = e match {
     case Extern.Def(id, tparams, params, ret, bodies) =>
       "extern def" <+> toDoc(id.name) <> signature(tparams, params, ret) <+> "=" <+> "\"" <> (bodies match {
-        case ExternBody(ff, body) => toDoc(ff) <> toDoc(body)
+        case ExternBody.StringExternBody(ff, body) => toDoc(ff) <> toDoc(body)
+        case ExternBody.Unsupported(e) => s"unsupported(${e})"
       }) <> "\""
     case Extern.Include(ff, contents) => emptyDoc // right now, do not print includes.
   }

--- a/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/lifted/Tree.scala
@@ -4,6 +4,7 @@ package lifted
 import effekt.context.Context
 import effekt.source.FeatureFlag
 import effekt.symbols.{Constructor, Name, Symbol}
+import effekt.util.messages.ErrorReporter
 import scala.collection.immutable
 
 export effekt.core.Id
@@ -55,7 +56,13 @@ enum Extern {
   case Def(id: Id, tparams: List[Id], params: List[Param], ret: ValueType, bodies: ExternBody)
   case Include(featureFlag: FeatureFlag, contents: String)
 }
-case class ExternBody(featureFlag: FeatureFlag, body: Template[Expr])
+sealed trait ExternBody
+object ExternBody {
+  case class StringExternBody(featureFlag: FeatureFlag, body: Template[Expr]) extends ExternBody
+  case class Unsupported(err: util.messages.EffektError) extends ExternBody {
+    def report(using E: ErrorReporter): Unit = E.report(err)
+  }
+}
 
 enum Definition {
   def id: Id

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -56,11 +56,13 @@ object Transformer {
       }
       noteDefinition(name, params map transform, Nil)
       val tBody = body match {
-        case lifted.ExternBody(ff, Template(strings, args)) =>
-          ExternBody(ff, Template(strings, args map {
+        case lifted.ExternBody.StringExternBody(ff, Template(strings, args)) =>
+          ExternBody.StringExternBody(ff, Template(strings, args map {
             case lifted.ValueVar(id, tpe) => Variable(id.name.name, transform(tpe))
             case _ => ErrorReporter.abort("In the LLVM backend, only variables are allowed in templates")
           }))
+        case lifted.ExternBody.Unsupported(err) =>
+          ExternBody.Unsupported(err)
       }
       Extern(transform(name), transformedParams, transform(ret), tBody)
 

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -52,7 +52,13 @@ enum Declaration {
 }
 export Declaration.*
 
-case class ExternBody(featureFlag: FeatureFlag, contents: Template[Variable])
+sealed trait ExternBody
+object ExternBody {
+  case class StringExternBody(featureFlag: FeatureFlag, contents: Template[Variable]) extends ExternBody
+  case class Unsupported(err: util.messages.EffektError) extends ExternBody {
+    def report(using E: util.messages.ErrorReporter): Unit = E.report(err)
+  }
+}
 
 /**
  * Clauses are parametrized statements

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -129,6 +129,9 @@ sealed trait ExternBody extends Tree {
 object ExternBody {
   case class StringExternBody(featureFlag: FeatureFlag, template: Template[source.Term]) extends ExternBody
   case class EffektExternBody(featureFlag: FeatureFlag, body: source.Stmt) extends ExternBody
+  case class Unsupported(message: util.messages.EffektError) extends ExternBody {
+    override def featureFlag: FeatureFlag = FeatureFlag.Default
+  }
 }
 
 

--- a/examples/neg/unsupported_extern.effekt
+++ b/examples/neg/unsupported_extern.effekt
@@ -1,0 +1,9 @@
+extern io def foo(): Unit = none "" // WARN not supported
+extern io def foo2(): Unit = none "" // unused
+
+def bar(): Unit = foo()
+def bar2(): Unit = foo2()
+
+def main(): Unit = {
+  bar()
+}


### PR DESCRIPTION
Fixes #447 by (variant A):
- Adding a new variant `Unsupported` for `ExternBody`s in all IRs.
- Generating this in `ResolveExternDefs` if no matching clauses were found.
- In the backends, reporting the warning for `Unsupported` and generating code similar to holes.

Also moves the generation of the other warnings into `ResolveExternDefs`.