### PR TITLE
Allow passing command line parameters directly

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -5,7 +5,7 @@ import effekt.util.paths.file
 import kiama.util.REPLConfig
 import org.rogach.scallop.{ ScallopOption, fileConverter, fileListConverter, longConverter, stringConverter, stringListConverter }
 
-class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
+class EffektConfig(args: Seq[String]) extends REPLConfig(args.takeWhile(_ != "--")) {
 
   // Common
   // ------
@@ -57,6 +57,8 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args) {
     noshort = true,
     group = common
   ).map(Backend.backend)
+
+  def runArgs(): Seq[String] = args.dropWhile(_ != "--").drop(1)
 
   // Advanced
   // --------

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -71,7 +71,7 @@ trait Runner[Executable] {
   def eval(executable: Executable)(using C: Context): Unit = {
     val execFile = build(executable)
 
-    val exitCode = Process(execFile).run(new ProcessLogger {
+    val exitCode = Process(execFile, Context.config.runArgs()).run(new ProcessLogger {
 
       override def out(s: => String): Unit = {
         C.config.output().emitln(s)


### PR DESCRIPTION
This changed the argument parsing to interpret arguments after `--` as arguments to the compiled program.
That is, instead of
```sh
effekt --backend ml someprogram.effekt
out/someprogram 1 2 3
```
it is now possible to directly run
```sh
effekt --backend ml someprogram.effekt -- 1 2 3
```

Resolves #300.

Note that this does not solve the issues in #390, so those are still not correct in some backends.
Also note that the current behavior will be to pass the arguments to *all* compiled files.