### PR TITLE
Switch to LLVM's tailcc calling convention by passing arguments without env

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -122,6 +122,7 @@ class LLVMTests extends EffektTests {
     examplesDir / "pos" / "capture" / "borrows.effekt",
     examplesDir / "pos" / "capture" / "optimizing_unbox.effekt",
     examplesDir / "pos" / "capture" / "regions.effekt",
+    examplesDir / "pos" / "capture" / "state_eff.effekt",
     examplesDir / "pos" / "lambdas" / "annotated.effekt",
     examplesDir / "pos" / "lambdas" / "scheduler.effekt",
     examplesDir / "pos" / "lambdas" / "simpleclosure.effekt",

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -12,9 +12,9 @@ object PrettyPrinter {
     definitions.map(show).mkString("\n\n")
 
   def show(definition: Definition)(using C: Context): LLVMString = definition match {
-    case Function(returnType, name, parameters, basicBlocks, cc) =>
+    case Function(callingConvention, returnType, name, parameters, basicBlocks) =>
       s"""
-define ${cc} ${show(returnType)} ${globalName(name)}(${commaSeparated(parameters.map(show))}) {
+define ${show(callingConvention)} ${show(returnType)} ${globalName(name)}(${commaSeparated(parameters.map(show))}) {
     ${indentedLines(basicBlocks.map(show).mkString)}
 }
 """
@@ -39,6 +39,11 @@ define ${show(returnType)} ${globalName(name)}(${commaSeparated(parameters.map(s
       s"@$name = private constant ${show(initializer)}"
   }
 
+  def show(callingConvention: CallingConvention): LLVMString = callingConvention match {
+    case Ccc() => "ccc"
+    case Tailcc() => "tailcc"
+  }
+
   def show(basicBlock: BasicBlock)(using Context): LLVMString = basicBlock match {
     case BasicBlock(name, instructions, terminator) =>
       s"""
@@ -50,18 +55,18 @@ ${indentedLines(instructions.map(show).mkString("\n"))}
 
   def show(instruction: Instruction)(using C: Context): LLVMString = instruction match {
 
-    case Call(_, VoidType(), ConstantGlobal(_, name), arguments) =>
-      s"call void ${globalName(name)}(${commaSeparated(arguments.map(show))})"
-    case Call(result, tpe, ConstantGlobal(_, name), arguments) =>
-      s"${localName(result)} = call ${show(tpe)} ${globalName(name)}(${commaSeparated(arguments.map(show))})"
-    case Call(_, _, nonglobal, _) => C.abort(s"cannot call non-global operand: $nonglobal")
-
-    case TailCall(LocalReference(_, name), arguments, cc) =>
-      s"musttail call ${cc} void ${localName(name)}(${commaSeparated(arguments.map(show))})"
-    case TailCall(ConstantGlobal(_, name), arguments, cc) =>
-      s"musttail call ${cc} void ${globalName(name)}(${commaSeparated(arguments.map(show))})"
-    case TailCall(nonglobal, _, _) => C.abort(s"can only tail call references, not: $nonglobal")
-    // TODO [jfrech, 2022-07-26] Why does tail call even have a return type if we do not use it?
+    case Call(_, Ccc(), VoidType(), ConstantGlobal(_, name), arguments) =>
+      s"call ccc void ${globalName(name)}(${commaSeparated(arguments.map(show))})"
+    case Call(result, Ccc(), tpe, ConstantGlobal(_, name), arguments) =>
+      s"${localName(result)} = call ccc ${show(tpe)} ${globalName(name)}(${commaSeparated(arguments.map(show))})"
+    case Call(_, Ccc(), _, nonglobal, _) =>
+      C.abort(s"cannot call non-global operand: $nonglobal")
+    case Call(_, Tailcc(), VoidType(), ConstantGlobal(_, name), arguments) =>
+      s"musttail call tailcc void ${globalName(name)}(${commaSeparated(arguments.map(show))})"
+    case Call(_, Tailcc(), VoidType(), LocalReference(_, name), arguments) =>
+      s"musttail call tailcc void ${localName(name)}(${commaSeparated(arguments.map(show))})"
+    case Call(_, Tailcc(), tpe, _, _) =>
+      C.abort(s"tail call to non-void function returning: $tpe")
 
     case Load(result, tpe, LocalReference(PointerType(), name)) =>
       s"${localName(result)} = load ${show(tpe)}, ${show(LocalReference(PointerType(), name))}"

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -14,7 +14,7 @@ object PrettyPrinter {
   def show(definition: Definition)(using C: Context): LLVMString = definition match {
     case Function(returnType, name, parameters, basicBlocks) =>
       s"""
-define fastcc ${show(returnType)} ${globalName(name)}(${commaSeparated(parameters.map(show))}) {
+define tailcc ${show(returnType)} ${globalName(name)}(${commaSeparated(parameters.map(show))}) {
     ${indentedLines(basicBlocks.map(show).mkString)}
 }
 """
@@ -57,9 +57,9 @@ ${indentedLines(instructions.map(show).mkString("\n"))}
     case Call(_, _, nonglobal, _) => C.abort(s"cannot call non-global operand: $nonglobal")
 
     case TailCall(LocalReference(_, name), arguments) =>
-      s"tail call fastcc void ${localName(name)}(${commaSeparated(arguments.map(show))})"
+      s"musttail call tailcc void ${localName(name)}(${commaSeparated(arguments.map(show))})"
     case TailCall(ConstantGlobal(_, name), arguments) =>
-      s"tail call fastcc void ${globalName(name)}(${commaSeparated(arguments.map(show))})"
+      s"musttail call tailcc void ${globalName(name)}(${commaSeparated(arguments.map(show))})"
     case TailCall(nonglobal, _) => C.abort(s"can only tail call references, not: $nonglobal")
     // TODO [jfrech, 2022-07-26] Why does tail call even have a return type if we do not use it?
 

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
@@ -7,12 +7,18 @@ package llvm
  *  see: https://hackage.haskell.org/package/llvm-hs-pure-9.0.0/docs/LLVM-AST.html#t:Definition
  */
 enum Definition {
-  case Function(returnType: Type, name: String, parameters: List[Parameter], basicBlocks: List[BasicBlock], cc: String = "tailcc")
+  case Function(callingConvention: CallingConvention, returnType: Type, name: String, parameters: List[Parameter], basicBlocks: List[BasicBlock])
   case VerbatimFunction(returnType: Type, name: String, parameters: List[Parameter], body: String)
   case Verbatim(content: String)
   case GlobalConstant(name: String, initializer: Operand) // initializer should be constant
 }
 export Definition.*
+
+enum CallingConvention {
+  case Ccc()
+  case Tailcc()
+}
+export CallingConvention.*
 
 case class BasicBlock(name: String, instructions: List[Instruction], terminator: Terminator)
 
@@ -20,8 +26,7 @@ case class BasicBlock(name: String, instructions: List[Instruction], terminator:
  *  see: https://hackage.haskell.org/package/llvm-hs-pure-9.0.0/docs/LLVM-AST-Instruction.html#t:Instruction
  */
 enum Instruction {
-  case Call(result: String, resultType: Type, function: Operand, arguments: List[Operand])
-  case TailCall(function: Operand, arguments: List[Operand], cc: String = "tailcc")
+  case Call(result: String, callingConvention: CallingConvention, resultType: Type, function: Operand, arguments: List[Operand])
   case Load(result: String, tpe: Type, address: Operand)
   case Store(address: Operand, value: Operand)
   case GetElementPtr(result: String, tpe: Type, address: Operand, indices: List[Int])

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
@@ -7,7 +7,7 @@ package llvm
  *  see: https://hackage.haskell.org/package/llvm-hs-pure-9.0.0/docs/LLVM-AST.html#t:Definition
  */
 enum Definition {
-  case Function(returnType: Type, name: String, parameters: List[Parameter], basicBlocks: List[BasicBlock])
+  case Function(returnType: Type, name: String, parameters: List[Parameter], basicBlocks: List[BasicBlock], cc: String = "tailcc")
   case VerbatimFunction(returnType: Type, name: String, parameters: List[Parameter], body: String)
   case Verbatim(content: String)
   case GlobalConstant(name: String, initializer: Operand) // initializer should be constant
@@ -21,7 +21,7 @@ case class BasicBlock(name: String, instructions: List[Instruction], terminator:
  */
 enum Instruction {
   case Call(result: String, resultType: Type, function: Operand, arguments: List[Operand])
-  case TailCall(function: Operand, arguments: List[Operand])
+  case TailCall(function: Operand, arguments: List[Operand], cc: String = "tailcc")
   case Load(result: String, tpe: Type, address: Operand)
   case Store(address: Operand, value: Operand)
   case GetElementPtr(result: String, tpe: Type, address: Operand, indices: List[Int])

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -32,7 +32,8 @@ object Transformer {
     // collect all information
     val declarations = mod.externs.map(transform)
     val definitions = mod.definitions
-    val mainEntry = Jump(Label(mainName, List()))
+    val evidence = Variable(freshName("ev"), builtins.Evidence)
+    val mainEntry = LiteralEvidence(evidence, builtins.Here, Jump(Label(mainName, List(evidence))))
 
     findToplevelBlocksParams(definitions)
 

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -1,7 +1,5 @@
 ; Run-Time System
 
-attributes #0 = { "ccc" }
-
 %Evidence = type i64
 
 ; Basic types
@@ -207,7 +205,7 @@ define void @eraseObject(%Object %object) alwaysinline {
     %objectEraser = getelementptr %Header, ptr %object, i64 0, i32 1
     %eraser = load %Eraser, ptr %objectEraser
     %environment = call %Environment @objectEnvironment(%Object %object)
-    call fastcc void %eraser(%Environment %environment)
+    call void %eraser(%Environment %environment)
     call void @free(%Object %object)
     br label %done
 
@@ -491,7 +489,7 @@ loop:
     %newMemory = call %Memory @copyMemory(%Memory %memory)
 
     %newStackPointer = extractvalue %Memory %newMemory, 0
-    call fastcc void @shareFrames(%StackPointer %newStackPointer)
+    call void @shareFrames(%StackPointer %newStackPointer)
 
     %newRegion = call %Region @copyRegion(%Region %region)
 
@@ -534,7 +532,7 @@ define void @eraseStack(%Stack %stack) alwaysinline {
     free:
     %stackStackPointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 1, i32 0
     %stackPointer = load %StackPointer, ptr %stackStackPointer
-    call fastcc void @eraseFrames(%StackPointer %stackPointer)
+    call void @eraseFrames(%StackPointer %stackPointer)
 
     %regionPointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
     %region = load %Region, ptr %regionPointer
@@ -545,19 +543,19 @@ define void @eraseStack(%Stack %stack) alwaysinline {
     ret void
 }
 
-define fastcc void @shareFrames(%StackPointer %stackPointer) alwaysinline {
+define void @shareFrames(%StackPointer %stackPointer) alwaysinline {
     %newStackPointer = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 -1
     %stackSharer = getelementptr %FrameHeader, %StackPointer %newStackPointer, i64 0, i32 1
     %sharer = load %Sharer, ptr %stackSharer
-    tail call fastcc void %sharer(%StackPointer %newStackPointer)
+    tail call void %sharer(%StackPointer %newStackPointer)
     ret void
 }
 
-define fastcc void @eraseFrames(%StackPointer %stackPointer) alwaysinline {
+define void @eraseFrames(%StackPointer %stackPointer) alwaysinline {
     %newStackPointer = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 -1
     %stackEraser = getelementptr %FrameHeader, %StackPointer %newStackPointer, i64 0, i32 2
     %eraser = load %Eraser, ptr %stackEraser
-    tail call fastcc void %eraser(%StackPointer %newStackPointer)
+    tail call void %eraser(%StackPointer %newStackPointer)
     ret void
 }
 
@@ -596,7 +594,7 @@ define void @eraseRegion(%Region %region) alwaysinline {
 
 ; RTS initialization
 
-define fastcc void @topLevel(%Pos %val, %StackPointer noalias %stackPointer) {
+define tailcc void @topLevel(%Pos %val, %StackPointer noalias %stackPointer) {
     %base = load %Base, ptr @base
     call void @free(%Base %base)
 
@@ -612,12 +610,12 @@ define fastcc void @topLevel(%Pos %val, %StackPointer noalias %stackPointer) {
     ret void
 }
 
-define fastcc void @topLevelSharer(%Environment %environment) {
+define void @topLevelSharer(%Environment %environment) {
     ; TODO this should never be called
     ret void
 }
 
-define fastcc void @topLevelEraser(%Environment %environment) {
+define void @topLevelEraser(%Environment %environment) {
     ; TODO this should never be called
     ret void
 }
@@ -635,7 +633,7 @@ define %StackPointer @withEmptyStack() {
     ret %StackPointer %stackPointer_2
 }
 
-define fastcc void @run_i64(%Neg %f, i64 %arg) {
+define void @run_i64(%Neg %f, i64 %arg) {
     ; backup globals
     %base = load %Base, ptr @base
     %region = load %Region, ptr @region
@@ -664,7 +662,7 @@ define fastcc void @run_i64(%Neg %f, i64 %arg) {
 }
 
 
-define fastcc void @run_Pos(%Neg %f, %Pos %arg) {
+define void @run_Pos(%Neg %f, %Pos %arg) {
     ; backup globals
     %base = load %Base, ptr @base
     %region = load %Region, ptr @region

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -651,13 +651,8 @@ define fastcc void @run_i64(%Neg %f, i64 %arg) {
     %functionPointerPointer = getelementptr ptr, ptr %arrayPointer, i64 0
     %functionPointer = load ptr, ptr %functionPointerPointer
 
-    ; Store the argument (0th index is evidence)
-    %environment = call %Environment @malloc(i64 1048576)
-    %evidence2 = getelementptr {%Int, %Int}, %Environment %environment, i64 0, i32 1
-    store i64 %arg, ptr %evidence2
-
     ; call
-    %result = call fastcc %Pos %functionPointer(%Object %object, %Environment %environment, %StackPointer %stackPointer)
+    %result = call tailcc %Pos %functionPointer(%Object %object, %Evidence 0, i64 %arg, %StackPointer %stackPointer)
 
     ; restore stack (TODO this shouldn't be necessary, the moment we pass stacks...; then this is a tail-call again)
     store %StackPointer %base, ptr @base
@@ -685,13 +680,8 @@ define fastcc void @run_Pos(%Neg %f, %Pos %arg) {
     %functionPointerPointer = getelementptr ptr, ptr %arrayPointer, i64 0
     %functionPointer = load ptr, ptr %functionPointerPointer
 
-    ; Store the argument (0th index is evidence)
-    %environment = call %Environment @malloc(i64 1048576)
-    %arg_pos = getelementptr {%Int, %Pos}, %Environment %environment, i64 0, i32 1
-    store %Pos %arg, ptr %arg_pos
-
     ; call
-    %result = call fastcc %Pos %functionPointer(%Object %object, %Environment %environment, %StackPointer %stackPointer)
+    %result = call tailcc %Pos %functionPointer(%Object %object, %Evidence 0, %Pos %arg, %StackPointer %stackPointer)
 
     ; restore stack (TODO this shouldn't be necessary, the moment we pass stacks...; then this is a tail-call again)
     store %StackPointer %base, ptr @base
@@ -719,8 +709,7 @@ define void @run(%Neg %f) {
     %functionPointer = load ptr, ptr %functionPointerPointer
 
     ; call
-    %environment = call %Environment @malloc(i64 1048576)
-    %result = call fastcc %Pos %functionPointer(%Object %object, %Environment %environment, %StackPointer %stackPointer)
+    %result = call tailcc %Pos %functionPointer(%Object %object, %Evidence 0, %StackPointer %stackPointer)
 
     ; restore stack (TODO this shouldn't be necessary, the moment we pass stacks...; then this is a tail-call again)
     store %StackPointer %base, ptr @base

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -596,7 +596,7 @@ define void @eraseRegion(%Region %region) alwaysinline {
 
 ; RTS initialization
 
-define fastcc void @topLevel(%Environment %environment, %StackPointer noalias %stackPointer) {
+define fastcc void @topLevel(%Pos %val, %StackPointer noalias %stackPointer) {
     %base = load %Base, ptr @base
     call void @free(%Base %base)
 
@@ -609,7 +609,6 @@ define fastcc void @topLevel(%Environment %environment, %StackPointer noalias %s
     call void @free(%Base %base.1)
     call void @free(%Base %base.2)
 
-    call void @free(%Environment %environment)
     ret void
 }
 


### PR DESCRIPTION
It's not clear how much this change influences the performance of the LLVM backend; we should write/merge the new benchmarking infrastructure first before merging this.