### PR TITLE
Fix LLVM escape sequences

### DIFF
--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -431,9 +431,10 @@ object Transformer {
       }
 
     case lifted.Literal(javastring: String, _) =>
+      val escapedJavastring = StringContext.processEscapes(javastring)
       val literal_binding = Variable(freshName("utf8_string_literal"), Type.String());
       Binding { k =>
-        LiteralUTF8String(literal_binding, javastring.getBytes("utf-8"), k(literal_binding))
+        LiteralUTF8String(literal_binding, escapedJavastring.getBytes("utf-8"), k(literal_binding))
       }
 
     case lifted.PureApp(lifted.BlockVar(blockName: symbols.ExternFunction, tpe: lifted.BlockType.Function), targs, args) =>

--- a/examples/pos/escape_sequences.check
+++ b/examples/pos/escape_sequences.check
@@ -1,0 +1,2 @@
+
+abcdef	ghi

--- a/examples/pos/escape_sequences.effekt
+++ b/examples/pos/escape_sequences.effekt
@@ -1,0 +1,1 @@
+def main() = println("\nabc\bdef\tghi")


### PR DESCRIPTION
This is related to my [previous fixes](https://github.com/effekt-lang/effekt/pull/410/files#diff-ae47aecca5dc9ae5e4f930f8f26f09f1337346f7ee3188147c3290e0d0168777R533) for escape sequences in strings.
Apparently it's quite hard to get this 100% right since every backend handles strings differently.

Since Javascript escapes the sequences by itself and LLVM does not, I now explicitly de-escape the string using `StringContext` in a much later stage (machine transformer).

Let me know if you come up with a better solution :)

