### PR TITLE
Allow new-style `on[E].result` Result reification

### DIFF
--- a/libraries/common/result.effekt
+++ b/libraries/common/result.effekt
@@ -21,6 +21,11 @@ def result[A, E] { f: => A / Exception[E] }: Result[A, E] = try {
 } with Exception[E] {
   def raise(exc, msg) = Error(exc, msg)
 }
+def result[A, E](proxy: on[E]) { f: => A / Exception[E] }: Result[A, E] = try {
+  Success(f())
+} with Exception[E] {
+  def raise(exc, msg) = Error(exc, msg)
+}
 
 /**
  * Extracts the value of a result, if available


### PR DESCRIPTION
We introduced a new style of handling exceptions using `on[E]`-proxy objects.
This was not introduced for `Result`, but only for `Option`.

With this PR, we now also allow code like:
```scala
    with on[MyException].result
    // ...
```
