### PR TITLE
Fix ANSI highlighting of strings within multiline strings

### DIFF
--- a/effekt/shared/src/main/scala/effekt/util/AnsiHighlight.scala
+++ b/effekt/shared/src/main/scala/effekt/util/AnsiHighlight.scala
@@ -35,7 +35,7 @@ object AnsiHighlight {
   )
 
   val string = Token(
-    """["][^"]*["]""".r,
+    """["].*["]""".r,
     Console.GREEN + _ + Console.RESET
   )
 


### PR DESCRIPTION
If you write strings within multiline strings, the ANSI highlighting (e.g. in errors) gets escaped and rendered as if not a string at all. This annoyed me while trying to break unicode support :)

An example which induces an arbitrary error to generate wrong highlighting:

![image](https://github.com/effekt-lang/effekt/assets/32108934/dd376748-e326-4576-963d-809790cc58f9)

Not sure about the fix. Quotes shouldn't appear in normal strings after parsing anyway, so I believe we can just ignore them completely.

Other fixes wouldn't be straightforward since multiline strings are generally handled the same as normal strings. 