### PR TITLE
Use externs in `PolymorphismBoxing`

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/CoreTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/CoreTests.scala
@@ -107,7 +107,6 @@ trait CorePhaseTests[P <: Phase[CoreTransformed, CoreTransformed]](phase: P) ext
   }
   protected val theSourceModuleDecl: effekt.source.ModuleDecl = effekt.source.ModuleDecl("(core test)", Nil, Nil) // FIXME sentinel value
 
-  // TODO Maybe fix this up so we can do findPrelude. Cmp. PolymorphismBoxingTests for a hacky way to do this
   protected val theSourceModule: effekt.symbols.Module = effekt.symbols.Module(theSourceModuleDecl, theSource)
 
   override def transform(input: ModuleDecl): ModuleDecl = {

--- a/effekt/jvm/src/test/scala/effekt/core/PolymorphismBoxingTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/PolymorphismBoxingTests.scala
@@ -1,46 +1,46 @@
-package effekt.core
+package effekt
+package core
 
 import effekt.{core, source, symbols}
 import effekt.context.Context
 import effekt.core.{Block, Definition, DirectApp, PolymorphismBoxing, Pure, Run, Stmt}
 import effekt.source.{IdDef, Include}
-import effekt.symbols.{Module, Name, TypeConstructor, TypeSymbol, ValueSymbol, ValueType}
 import effekt.util.messages
 import effekt.util.messages.DebugMessaging
 import kiama.parsing.{Failure, NoSuccess, Success}
 
 abstract class AbstractPolymorphismBoxingTests extends CorePhaseTests(PolymorphismBoxing) {
 
-  def boxDef(tpe: ValueType.ValueTypeApp): List[symbols.Symbol] = {
-    val tpeCns: symbols.TypeConstructor.Record =
-      symbols.TypeConstructor.Record(symbols.LocalName("Boxed" ++ tpe.constructor.name.name), List(), null)
-    tpeCns.constructor =
-      symbols.Constructor(symbols.LocalName("MkBoxed" ++ tpe.constructor.name.name), List(), null, tpeCns)
-    tpeCns.constructor.fields = List(
-      symbols.Field(symbols.LocalName("unbox" ++ tpe.constructor.name.name),
-        symbols.ValueParam(symbols.LocalName("value"), Some(tpe)), tpeCns.constructor))
-    List(tpeCns, tpeCns.constructor, tpeCns.constructor.fields.head)
+  override protected val defaultNames: Map[String, _root_.effekt.symbols.Symbol] = super.defaultNames ++ Map(
+    "BoxedInt" -> Id("BoxedInt"),
+    "BoxedString" -> Id("BoxedString"),
+    "MkBoxedString" -> Id("MkBoxedString"),
+    "boxInt" -> Id("boxInt"),
+    "unboxInt" -> Id("unboxInt"),
+    "unboxString" -> Id("unboxInt"),
+  )
+  val boxDecls = List(
+    Declaration.Data(defaultNames("BoxedString"), List(),
+      List(Constructor(defaultNames("MkBoxedString"),
+        List(Field(defaultNames("unboxString"), ValueType.Data(defaultNames("String"), Nil))))))
+  )
+  val boxExterns = List(
+    Extern.Def(defaultNames("boxInt"), Nil, Nil, List(ValueParam(Id("i"), ValueType.Data(defaultNames("Int"), Nil))), Nil,
+      ValueType.Data(defaultNames("BoxedInt"), Nil), Set.empty,
+      ExternBody.StringExternBody(source.FeatureFlag.Default, Template(List("<box int>"), Nil))),
+    Extern.Def(defaultNames("unboxInt"), Nil, Nil, List(ValueParam(Id("i"), ValueType.Data(defaultNames("BoxedInt"), Nil))), Nil,
+      ValueType.Data(defaultNames("Int"), Nil), Set.empty,
+      ExternBody.StringExternBody(source.FeatureFlag.Default, Template(List("<unbox int>"), Nil)))
+  )
+
+  override def transform(input: ModuleDecl): ModuleDecl = input match {
+    case ModuleDecl(path, includes, declarations, externs, definitions, exports) =>
+      super.transform(ModuleDecl(path, includes, boxDecls ++ declarations, boxExterns ++ externs, definitions, exports)) match {
+        case ModuleDecl(path, includes, declarations, externs, definitions, exports) =>
+          ModuleDecl(path, includes, declarations.filterNot(boxDecls.contains), externs.filterNot(boxExterns.contains), definitions, exports)
+      }
   }
 
-  val boxtpes = symbols.builtins.rootTypes.values.flatMap {
-    case t: TypeConstructor.ExternType => boxDef(ValueType.ValueTypeApp(t, List()))
-    case _ => Nil
-  }.map { c => (c.name.name, c) }.toMap
-
-  /** Make sure that the stdlib module is found, with the appropriate `Boxed`... definitions */
-  val pseudoStdLib = Module(effekt.source.ModuleDecl("effekt", List(), List()), kiama.util.StringSource("", "effekt"))
-
-  pseudoStdLib.exports(Nil, symbols.Bindings(Map.empty, boxtpes.collect[String, symbols.TypeSymbol]{
-    case (k,t: symbols.TypeSymbol) => (k,t)
-  }, Map.empty, Map.empty))
-
-  override val theSourceModule = Module(source.ModuleDecl("test", List(Include("effekt")), List()), kiama.util.StringSource("", "test"))
-  theSourceModule.exports(List(pseudoStdLib), symbols.Bindings.empty)
-
-  override protected val defaultNames = boxtpes ++
-    symbols.builtins.rootTypes ++ Map(
-    // TODO maybe add used names
-  )
 }
 class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
   test("simple non-polymorphic code should stay the same"){
@@ -87,7 +87,7 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
       """module main
         |
         |def id = { ['A](a: 'A) => return a: 'A }
-        |def idInt = { (x: Int) => return (id: ['A]('A) => 'A @ {})[BoxedInt](make BoxedInt MkBoxedInt(x: Int)).unboxInt: Int }
+        |def idInt = { (x: Int) => return (unboxInt: (BoxedInt) => Int @ {})((id: ['A]('A) => 'A @ {})[BoxedInt]((boxInt: (Int) => BoxedInt @ {})(x: Int))) }
         |""".stripMargin
     assertTransformsTo(from, to)
   }
@@ -103,7 +103,7 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
       """module main
         |
         |def id = { ['A](a: 'A) => return a: 'A }
-        |def idInt = { (x: Int) => val tmp = (id: ['A]('A) => 'A @ {})[BoxedInt](make BoxedInt MkBoxedInt(x: Int)) ; return tmp:BoxedInt.unboxInt: Int }
+        |def idInt = { (x: Int) => val tmp = (id: ['A]('A) => 'A @ {})[BoxedInt]((boxInt: (Int) => BoxedInt @ {})(x: Int)) ; return (unboxInt: (BoxedInt) => Int @ {})(tmp:BoxedInt) }
         |""".stripMargin
     assertTransformsTo(from, to)
   }
@@ -127,8 +127,8 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
         |def idInt = { (x: Int) =>
         |    {
         |        let res = run {
-        |            let boxedRes = !(id: ['A]('A) => 'A @ {})[BoxedInt](make BoxedInt MkBoxedInt(x: Int))
-        |            return boxedRes:BoxedInt.unboxInt: Int
+        |            let boxedRes = !(id: ['A]('A) => 'A @ {})[BoxedInt]((boxInt: (Int) => BoxedInt @ {})(x: Int))
+        |            return (unboxInt: (BoxedInt) => Int @ {})(boxedRes:BoxedInt)
         |        }
         |        return res: Int
         |    }
@@ -150,11 +150,11 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
         |    val r = (hof: ['A](){ b : ('A) => 'A } => 'A @ {} )[BoxedInt](){ (boxedX: BoxedInt) =>
         |      {
         |         def originalFn = { (x: Int) => return x: Int }
-        |         val result = (originalFn: (Int) => Int @ {})(boxedX: BoxedInt.unboxInt: Int);
-        |         return make BoxedInt MkBoxedInt(result: Int)
+        |         val result = (originalFn: (Int) => Int @ {})((unboxInt: (BoxedInt) => Int @ {})(boxedX: BoxedInt));
+        |         return (boxInt: (Int) => BoxedInt @ {})(result: Int)
         |      }
         |    };
-        |    return r:BoxedInt.unboxInt: Int
+        |    return (unboxInt: (BoxedInt) => Int @ {})(r:BoxedInt)
         |}
         |""".stripMargin
     assertTransformsTo(from, to)
@@ -182,14 +182,14 @@ class PolymorphismBoxingTests extends AbstractPolymorphismBoxingTests {
         |                  (hhofargarg: Int) =>
         |                      {
         |                        def tmp = hhofargB: ('A) => 'A @ {}
-        |                        val rres:BoxedInt = (tmp: ('A) => 'A @ {})(make BoxedInt MkBoxedInt(hhofargarg: Int));
-        |                        return rres:BoxedInt.unboxInt: Int
+        |                        val rres:BoxedInt = (tmp: ('A) => 'A @ {})((boxInt: (Int) => BoxedInt @ {})(hhofargarg: Int));
+        |                        return (unboxInt: (BoxedInt) => Int @ {})(rres:BoxedInt)
         |                      }
         |              };
-        |              return make BoxedInt MkBoxedInt(res:Int)
+        |              return (boxInt: (Int) => BoxedInt @ {})(res:Int)
         |          }
         |    };
-        |    return result:BoxedInt.unboxInt: Int
+        |    return (unboxInt: (BoxedInt) => Int @ {})(result:BoxedInt)
         |}
         |""".stripMargin
     assertTransformsTo(from, to)

--- a/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
@@ -43,9 +43,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
   def box(using PContext): PartialFunction[ValueType, Boxer] = {
     case core.Type.TInt     => PContext.boxer("Int")
     case core.Type.TChar    => PContext.boxer("Char")
-    case core.Type.TBoolean => PContext.boxer("Bool")
     case core.Type.TDouble  => PContext.boxer("Double")
-    case core.Type.TUnit    => PContext.boxer("Unit")
     // Do strings need to be boxed? Really?
     case core.Type.TString  => PContext.boxer("String")
   }
@@ -421,9 +419,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
     override def apply(t: Pure): Pure = {
       to match {
         case core.Type.TInt => Pure.Literal(1337L, core.Type.TInt)
-        case core.Type.TBoolean => Pure.Literal(false, core.Type.TBoolean)
         case core.Type.TDouble  => Pure.Literal(13.37, core.Type.TDouble)
-        case core.Type.TUnit    => Pure.Literal((), core.Type.TUnit)
         // Do strings need to be boxed? Really?
         case core.Type.TString  => Pure.Literal("<?nothing>", core.Type.TString)
         case t if box.isDefinedAt(t) => sys error s"No default value defined for ${t}"

--- a/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
@@ -78,8 +78,6 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
   }
 
   class PContext(declarations: List[Declaration], externs: List[Extern])(using val Context: Context) extends DeclarationContext(declarations, externs){
-    lazy val prelude = Context.module.findPrelude
-
     /**
      * Find a pure extern def with one value parameter named [[name]] in the prelude (or some namespace in the prelude).
      */

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -604,11 +604,31 @@ def each(start: Int, end: Int) { action: (Int) => Unit / Control } = {
 
 def repeat(n: Int) { action: () => Unit / Control } = each(0, n) { n => action() }
 
+namespace internal {
+  namespace boxing {
+    // For boxing polymorphic values
+    extern type BoxedUnit
+    extern pure def boxUnit(u: Unit): Unit =
+    extern pure def unboxUnit(u: Unit): Unit =
 
-// For boxing polymorphic values
-record BoxedUnit(unboxUnit: Unit)
-record BoxedInt(unboxInt: Int)
-record BoxedChar(unboxChar: Char)
-record BoxedBool(unboxBool: Bool)
-record BoxedDouble(unboxDouble: Double)
-record BoxedString(unboxString: String)
+    extern type BoxedInt
+    extern pure def boxInt(n: Int): BoxedInt =
+    extern pure def unboxInt(b: BoxedInt): Int =
+
+    extern type BoxedChar
+    extern pure def boxChar(c: Char): BoxedChar =
+    extern pure def unboxChar(b: BoxedChar): Char =
+
+    extern type BoxedBool
+    extern pure def boxBool(b: Bool): BoxedBool =
+    extern pure def unboxBool(b: BoxedBool): Bool =
+
+    extern type BoxedDouble
+    extern pure def boxDouble(d: Double): BoxedDouble =
+    extern pure def unboxDouble(b: BoxedDouble): Double =
+
+    extern type BoxedString
+    extern pure def boxString(s: String): BoxedString =
+    extern pure def unboxString(b: BoxedString): String =
+  }
+}

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -656,8 +656,6 @@ namespace internal {
         ret %Double %d
       """
 
-    extern type BoxedString
-    extern pure def boxString(s: String): BoxedString =
-    extern pure def unboxString(b: BoxedString): String =
+    record BoxedString(unboxString: String)
   }
 }

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -613,11 +613,29 @@ namespace internal {
 
     extern type BoxedInt
     extern pure def boxInt(n: Int): BoxedInt =
+      llvm """
+        %boxed1 = insertvalue %Pos zeroinitializer, i64 %n, 0
+        %boxed2 = insertvalue %Pos %boxed1, %Obj null, 1
+        ret %Pos %boxed2
+      """
     extern pure def unboxInt(b: BoxedInt): Int =
+      llvm """
+        %unboxed = extractvalue %Pos %b, 0
+        ret %Int %unboxed
+      """
 
     extern type BoxedChar
     extern pure def boxChar(c: Char): BoxedChar =
+      llvm """
+        %boxed1 = insertvalue %Pos zeroinitializer, i64 %c, 0
+        %boxed2 = insertvalue %Pos %boxed1, %Obj null, 1
+        ret %Pos %boxed2
+      """
     extern pure def unboxChar(b: BoxedChar): Char =
+      llvm """
+        %unboxed = extractvalue %Pos %b, 0
+        ret %Int %unboxed
+      """
 
     extern type BoxedBool
     extern pure def boxBool(b: Bool): BoxedBool =

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -643,7 +643,18 @@ namespace internal {
 
     extern type BoxedDouble
     extern pure def boxDouble(d: Double): BoxedDouble =
+      llvm """
+        %n = bitcast double %d to i64
+        %boxed1 = insertvalue %Pos zeroinitializer, i64 %n, 0
+        %boxed2 = insertvalue %Pos %boxed1, %Obj null, 1
+        ret %Pos %boxed2
+      """
     extern pure def unboxDouble(b: BoxedDouble): Double =
+      llvm """
+        %unboxed = extractvalue %Pos %b, 0
+        %d = bitcast i64 %unboxed to double
+        ret %Double %d
+      """
 
     extern type BoxedString
     extern pure def boxString(s: String): BoxedString =


### PR DESCRIPTION
With this PR, `PolymorphismBoxing` will search for `extern pure def unboxT` and `extern pure def boxT` to box/unbox values.
If those are not found, it will still search for a record `BoxedT`.

It also changes the search s.t. the definitions will also be found if they are in a namespace.

This allows us to, e.g., store `int`s in the tag of a `%Pos` in LLVM.