### PR TITLE
Standardize command-line argument passing across backends

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -40,16 +40,17 @@ trait Runner[Executable] {
   def prelude: List[String] = List("effekt")
 
   /**
-   * Creates a OS-specific script file that will execute the command when executed.
+   * Creates a OS-specific script file that will execute the command when executed,
+   * forwarding command line arguments.
    * @return the actual name of the generated script (might be `!= name`)
    */
   def createScript(name: String, command: String*): String = os match {
     case OS.POSIX =>
-      IO.createFile(name, s"#!/bin/sh\n${command.mkString(" ")}", true)
+      IO.createFile(name, s"#!/bin/sh\n${command.mkString(" ")} \"$$@\"", true)
       name
     case OS.Windows =>
       val batName = name + ".bat"
-      IO.createFile(batName, "@echo off\r\n" + command.mkString(" "))
+      IO.createFile(batName, "@echo off\r\n" + command.mkString(" ") + " %*")
       batName
   }
 

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -176,7 +176,7 @@ trait ChezRunner extends Runner[String] {
     val out = C.config.outputPath().getAbsolutePath
     val schemeFilePath = (out / path).canonicalPath.escape
     val exeScriptPath = schemeFilePath.stripSuffix(s".$extension")
-    createScript(exeScriptPath, "scheme", "--script", schemeFilePath, "\"$@\"")
+    createScript(exeScriptPath, "scheme", "--script", schemeFilePath)
 }
 
 object ChezMonadicRunner extends ChezRunner {

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -176,7 +176,7 @@ trait ChezRunner extends Runner[String] {
     val out = C.config.outputPath().getAbsolutePath
     val schemeFilePath = (out / path).canonicalPath.escape
     val exeScriptPath = schemeFilePath.stripSuffix(s".$extension")
-    createScript(exeScriptPath, "scheme", "--script", schemeFilePath)
+    createScript(exeScriptPath, "scheme", "--script", schemeFilePath, "\"$@\"")
 }
 
 object ChezMonadicRunner extends ChezRunner {

--- a/libraries/common/args.effekt
+++ b/libraries/common/args.effekt
@@ -9,7 +9,7 @@ extern io def commandLineArgs(): List[String] =
 namespace js {
   extern type Args // = Array[String]
 
-  extern io def nativeArgs(): Args = js "process.argv.slice(2)"
+  extern io def nativeArgs(): Args = js "process.argv.slice(1)"
 
   extern io def argCount(args: Args): Int = js "${args}.length"
 


### PR DESCRIPTION
## Motivation

Resolves #390 
Resolves #318 

As far as I know, with #487 merged, there are two nice ways of running an Effekt program with arguments (please correct me if I'm wrong):
1. Run the compiler directly on a file: `effekt test.effekt -- hello world 42`
2. First build, then run the executable: `effekt test.effekt && ./out/test hello world 42`

## Testing

I tested this locally with:
```sh
# 1. Run the compiler directly on a file
for BACKEND in js chez-callcc chez-monadic chez-lift llvm ml; do echo -n "$BACKEND: " && effekt --backend $BACKEND test.effekt -- hello world 42; done

# 2. First build, then run the executable
for BACKEND in js chez-callcc chez-monadic chez-lift llvm ml; do effekt --backend $BACKEND --build test.effekt && echo -n "$BACKEND: " && ./out/test hello world 42; done
```
on a small file `test.effekt`:
```scala
module test

import args

def main() = {
  println(commandLineArgs())
}
```

Both of those print the same output:
```txt
js: Cons(hello, Cons(world, Cons(42, Nil())))
chez-callcc: Cons(hello, Cons(world, Cons(42, Nil())))
chez-monadic: Cons(hello, Cons(world, Cons(42, Nil())))
chez-lift: Cons(hello, Cons(world, Cons(42, Nil())))
llvm: Cons(hello, Cons(world, Cons(42, Nil())))
ml: Cons(hello, Cons(world, Cons(42, Nil())))
```

## Questions

1. ~~How do we do this on Windows?~~ _Resolved, but untested, see below!_
2. Are there any other ways of running an Effekt program that I can try out?
3. How does this interact with `effekt.sh`?
4. How can we test this? Should we even test this?