### PR TITLE
Use consistent naming scheme for output files

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -318,5 +318,5 @@ trait Compiler[Executable] {
    * Path relative to the output folder
    */
   def path(m: symbols.Module)(using C: Context): String =
-    (m.path.replace('/', '_').replace('-', '_')) + extension
+    (m.path.split('/').last.replace('-', '_')) + extension
 }


### PR DESCRIPTION
This PR closes issue #471 by only using the file basename without extension for its output path.