### PR TITLE
Print types of block arguments without an Option wrapper

### DIFF
--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -79,7 +79,7 @@ object DeclPrinter extends ParenPrettyPrinter {
 
     val valueParams = f.vparams.map { p => pp"${p.name}: ${p.tpe.get}" }.mkString(", ")
     val vps = if valueParams.isEmpty then "" else s"($valueParams)"
-    val bps = f.bparams.map { b => pp"{ ${b.name}: ${b.tpe} }" }.mkString("")
+    val bps = f.bparams.map { b => pp"{ ${b.name}: ${b.tpe.get} }" }.mkString("")
 
     val ps = if (vps.isEmpty && bps.isEmpty) "()" else s"$vps$bps"
 


### PR DESCRIPTION
Resolves #473 by fixing a regression from #417 which mistakenly wrapped block types with `Option( ... )`

I think this only shows up when hovering over `bar` (see below) -- do we have a way to reliably test this?

---

Before:
<img width="370" alt="Screenshot 2024-05-28 at 14 34 27" src="https://github.com/effekt-lang/effekt/assets/11269173/21443ca3-9881-44c7-a7f0-abd7d1e43a07">

After:
<img width="349" alt="Screenshot 2024-06-05 at 11 30 24" src="https://github.com/effekt-lang/effekt/assets/11269173/a58c708a-7bba-4944-876d-dd0b938457b4">
