### PR TITLE
Fix/dont match on unit

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
@@ -124,7 +124,7 @@ object PatternMatchingCompiler {
     }
 
     // (3a) Match on a literal
-    def splitOnLiteral(lit: Literal, equals: (Pure, Pure) => Pure) = {
+    def splitOnLiteral(lit: Literal, equals: (Pure, Pure) => Pure): core.Stmt = {
       // the different literal values that we match on
       val variants: List[core.Literal] = normalized.collect {
         case Clause(Split(Pattern.Literal(lit, _), _, _), _, _) => lit
@@ -147,6 +147,10 @@ object PatternMatchingCompiler {
           addDefault(c)
           variants.foreach { v => addClause(v, c) }
       }
+
+      // special case matching on ()
+      val unit: Literal = Literal((), core.Type.TUnit)
+      if (lit == unit) return compile(clausesFor.getOrElse(unit, Nil))
 
       // (4) assemble syntax tree for the pattern match
       variants.foldRight(compile(defaults)) {

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -400,8 +400,12 @@ object normal {
         clauses.collectFirst { case (tag, lit) if tag == ctorTag => lit }
           .map(body => app(body, Nil, vargs, Nil))
           .orElse { default }.getOrElse { sys error "Pattern not exhaustive. This should not happen" }
-      case other =>
-        Match(scrutinee, clauses, default)
+      case other => (clauses, default) match {
+        // Unit-like types: there is only one case and it is just a tag.
+        //   sc match { case Unit() => body }   ==>   body
+        case ((id, lit) :: Nil, None) if lit.vparams.isEmpty => lit.body
+        case _ => Match(scrutinee, clauses, default)
+      }
     }
 
 


### PR DESCRIPTION
This treats one half of #464. Ideally, we would represent unit as a data type (which is defined in the prelude). 

However, we still need to special case its rendering to `()`.

A data type like

```
type Unit { unit() }
```

would be shown as `unit()` by the generic show methods (in `inspect`), which would be surprising. This is not impossible to work around, however.