### PR TITLE
Report detailed missing case on non-exhaustive pattern match

### DIFF
--- a/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
@@ -8,6 +8,7 @@ import effekt.source.{ Def, ExprTarget, IdTarget, MatchGuard, MatchPattern, Tree
 import effekt.source.Tree.{ Query, Visit }
 import effekt.util.messages.{ ErrorReporter, INTERNAL_ERROR }
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 /**
@@ -148,17 +149,36 @@ object ExhaustivityChecker {
 
     // Error Reporting
     // ---------------
-    def reportNonExhaustive()(using C: ErrorReporter): Unit = missingCases.foreach {
-      case Missing.Tag(ctor, at) =>
-        C.error(pp"Non exhaustive pattern matching, missing case for ${ ctor }")
-      case Missing.Guard(term) =>
-        C.at(term) {
-          C.error(pp"Non exhaustive pattern matching, guard could be false which is not covered")
-        }
-      case Missing.Literal(value, tpe, at) =>
-        C.error(pp"Non exhaustive pattern matching, missing case for ${value}")
-      case Missing.Default(tpe, at) =>
-        C.error(pp"Non exhaustive pattern matching, scrutinees of type ${tpe} require a default case")
+    def reportNonExhaustive()(using C: ErrorReporter): Unit = {
+      @tailrec
+      def traceToCase(at: Trace, acc: String): String = at match {
+        case Trace.Root(_) => acc
+        case Trace.Child(childCtor, field, outer) =>
+          val newAcc = s"${childCtor.name}(${childCtor.fields.map { f => if f == field then acc else "_" }.mkString(", ")})"
+          traceToCase(outer, newAcc)
+      }
+
+      missingCases.foreach {
+        case Missing.Tag(ctor, at) =>
+          val missingSubcase = ctor.fields match
+            case Nil => s"${ctor.name}()"
+            case _ => s"${ctor.name}(${ctor.fields.map { _f => "_" }.mkString(", ")})"
+          val missingCase = traceToCase(at, missingSubcase)
+
+          C.error(pp"Non-exhaustive pattern matching, missing case ${missingCase}")
+        case Missing.Guard(term) =>
+          C.at(term) {
+            C.error(pp"Non-exhaustive pattern matching, guard could be false which is not covered")
+          }
+        case Missing.Literal(value, tpe, at) =>
+          val missingCase = traceToCase(at, pp"${value}")
+
+          C.error(pp"Non-exhaustive pattern matching, missing case $missingCase")
+        case Missing.Default(tpe, at) =>
+          val missingCase = traceToCase(at, "_")
+
+          C.error(pp"Non-exhaustive pattern matching, scrutinees of type ${tpe} require a default case ${missingCase}")
+      }
     }
 
     def reportRedundant()(using C: ErrorReporter): Unit = redundant.foreach { p =>

--- a/examples/neg/coverage.check
+++ b/examples/neg/coverage.check
@@ -1,6 +1,6 @@
-[error] examples/neg/coverage.effekt:9:21: Non exhaustive pattern matching, missing case for Third
+[error] examples/neg/coverage.effekt:9:21: Non-exhaustive pattern matching, missing case Third()
 def user(t: Test) = t match {
                     ^
-[error] examples/neg/coverage.effekt:9:21: Non exhaustive pattern matching, missing case for First
+[error] examples/neg/coverage.effekt:9:21: Non-exhaustive pattern matching, missing case First()
 def user(t: Test) = t match {
                     ^

--- a/examples/neg/match_exhaustive.effekt
+++ b/examples/neg/match_exhaustive.effekt
@@ -4,18 +4,18 @@ def guard(): Bool = false
 
 def foo(t: Option[Int]) =
   t match {
-    case Some(n) and n > 0 => n - 1 // ERROR Non exhaustive pattern
+    case Some(n) and n > 0 => n - 1 // ERROR Non-exhaustive pattern
     case None() => 0
   }
 
-def ex1(opt: Option[String]) = opt match { // ERROR missing case for None
-  case _ and guard() and opt is Some(voo) => voo // ERROR Non exhaustive pattern
+def ex1(opt: Option[String]) = opt match { // ERROR missing case None()
+  case _ and guard() and opt is Some(voo) => voo // ERROR Non-exhaustive pattern
   case None() => "world"
 }
 
-def unknownMatch(e: FFI) = e match {} // ERROR Non exhaustive pattern
+def unknownMatch(e: FFI) = e match {} // ERROR Non-exhaustive pattern
 
-def ex2(n: Int) = n match { // ERROR Non exhaustive pattern
+def ex2(n: Int) = n match { // ERROR Non-exhaustive pattern
   case 1 => 2
   case 2 => 3
   case 3 => 4

--- a/examples/neg/match_nested.check
+++ b/examples/neg/match_nested.check
@@ -1,3 +1,3 @@
-[error] examples/neg/match_nested.effekt:9:20: Non exhaustive pattern matching, missing case for Mul
+[error] examples/neg/match_nested.effekt:9:20: Non-exhaustive pattern matching, missing case Add(Mul(_, Mul(_, _)), _)
 def test(l: Exp) = l match {
                    ^

--- a/examples/neg/match_nested.check
+++ b/examples/neg/match_nested.check
@@ -1,3 +1,6 @@
 [error] examples/neg/match_nested.effekt:9:20: Non-exhaustive pattern matching, missing case Add(Mul(_, Mul(_, _)), _)
 def test(l: Exp) = l match {
                    ^
+[error] examples/neg/match_nested.effekt:9:20: Non-exhaustive pattern matching, scrutinees of type Int require a default case Add(Mul(_, Lit(_)), _)
+def test(l: Exp) = l match {
+                   ^

--- a/examples/neg/match_nested.effekt
+++ b/examples/neg/match_nested.effekt
@@ -10,10 +10,11 @@ def test(l: Exp) = l match {
   case Add(Lit(n), r) => 0
   case Add(Mul(_, Add(_, _)), r) => 1
   // case Add(Mul(_, Mul(_, _)), r) => 2
-  case Add(Mul(_, Lit(_)), r) => 3
-  case Add(Add(_, _), _) => 4
-  case Mul(_, _) => 5
-  case Lit(_) => 6
+  case Add(Mul(_, Lit(42)), r) => 3
+  // case Add(Mul(_, Lit(_)), r) => 4
+  case Add(Add(_, _), _) => 5
+  case Mul(_, _) => 6
+  case Lit(_) => 7
 }
 
 def main() = ()

--- a/examples/neg/match_nested_literal.check
+++ b/examples/neg/match_nested_literal.check
@@ -1,0 +1,6 @@
+[error] examples/neg/match_nested_literal.effekt:9:21: Non-exhaustive pattern matching, missing case Or(_, And(Lit(true), _))
+def test(b: BExp) = b match {
+                    ^
+[error] examples/neg/match_nested_literal.effekt:9:21: Non-exhaustive pattern matching, missing case Lit(false)
+def test(b: BExp) = b match {
+                    ^

--- a/examples/neg/match_nested_literal.effekt
+++ b/examples/neg/match_nested_literal.effekt
@@ -1,0 +1,21 @@
+module nested
+
+type BExp {
+  Lit(b: Bool)
+  Or(l: BExp, r: BExp)
+  And(l: BExp, r: BExp)
+}
+
+def test(b: BExp) = b match {
+  case Lit(true) => 0
+  // case Lit(false) => 1
+  case Or(_, And(Lit(false), _)) => 2
+  // case Or(_, And(Lit(true), _)) => 3
+  case Or(_, And(And(_, _), _)) => 4
+  case Or(_, And(Or(_, _), _)) => 5
+  case Or(_, Lit(_)) => 6
+  case Or(_, Or(_, _)) => 7
+  case And(_, _) => 8
+}
+
+def main() = ()

--- a/examples/neg/matchdef.check
+++ b/examples/neg/matchdef.check
@@ -1,3 +1,3 @@
-[error] examples/neg/matchdef.effekt:13:9: Non exhaustive pattern matching, missing case for Other
+[error] examples/neg/matchdef.effekt:13:9: Non-exhaustive pattern matching, missing case Other()
     val Person(name, age) = r;
         ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Resolves #463 by reporting the whole missing case instead of just the sub-pattern.

### Example

```scala
type BooleyTree {
  Leaf()
  Fork(l: BooleyTree, v: Bool, r: BooleyTree)
}

def testTree(t: BooleyTree): Int = t match {
  case Leaf() => 42
  case Fork(Fork(l, true, Leaf()), _, r) => 1000
}
```

Error before:
```
Non exhaustive pattern matching, missing case for false
Non exhaustive pattern matching, missing case for Fork
Non exhaustive pattern matching, missing case for Leaf
```

Error after:
```
Non-exhaustive pattern matching, missing case Fork(Fork(_, false, _), _, _)
Non-exhaustive pattern matching, missing case Fork(Fork(_, _, Fork(_, _, _)), _, _))
Non-exhaustive pattern matching, missing case Fork(Leaf(), _, _)
```

(I like that one can now copy the `case Fork(Fork(_, false, _), _, _)` suffix to get the actual case they should copy-paste :) )

### Caveats

- It would be nice to offer a quick-fix here, similarly to how it's done in the Scala 3 compiler: https://github.com/scala/scala3/blob/e0c030ccd44089e70629b59d76962c1dfc8dbb16/compiler/src/dotty/tools/dotc/reporting/messages.scala#L871-L891.
- Related to the one above: We construct a textual representation of the missing case now, we could instead pretty-print an actual term instead!
- I made no attempt at all to handle missing guards.
- I have no idea how this works for edge-cases like existential types.