### PR TITLE
Rename constructors of collections

### DIFF
--- a/examples/casestudies/ad.effekt.md
+++ b/examples/casestudies/ad.effekt.md
@@ -103,27 +103,27 @@ Otherwise the implementation closely follows the one by Wang et al.
 record NumB(value: Double, d: Ref[Double])
 def backwards(in: Double) { prog: NumB => NumB / AD[NumB] }: Double = {
   // the representation of our input
-  val input = NumB(in, fresh(0.0))
+  val input = NumB(in, ref(0.0))
 
   // a helper function to update the derivative of a given number by adding v
   def push(n: NumB, v: Double): Unit = set(n.d, get(n.d) + v)
 
   try { prog(input).push(1.0) } with AD[NumB] {
-    def num(v) = resume(NumB(v, fresh(0.0)))
+    def num(v) = resume(NumB(v, ref(0.0)))
     def add(x, y) = {
-      val z = NumB(x.value + y.value, fresh(0.0))
+      val z = NumB(x.value + y.value, ref(0.0))
       resume(z)
       x.push(get(z.d));
       y.push(get(z.d))
     }
     def mul(x, y) = {
-      val z = NumB(x.value * y.value, fresh(0.0))
+      val z = NumB(x.value * y.value, ref(0.0))
       resume(z)
       x.push(y.value * get(z.d));
       y.push(x.value * get(z.d))
     }
     def exp(x) = {
-      val z = NumB(mathExp(x.value), fresh(0.0))
+      val z = NumB(mathExp(x.value), ref(0.0))
       resume(z)
       x.push(mathExp(x.value) * get(z.d))
     }

--- a/examples/pos/array/list_conversion.effekt
+++ b/examples/pos/array/list_conversion.effekt
@@ -48,7 +48,7 @@ def main() = {
   listToArrayAndBack(list)
 
   println("empty array")
-  val emptyArray = array::unsafeFresh[Int](0)
+  val emptyArray = array::allocate[Int](0)
   arrayToListAndBack(emptyArray)
 
   println("nonempty array")

--- a/examples/pos/array/sum.effekt
+++ b/examples/pos/array/sum.effekt
@@ -1,7 +1,7 @@
 module examples/pos/array/sum
 
 def main() = {
-  val emptyArray: Array[Int] = array::unsafeFresh(0)
+  val emptyArray: Array[Int] = array::allocate(0)
   println(emptyArray.sum())
 
   val array: Array[Int] = build(3) { i => i + 1 } // Array(1, 2, 3)

--- a/examples/pos/arrays.effekt
+++ b/examples/pos/arrays.effekt
@@ -1,14 +1,14 @@
 module examples/pos/arrays
 
 def main() = {
-    val arr = array::unsafeFresh[String](5);
+    val arr = array::allocate[String](5);
 
     arr.unsafeSet(0, "hello");
     arr.unsafeSet(2, "world");
     println(arr.unsafeGet(0));
     println(arr.unsafeGet(2));
 
-    val arrWithVals: Array[String] = array::fresh(4, "Hello World");
+    val arrWithVals: Array[String] = array(4, "Hello World");
     println(arrWithVals)
 
     val arrByF: Array[Int] = array::build(5){ i => i };

--- a/examples/pos/propagators.effekt
+++ b/examples/pos/propagators.effekt
@@ -98,9 +98,9 @@ def propagators { net: => Unit / Net }: Unit = {
 
   try { net(); run() } with Net {
     def unknown[R]() =
-      resume(fresh((None(), Nil())))
+      resume(ref((None(), Nil())))
     def make[R](value) =
-      resume(fresh((Some(value), Nil())))
+      resume(ref((Some(value), Nil())))
     def learn[A](cell, value) = get(cell) match {
       case (None(), k) =>
         // update network with new information

--- a/examples/pos/raytracer.effekt
+++ b/examples/pos/raytracer.effekt
@@ -254,14 +254,14 @@ def bench() = {
   val scene = exampleScene();
 
   measure(5, 10) {
-    val buffer: Buffer = array::unsafeFresh(scene.width * scene.height * 4);
+    val buffer: Buffer = array::allocate(scene.width * scene.height * 4);
     render(scene, buffer)
   }
 }
 
 def main() = {
   val scene = exampleScene();
-  val buffer: Buffer = array::unsafeFresh(scene.width * scene.height * 4);
+  val buffer: Buffer = array::allocate(scene.width * scene.height * 4);
   render(scene, buffer);
 
   var i = 0;

--- a/examples/stdlib/bytes/bytes.effekt
+++ b/examples/stdlib/bytes/bytes.effekt
@@ -2,7 +2,7 @@ import bytes
 
 def main() = {
 
-  val b = bytes::empty(16);
+  val b = bytes::allocate(16);
   b.write(0, 104.toByte)
   b.write(1, 101.toByte)
   b.write(2, 108.toByte)

--- a/examples/stdlib/bytes/bytes.effekt
+++ b/examples/stdlib/bytes/bytes.effekt
@@ -2,7 +2,7 @@ import bytes
 
 def main() = {
 
-  val b = bytes::allocate(16);
+  val b = bytes(16);
   b.write(0, 104.toByte)
   b.write(1, 101.toByte)
   b.write(2, 108.toByte)

--- a/libraries/common/array.effekt
+++ b/libraries/common/array.effekt
@@ -4,17 +4,16 @@ import effekt
 import exception
 import list
 
-// Primitive operations:
-
 /**
  * A mutable 0-indexed fixed-sized array.
  */
 extern type Array[T]
 
 /**
- * Violated Postcondition: Fields contain values
+ * Allocates a new array of size `size`, keeping its values _undefined_.
+ * Prefer using `array` constructor instead to ensure that values are defined.
  */
-extern global def unsafeFresh[T](size: Int): Array[T] =
+extern global def allocate[T](size: Int): Array[T] =
   js "(new Array(${size}))"
   chez "(make-vector ${size})" // creates an array filled with 0s on CS
   llvm """
@@ -22,6 +21,35 @@ extern global def unsafeFresh[T](size: Int): Array[T] =
     ret %Pos %z
   """
 
+/**
+ * Creates a new Array of size `size` filled with the value `init`
+ */
+extern global def array[T](size: Int, init: T): Array[T] =
+  ml "Array.array (${size}, ${init})"
+  default {
+    val arr = allocate[T](size);
+    each(0, size) { i =>
+      unsafeSet(arr, i, init)
+    };
+    arr
+  }
+
+/**
+ * Converts a List `list` to an Array
+ */
+def fromList[T](list: List[T]): Array[T] = {
+  val listSize = list.size();
+  val arr = allocate(listSize);
+
+  foreachIndex(list) { (i, head) =>
+    arr.unsafeSet(i, head)
+  }
+  return arr;
+}
+
+/**
+ * Gets the length of the array in constant time.
+ */
 extern pure def size[T](arr: Array[T]): Int =
   js "${arr}.length"
   chez "(vector-length ${arr})"
@@ -32,7 +60,10 @@ extern pure def size[T](arr: Array[T]): Int =
   """
 
 /**
- * Unchecked Precondition: Index in bounds
+ * Gets the element of the `arr` at given `index` in constant time.
+ * Unchecked Precondition: `index` is in bounds (0 ≤ index < arr.size)
+ *
+ * Prefer using `get` instead.
  */
 extern global def unsafeGet[T](arr: Array[T], index: Int): T =
   js "${arr}[${index}]"
@@ -50,8 +81,11 @@ function array$set(arr, index, value) {
 }
 """
 
-/**
- * Unchecked Precondition: Index in bounds
+ /**
+ * Sets the element of the `arr` at given `index` to `value` in constant time.
+ * Unchecked Precondition: `index` is in bounds (0 ≤ index < arr.size)
+ *
+ * Prefer using `set` instead.
  */
 extern global def unsafeSet[T](arr: Array[T], index: Int, value: T): Unit =
   js "array$set(${arr}, ${index}, ${value})"
@@ -68,7 +102,7 @@ extern global def unsafeSet[T](arr: Array[T], index: Int, value: T): Unit =
 def copy[T](arr: Array[T]): Array[T] = {
   with on[OutOfBounds].default { <> }; // should not happen
   val len = arr.size;
-  val newArray = unsafeFresh[T](len);
+  val newArray = allocate[T](len);
   copy[T](arr, 0, newArray, 0, len);
   newArray
 }
@@ -94,22 +128,17 @@ def copy[T](from: Array[T], start: Int, to: Array[T], offset: Int, length: Int):
 // Derived operations:
 
 /**
- * Creates a new Array of size `size` filled with the value `init`
+ * Gets the element of the `arr` at given `index` in constant time,
+ * throwing an `Exception[OutOfBounds]` unless `0 ≤ index < arr.size`.
  */
-extern global def fresh[T](size: Int, init: T): Array[T] =
- ml "Array.array (${size}, ${init})"
- default {
-    val arr = unsafeFresh[T](size);
-    each(0, size) { i =>
-      unsafeSet(arr, i, init)
-    };
-    arr
-  }
-
 def get[T](arr: Array[T], index: Int): T / Exception[OutOfBounds] =
   if (index >= 0 && index < arr.size) arr.unsafeGet(index)
   else do raise(OutOfBounds(), "Array index out of bounds: " ++ show(index))
 
+/**
+ * Sets the element of the `arr` at given `index` to `value` in constant time,
+ * throwing an `Exception[OutOfBounds]` unless `0 ≤ index < arr.size`.
+ */
 def set[T](arr: Array[T], index: Int, value: T): Unit / Exception[OutOfBounds] =
   if (index >= 0 && index < arr.size) unsafeSet(arr, index, value)
   else do raise(OutOfBounds(), "Array index out of bounds: " ++ show(index))
@@ -119,7 +148,7 @@ def set[T](arr: Array[T], index: Int, value: T): Unit / Exception[OutOfBounds] =
  * and returns a value that will be on that position in the resulting array
  */
 def build[T](size: Int) { index: Int => T }: Array[T] = {
-  val arr = unsafeFresh[T](size);
+  val arr = allocate[T](size);
   each(0, size) { i =>
     unsafeSet(arr, i, index(i))
   };
@@ -128,24 +157,11 @@ def build[T](size: Int) { index: Int => T }: Array[T] = {
 
 // Utility functions:
 
-/**
- * Converts a List `list` to an Array
- */
-def fromList[T](list: List[T]): Array[T] = {
-  val listSize = list.size();
-  val arr = unsafeFresh(listSize);
-
-  foreachIndex(list) { (i, head) =>
-    unsafeSet(arr, i, head)
-  }
-  return arr;
-}
-
 def toList[T](arr: Array[T]): List[T] = {
   var i = arr.size - 1;
   var l = Nil[T]()
   while (i >= 0) {
-    l = Cons(unsafeGet(arr, i), l)
+    l = Cons(arr.unsafeGet(i), l)
     i = i - 1
   }
   l

--- a/libraries/common/bytes.effekt
+++ b/libraries/common/bytes.effekt
@@ -1,14 +1,16 @@
 module bytes
 
 /**
- * A memory managed, mutable, fixed-length buffer of bytes
+ * A memory managed, mutable, fixed-length buffer of bytes.
  */
 extern type Bytes
   // = llvm "%Pos"
   // = js "Uint8Array"
 
-
-extern io def empty(capacity: Int): Bytes =
+/**
+ * Allocates new bytes with the given `capacity`, keeping its values _undefined_.
+ */
+extern io def allocate(capacity: Int): Bytes =
   js "(new Uint8Array(${capacity}))"
   llvm """
     %buf = call %Pos @c_buffer_construct_uninitialized(i64 %capacity)
@@ -17,7 +19,7 @@ extern io def empty(capacity: Int): Bytes =
 
 def copy(b: Bytes): Bytes = {
   val len = b.size
-  val clone = empty(len)
+  val clone = allocate(len)
   copy(b, clone, 0, 0, len)
   clone
 }

--- a/libraries/common/bytes.effekt
+++ b/libraries/common/bytes.effekt
@@ -8,9 +8,9 @@ extern type Bytes
   // = js "Uint8Array"
 
 /**
- * Allocates new bytes with the given `capacity`, keeping its values _undefined_.
+ * Allocates new bytes with the given `capacity`, setting its values to `0`.
  */
-extern io def allocate(capacity: Int): Bytes =
+extern io def bytes(capacity: Int): Bytes =
   js "(new Uint8Array(${capacity}))"
   llvm """
     %buf = call %Pos @c_buffer_construct_uninitialized(i64 %capacity)
@@ -19,7 +19,7 @@ extern io def allocate(capacity: Int): Bytes =
 
 def copy(b: Bytes): Bytes = {
   val len = b.size
-  val clone = allocate(len)
+  val clone = bytes(len)
   copy(b, clone, 0, 0, len)
   clone
 }

--- a/libraries/common/io/files.effekt
+++ b/libraries/common/io/files.effekt
@@ -95,7 +95,7 @@ def readFile(path: String): String / { AsyncIO, Exception[IOError] } = {
 
   val readSize = 1048576 // 1MB
   var size = readSize
-  var buffer = bytes::empty(size)
+  var buffer = bytes::allocate(size)
   var offset = 0;
 
   def go(): String = {
@@ -109,7 +109,7 @@ def readFile(path: String): String / { AsyncIO, Exception[IOError] } = {
         // we are at maximum capacity
         if (n == readSize && (offset + readSize) > size) {
           val newSize   = size * 2
-          val newBuffer = bytes::empty(newSize)
+          val newBuffer = bytes::allocate(newSize)
           copy(buffer, newBuffer, 0, 0, size)
           buffer = newBuffer
           size = newSize

--- a/libraries/common/io/files.effekt
+++ b/libraries/common/io/files.effekt
@@ -95,7 +95,7 @@ def readFile(path: String): String / { AsyncIO, Exception[IOError] } = {
 
   val readSize = 1048576 // 1MB
   var size = readSize
-  var buffer = bytes::allocate(size)
+  var buffer = bytes(size)
   var offset = 0;
 
   def go(): String = {
@@ -109,7 +109,7 @@ def readFile(path: String): String / { AsyncIO, Exception[IOError] } = {
         // we are at maximum capacity
         if (n == readSize && (offset + readSize) > size) {
           val newSize   = size * 2
-          val newBuffer = bytes::allocate(newSize)
+          val newBuffer = bytes(newSize)
           copy(buffer, newBuffer, 0, 0, size)
           buffer = newBuffer
           size = newSize

--- a/libraries/common/queue.effekt
+++ b/libraries/common/queue.effekt
@@ -27,7 +27,7 @@ def emptyQueue[T](): Queue[T] at {global} =
 
 def emptyQueue[T](initialCapacity: Int): Queue[T] at {global} = {
 
-  var contents in global = fresh[Option[T]](initialCapacity, None())
+  var contents in global = array[Option[T]](initialCapacity, None())
   var head in global = 0
   var tail in global = 0
   var size in global = 0
@@ -51,7 +51,7 @@ def emptyQueue[T](initialCapacity: Int): Queue[T] at {global} = {
       val oldSize = capacity
       val newSize = capacity * 2
       val oldContents = contents
-      val newContents = unsafeFresh[Option[T]](newSize)
+      val newContents = allocate[Option[T]](newSize)
 
       if (head < tail) {
         // The queue does not wrap around; direct copy is possible.

--- a/libraries/common/queue.effekt
+++ b/libraries/common/queue.effekt
@@ -51,7 +51,7 @@ def emptyQueue[T](initialCapacity: Int): Queue[T] at {global} = {
       val oldSize = capacity
       val newSize = capacity * 2
       val oldContents = contents
-      val newContents = allocate[Option[T]](newSize)
+      val newContents = array::allocate[Option[T]](newSize)
 
       if (head < tail) {
         // The queue does not wrap around; direct copy is possible.

--- a/libraries/common/ref.effekt
+++ b/libraries/common/ref.effekt
@@ -12,7 +12,11 @@ function set$impl(ref, value) {
  */
 extern type Ref[T]
 
-extern global def unsafeFresh[T](): Ref[T] =
+/**
+ * Allocates a new reference of size `size`, keeping its value _undefined_.
+ * Prefer using `ref` constructor instead to ensure that the value is defined.
+ */
+extern global def allocate[T](): Ref[T] =
   js "{ value: undefined }"
   chez "(box #f)"
   llvm """
@@ -20,7 +24,10 @@ extern global def unsafeFresh[T](): Ref[T] =
     ret %Pos %z
   """
 
-extern global def fresh[T](init: T): Ref[T] =
+/**
+ * Creates a new reference with the initial value `init`.
+ */
+extern global def ref[T](init: T): Ref[T] =
   js "{ value: ${init} }"
   chez "(box ${init})"
   ml "ref ${init}"
@@ -29,6 +36,9 @@ extern global def fresh[T](init: T): Ref[T] =
     ret %Pos %z
   """
 
+/**
+ * Gets the referenced element of the `ref` in constant time.
+ */
 extern global def get[T](ref: Ref[T]): T =
   js "${ref}.value"
   chez "(unbox ${ref})"
@@ -38,6 +48,9 @@ extern global def get[T](ref: Ref[T]): T =
     ret %Pos %z
   """
 
+/**
+ * Sets the referenced element of the `ref` to `value` in constant time.
+ */
 extern global def set[T](ref: Ref[T], value: T): Unit =
   js "set$impl(${ref}, ${value})"
   chez "(set-box! ${ref} ${value})"


### PR DESCRIPTION
## Motivation

Resolves #484 

## Description

In `array`, `ref`, `bytes`:
1. Rename `unsafeFresh` to `allocate` and clearly document that it is unsafe
2. Rename `fresh` (formerly `fill`) to `$collection_name` or `$Collection_name`, for example `array` or `Array`
3. Add documentation comments where needed :)

I also restructured `array` a little bit so that the "constructors" are at the top (intended for easier API discovery).

### Questions

1. Are we happy with the naming scheme of `$collection_name` for the "fill"/"fresh" constructor?
    - if so, are there any other data structures we want to support here? (what about `bytes`, for example?)
2. Should unsafe functions be in their own sub-namespace?
2. Is there anything else we want to add in this PR?