### PR TITLE
Implement equality/inequality for `Double`

### DIFF
--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -485,6 +485,16 @@ extern pure def infixGte(x: Int, y: Int): Bool =
     ret %Pos %adt_boolean
   """
 
+extern pure def infixEq(x: Double, y: Double): Bool =
+  js "${x} === ${y}"
+  chez "(= ${x} ${y})"
+  ml "(${x}: real) = ${y}"
+
+extern pure def infixNeq(x: Double, y: Double): Bool =
+  js "${x} !== ${y}"
+  chez "(not (= ${x} ${y}))"
+  ml "(${x}: real) <> ${y}"
+
 extern pure def infixLt(x: Double, y: Double): Bool =
   js "(${x} < ${y})"
   chez "(< ${x} ${y})"


### PR DESCRIPTION
While comparing floating point numbers for equality can lead to surprising results, it is a standardized in ANSI/IEEE754-2019 (https://754r.ucbtest.org/background/) and available in (proabably) all mainstream languages.
It, however, is not in the Effekt stdlib yet.

This adds `infixEq` and `infixNeq` on `Double`.

This, ans many operations on floating point numbers, is still unimplemented for LLVM.