### PR TITLE
Homogenize options

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -15,6 +15,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     "compile",
     descrYes = "Compile the Effekt program to the backend specific representation",
     default = Some(false),
+    prefix = "no-",
     group = common
   )
 
@@ -82,6 +83,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     descrYes = "Exit with non-zero exit code on error",
     default = Some(!repl() && !server()),
     noshort = true,
+    prefix = "no-",
     group = advanced
   )
 
@@ -90,6 +92,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     descrYes = "Run optimizations (in particular the inliner) when compiling programs",
     default = Some(true),
     short = 'O',
+    prefix = "no-",
     group = advanced
   )
 
@@ -123,6 +126,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     descrYes = "Write all IRs to files in the output directory",
     default = Some(false),
     noshort = true,
+    prefix = "no-",
     group = debugging
   )
 

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -1,66 +1,51 @@
 package effekt
 
 import java.io.File
-
 import effekt.util.paths.file
 import kiama.util.REPLConfig
-
-import org.rogach.scallop.ScallopOption
-import org.rogach.scallop.{ fileConverter, fileListConverter, stringConverter, stringListConverter, longConverter }
+import org.rogach.scallop.{ ScallopOption, fileConverter, fileListConverter, longConverter, stringConverter, stringListConverter }
 
 class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
+
+  // Common
+  // ------
+  private val common = group("Common Options")
 
   val compile: ScallopOption[Boolean] = toggle(
     "compile",
     descrYes = "Compile the Effekt program to the backend specific representation",
-    default = Some(false)
+    default = Some(false),
+    group = common
   )
 
   val build: ScallopOption[Boolean] = toggle(
     "build",
     descrYes = "Compile the Effekt program and build a backend specific executable",
-    default = Some(false)
-  )
-
-  val showIR: ScallopOption[Option[Stage]] = choice(
-    choices = List("none", "core", "lifted", "machine", "target"),
-    name = "showIR",
-    descr = "The intermediate presentation that should be printed.",
-    default = Some("none"),
-    noshort = true
-  ).map(s => Stage.values.find(_.toString.toLowerCase == s))
-
-  val writeIRs: ScallopOption[Boolean] = toggle(
-    "writeIRs",
-    descrYes = "Write all IRs to files in the output directory",
     default = Some(false),
-  )
-
-  val time: ScallopOption[String] = choice(
-    choices = Seq("text", "json"),
-    name = "time",
-    descr = "Measure the time spent in each compilation phase",
-    required = false
+    group = common
   )
 
   val outputPath: ScallopOption[File] = opt[File](
     "out",
     descr = "Path to write generated files to (defaults to ./out)",
     default = Some(new File("./out")),
-    required = false
+    required = false,
+    group = common
   )
 
   val includePath: ScallopOption[List[File]] = opt[List[File]](
     "includes",
     descr = "Path to consider for includes (can be set multiple times)",
     default = Some(List(new File("."))),
-    noshort = true
+    noshort = true,
+    group = common
   )
 
   val stdlibPath: ScallopOption[File] = opt[File](
     "lib",
     descr = "Path to the standard library to be used",
-    required = false
+    required = false,
+    group = common
   )
 
   val backend: ScallopOption[Backend[_]] = choice(
@@ -68,42 +53,85 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     name = "backend",
     descr = "The backend that should be used",
     default = Some("js"),
-    noshort = true
+    noshort = true,
+    group = common
   ).map(Backend.backend)
+
+  // Advanced
+  // --------
+  private val advanced = group("Advanced Options")
 
   val llvmVersion: ScallopOption[String] = opt[String](
     "llvm-version",
     descr = "the llvm version that should be used to compile the generated programs (only necessary if backend is llvm, defaults to 15)",
     default = Some(sys.env.getOrElse("EFFEKT_LLVM_VERSION", "15")),
-    noshort = true
+    noshort = true,
+    group = advanced
   )
 
   val preludePath: ScallopOption[List[String]] = opt[List[String]](
     "prelude",
     descr = "Modules to be automatically imported in every file",
     default = None,
-    noshort = true
+    noshort = true,
+    group = advanced
   )
 
   val exitOnError: ScallopOption[Boolean] = toggle(
     "exit-on-error",
     descrYes = "Exit with non-zero exit code on error",
     default = Some(!repl() && !server()),
-    noshort = true
+    noshort = true,
+    group = advanced
   )
 
   val optimize: ScallopOption[Boolean] = toggle(
     "optimize",
     descrYes = "Run optimizations (in particular the inliner) when compiling programs",
     default = Some(true),
-    short = 'O'
+    short = 'O',
+    group = advanced
   )
 
   val maxInlineSize: ScallopOption[Long] = opt(
     "max-inline-size",
     descr = "Maximum size (number of core tree-nodes) of a function considered by the inliner",
     default = Some(50L),
-    noshort = true
+    noshort = true,
+    group = advanced
+  )
+  advanced.append(server)
+
+
+  // Debugging
+  // ---------
+  private val debugging = group("Compiler Development")
+
+  val showIR: ScallopOption[Option[Stage]] = choice(
+    choices = List("none", "core", "lifted", "machine", "target"),
+    name = "ir-show",
+    descr = "The intermediate presentation that should be printed.",
+    default = Some("none"),
+    noshort = true,
+    group = debugging
+  ).map(s => Stage.values.find(_.toString.toLowerCase == s))
+
+  debugging.append(showIR)
+
+  val writeIRs: ScallopOption[Boolean] = toggle(
+    "ir-write-all",
+    descrYes = "Write all IRs to files in the output directory",
+    default = Some(false),
+    noshort = true,
+    group = debugging
+  )
+
+  val time: ScallopOption[String] = choice(
+    choices = Seq("text", "json"),
+    name = "time",
+    descr = "Measure the time spent in each compilation phase",
+    required = false,
+    group = debugging
   )
 
   /**

--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -45,7 +45,7 @@ trait EffektTests extends munit.FunSuite {
     val configs = compiler.createConfig(Seq(
       "--Koutput", "string",
       "--compile",
-      "--noexit-on-error",
+      "--no-exit-on-error",
       "--backend", backendName,
       "--out", output.getPath
     ))
@@ -72,7 +72,7 @@ trait EffektTests extends munit.FunSuite {
     val configs = compiler.createConfig(Seq(
       "--Koutput", "string",
       "--compile",
-      "--noexit-on-error",
+      "--no-exit-on-error",
       "--backend", backendName,
       "--out", output.getPath
     ))


### PR DESCRIPTION
This homogenizes option names and groups them in the help dialog according to their frequent usage.

Fixes #465 


Here is how the help dialog is now rendered:

```
effekt --help
 Common Options
  -c, --compile                  Compile the Effekt program to the backend
                                 specific representation
      --nocompile
  -b, --build                    Compile the Effekt program and build a backend
                                 specific executable
      --nobuild
  -o, --out  <arg>               Path to write generated files to (defaults to
                                 ./out)
      --includes  <arg>...       Path to consider for includes (can be set
                                 multiple times)
  -l, --lib  <arg>               Path to the standard library to be used
      --backend  <arg>           The backend that should be used Choices: js,
                                 chez-callcc, chez-monadic, chez-lift, llvm, ml

 Advanced Options
      --llvm-version  <arg>      the llvm version that should be used to compile
                                 the generated programs (only necessary if
                                 backend is llvm, defaults to 15)
      --prelude  <arg>...        Modules to be automatically imported in every
                                 file
      --exit-on-error            Exit with non-zero exit code on error
      --noexit-on-error
  -O, --optimize                 Run optimizations (in particular the inliner)
                                 when compiling programs
      --nooptimize
      --max-inline-size  <arg>   Maximum size (number of core tree-nodes) of a
                                 function considered by the inliner
  -s, --server                   Run compiler as a language server
      --noserver                 Run compiler in standard batch mode

 Compiler Development
      --ir-show  <arg>           The intermediate presentation that should be
                                 printed. Choices: none, core, lifted, machine,
                                 target
      --ir-write-all             Write all IRs to files in the output directory
      --noir-write-all
  -t, --time  <arg>              Measure the time spent in each compilation
                                 phase Choices: text, json

  -h, --help                     Show help message

 trailing arguments:
  files (not required)   Input files
```