### PR TITLE
Improve readability of generated LLVM code

### DIFF
--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -193,7 +193,7 @@ object Transformer {
         if (targs.exists(requiresBoxing)) { ErrorReporter.abort(s"Types ${targs} are used as type parameters but would require boxing.") }
 
         val tpe = transform(stateType)
-        val variable = Variable(freshName("x"), tpe)
+        val variable = Variable(freshName("app"), tpe)
         val reference = Variable(transform(x), Type.Reference(tpe))
         transform(ev).run { evValue =>
           Load(variable, reference, evValue, Return(List(variable)))
@@ -203,7 +203,7 @@ object Transformer {
         if (targs.exists(requiresBoxing)) { ErrorReporter.abort(s"Types ${targs} are used as type parameters but would require boxing.") }
 
         val tpe = transform(stateType)
-        val variable = Variable(freshName("x"), Positive());
+        val variable = Variable(freshName("app"), Positive());
         val reference = Variable(transform(x), Type.Reference(tpe))
         transform(arg).run { value =>
           transform(ev).run { evValue =>
@@ -257,7 +257,7 @@ object Transformer {
 
         noteParameters(ids)
 
-        val variable = Variable(freshName("a"), transform(body.tpe))
+        val variable = Variable(freshName("try"), transform(body.tpe))
         val returnClause = Clause(List(variable), Return(List(variable)))
         val delimiter = Variable(freshName("returnClause"), Type.Stack())
 
@@ -278,7 +278,7 @@ object Transformer {
         }
 
       case lifted.Region(lifted.BlockLit(tparams, List(ev, id), body)) =>
-        val variable = Variable(freshName("a"), transform(body.tpe))
+        val variable = Variable(freshName("region"), transform(body.tpe))
         val returnClause = Clause(List(variable), Return(List(variable)))
         val delimiter = Variable(freshName("returnClause"), Type.Stack())
 
@@ -324,7 +324,7 @@ object Transformer {
       case lifted.Get(id, ev, tpe) =>
         val stateType = transform(tpe)
         val reference = Variable(transform(id), Type.Reference(stateType))
-        val variable = Variable(freshName("x"), stateType)
+        val variable = Variable(freshName("get"), stateType)
 
         transform(ev).run { evidence =>
           Load(variable, reference, evidence,
@@ -334,7 +334,7 @@ object Transformer {
       case lifted.Put(id, ev, arg) =>
         val stateType = transform(arg.tpe)
         val reference = Variable(transform(id), Type.Reference(stateType))
-        val variable = Variable(freshName("x"), Positive())
+        val variable = Variable(freshName("put"), Positive())
 
         transform(arg).run { value =>
           transform(ev).run { evidence =>
@@ -358,12 +358,12 @@ object Transformer {
 
   def transform(scopes: List[lifted.Lift])(using ErrorReporter): Binding[Variable] = scopes match {
     case Nil =>
-      val name = Variable(freshName("evidence_zero"), builtins.Evidence)
+      val name = Variable(freshName("evidenceZero"), builtins.Evidence)
       Binding { k => LiteralEvidence(name, builtins.Here, k(name)) }
     case lift :: Nil =>
       pure(transform(lift))
     case lift :: rest =>
-      val name = Variable(freshName("evidence_composed"), builtins.Evidence)
+      val name = Variable(freshName("evidenceComposed"), builtins.Evidence)
       Binding { k =>
         transform(rest).run { value =>
           ComposeEvidence(name, transform(lift), value, k(name))
@@ -397,13 +397,13 @@ object Transformer {
     case lifted.BlockLit(tparams, params, body) =>
       noteParameters(params)
       val parameters = params.map(transform);
-      val variable = Variable(freshName("g"), Negative())
+      val variable = Variable(freshName("blockLit"), Negative())
       Binding { k =>
         New(variable, List(Clause(parameters, transform(body))), k(variable))
       }
 
     case lifted.New(impl) =>
-      val variable = Variable(freshName("g"), Negative())
+      val variable = Variable(freshName("new"), Negative())
       Binding { k =>
         New(variable, transform(impl), k(variable))
       }
@@ -417,38 +417,38 @@ object Transformer {
       pure(Variable(transform(id), transform(tpe)))
 
     case lifted.Literal((), _) =>
-      val variable = Variable(freshName("x"), Positive());
+      val variable = Variable(freshName("literal"), Positive());
       Binding { k =>
         Construct(variable, builtins.Unit, List(), k(variable))
       }
 
     case lifted.Literal(value: Long, _) =>
-      val variable = Variable(freshName("x"), Type.Int());
+      val variable = Variable(freshName("longLiteral"), Type.Int());
       Binding { k =>
         LiteralInt(variable, value, k(variable))
       }
 
     // for characters
     case lifted.Literal(value: Int, _) =>
-      val variable = Variable(freshName("x"), Type.Int());
+      val variable = Variable(freshName("intLiteral"), Type.Int());
       Binding { k =>
         LiteralInt(variable, value, k(variable))
       }
 
     case lifted.Literal(value: Boolean, _) =>
-      val variable = Variable(freshName("x"), Positive())
+      val variable = Variable(freshName("booleanLiteral"), Positive())
       Binding { k =>
         Construct(variable, if (value) builtins.True else builtins.False, List(), k(variable))
       }
 
     case lifted.Literal(v: Double, _) =>
-      val literal_binding = Variable(freshName("x"), Type.Double());
+      val literal_binding = Variable(freshName("doubleLiteral"), Type.Double());
       Binding { k =>
         LiteralDouble(literal_binding, v, k(literal_binding))
       }
 
     case lifted.Literal(javastring: String, _) =>
-      val literal_binding = Variable(freshName("utf8_string_literal"), Type.String());
+      val literal_binding = Variable(freshName("utf8StringLiteral"), Type.String());
       Binding { k =>
         LiteralUTF8String(literal_binding, javastring.getBytes("utf-8"), k(literal_binding))
       }
@@ -456,7 +456,7 @@ object Transformer {
     case lifted.PureApp(lifted.BlockVar(blockName: symbols.ExternFunction, tpe: lifted.BlockType.Function), targs, args) =>
       if (targs.exists(requiresBoxing)) { ErrorReporter.abort(s"Types ${targs} are used as type parameters but would require boxing.") }
 
-      val variable = Variable(freshName("x"), transform(tpe.result))
+      val variable = Variable(freshName("pureApp"), transform(tpe.result))
       transform(args).flatMap { values =>
         Binding { k =>
           ForeignCall(variable, transform(blockName), values, k(variable))
@@ -464,7 +464,7 @@ object Transformer {
       }
 
     case lifted.Make(data, constructor, args) =>
-      val variable = Variable(freshName("x"), transform(data));
+      val variable = Variable(freshName("make"), transform(data));
       val tag = DeclarationContext.getConstructorTag(constructor)
 
       transform(args).flatMap { values =>
@@ -477,7 +477,7 @@ object Transformer {
       // TODO all of this can go away, if we desugar records in the translation to core!
       val fields = DeclarationContext.getField(field).constructor.fields
       val fieldIndex = fields.indexWhere(_.id == field)
-      val variables = fields.map { f => Variable(freshName("n"), transform(tpe)) }
+      val variables = fields.map { f => Variable(freshName("select"), transform(tpe)) }
       transform(target).flatMap { value =>
         Binding { k =>
           Switch(value, List(0 -> Clause(variables, k(variables(fieldIndex)))), None)
@@ -486,7 +486,7 @@ object Transformer {
 
     case lifted.Run(stmt) =>
       // NOTE: `stmt` is guaranteed to be of type `tpe`.
-      val variable = Variable(freshName("x"), transform(stmt.tpe))
+      val variable = Variable(freshName("run"), transform(stmt.tpe))
       Binding { k =>
         PushFrame(Clause(List(variable), k(variable)), transform(stmt))
       }

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -684,7 +684,7 @@ namespace internal {
     extern pure def boxInt(n: Int): BoxedInt =
       llvm """
         %boxed1 = insertvalue %Pos zeroinitializer, i64 %n, 0
-        %boxed2 = insertvalue %Pos %boxed1, %Obj null, 1
+        %boxed2 = insertvalue %Pos %boxed1, %Object null, 1
         ret %Pos %boxed2
       """
     extern pure def unboxInt(b: BoxedInt): Int =
@@ -698,7 +698,7 @@ namespace internal {
       llvm """
         %extended = sext i8 %n to i64
         %boxed1 = insertvalue %Pos zeroinitializer, i64 %extended, 0
-        %boxed2 = insertvalue %Pos %boxed1, %Obj null, 1
+        %boxed2 = insertvalue %Pos %boxed1, %Object null, 1
         ret %Pos %boxed2
       """
     extern pure def unboxByte(b: BoxedByte): Byte =
@@ -712,7 +712,7 @@ namespace internal {
     extern pure def boxChar(c: Char): BoxedChar =
       llvm """
         %boxed1 = insertvalue %Pos zeroinitializer, i64 %c, 0
-        %boxed2 = insertvalue %Pos %boxed1, %Obj null, 1
+        %boxed2 = insertvalue %Pos %boxed1, %Object null, 1
         ret %Pos %boxed2
       """
     extern pure def unboxChar(b: BoxedChar): Char =
@@ -730,7 +730,7 @@ namespace internal {
       llvm """
         %n = bitcast double %d to i64
         %boxed1 = insertvalue %Pos zeroinitializer, i64 %n, 0
-        %boxed2 = insertvalue %Pos %boxed1, %Obj null, 1
+        %boxed2 = insertvalue %Pos %boxed1, %Object null, 1
         ret %Pos %boxed2
       """
     extern pure def unboxDouble(b: BoxedDouble): Double =

--- a/libraries/llvm/ref.c
+++ b/libraries/llvm/ref.c
@@ -4,9 +4,9 @@
 /** We represent references like positive types.
  *  The tag is 0 and the obj points to memory with the following layout:
  *
- *   +--[ Header ]--+------------+
- *   | Rc  | Eraser | Field      |
- *   +--------------+------------+
+ *   +--[ Header ]--------------+------------+
+ *   | ReferenceCount  | Eraser | Field      |
+ *   +--------------------------+------------+
  */
 
 void c_ref_erase_field(void *envPtr) {

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -2,14 +2,14 @@
 
 attributes #0 = { "ccc" }
 
-%Evi = type i64
+%Evidence = type i64
 
 ; Basic types
 
-%Env = type ptr
+%Environment = type ptr
 
 ; Reference counts
-%Rc = type i64
+%ReferenceCount = type i64
 
 ; Code to share (bump rc) an environment
 %Sharer = type ptr
@@ -18,21 +18,21 @@ attributes #0 = { "ccc" }
 %Eraser = type ptr
 
 ; Every heap object starts with a header
-%Header = type {%Rc, %Eraser}
+%Header = type {%ReferenceCount, %Eraser}
 
 ; A heap object is a pointer to a header followed by payload.
 ;
-;   +--[ Header ]--+-------------+
-;   | Rc  | Eraser | Payload ... |
-;   +--------------+-------------+
-%Obj = type ptr
+;   +--[ Header ]--------------+-------------+
+;   | ReferenceCount  | Eraser | Payload ... |
+;   +-----------------+--------+-------------+
+%Object = type ptr
 
 
 ; A Frame has the following layout
 ;
-;   +-------[ FrameHeader ]-----+--------------+
-;   | RetAdr  | Sharer | Eraser | Payload ...  |
-;   +---------------------------+--------------+
+;   +-------[ FrameHeader ]------------+--------------+
+;   | ReturnAddress  | Sharer | Eraser | Payload ...  |
+;   +----------------------------------+--------------+
 
 ; A stack pointer points to the top-most frame followed by all other frames.
 ;
@@ -40,7 +40,7 @@ attributes #0 = { "ccc" }
 ;
 ;     +--------------------+   <- Limit
 ;     :                    :
-;     :                    :   <- Sp
+;     :                    :   <- StackPointer
 ;     +--------------------+
 ;     | FrameHeader        |
 ;     |    z               |
@@ -51,14 +51,14 @@ attributes #0 = { "ccc" }
 ;     +--------------------+
 ;     :        ...         :
 ;     +--------------------+ <- Base
-%Sp = type ptr
-%Base = type %Sp
-%Limit = type %Sp
-%RetAdr = type ptr
-%FrameHeader = type { %RetAdr, %Sharer, %Eraser }
+%StackPointer = type ptr
+%Base = type %StackPointer
+%Limit = type %StackPointer
+%ReturnAddress = type ptr
+%FrameHeader = type { %ReturnAddress, %Sharer, %Eraser }
 
 ; Pointers for a heap allocated stack
-%Mem = type { %Sp, %Base, %Limit }
+%Memory = type { %StackPointer, %Base, %Limit }
 
 ; The garbage collector differentiates three groups of types:
 ; - Values (Integer, Double)
@@ -66,24 +66,24 @@ attributes #0 = { "ccc" }
 ; - Strings
 ; For each group we have an arena where mutable state is allocated.
 ;
-%Region = type [ 3 x %Mem ]
+%Region = type [ 3 x %Memory ]
 
-; The "meta" stack (a stack of stacks) -- a pointer to a %StkVal
-%Stk = type ptr
+; The "meta" stack (a stack of stacks) -- a pointer to a %StackValue
+%Stack = type ptr
 
 ; This is used for two purposes:
 ;   - a refied first-class list of stacks (cyclic linked-list)
 ;   - as part of an intrusive linked-list of stacks (meta stack)
-%StkVal = type { %Rc, %Mem, %Region, %Stk }
+%StackValue = type { %ReferenceCount, %Memory, %Region, %Stack }
 
 ; Positive data types consist of a (type-local) tag and a heap object
-%Pos = type {i64, %Obj}
+%Pos = type {i64, %Object}
 
 ; Negative types (codata) consist of a vtable and a heap object
-%Neg = type {ptr, %Obj}
+%Neg = type {ptr, %Object}
 
 ; Offset within the arena
-%Ref = type i64
+%Reference = type i64
 
 ; Builtin Types
 
@@ -100,35 +100,35 @@ attributes #0 = { "ccc" }
 @base = private global %Base null
 @limit = private global %Limit null
 @region = private global %Region zeroinitializer
-@rest = private global %Stk undef
+@rest = private global %Stack undef
 
 
-define %StkVal @getStk(%Sp %sp) alwaysinline {
+define %StackValue @getStack(%StackPointer %stackPointer) alwaysinline {
     %base = load %Base, ptr @base
     %limit = load %Limit, ptr @limit
     %region = load %Region, ptr @region
-    %rest = load %Stk, ptr @rest
+    %rest = load %Stack, ptr @rest
 
-    %stk.0 = insertvalue %StkVal undef, %Rc 0, 0
-    %stk.1 = insertvalue %StkVal %stk.0, %Sp %sp, 1, 0
-    %stk.2 = insertvalue %StkVal %stk.1, %Base %base, 1, 1
-    %stk.3 = insertvalue %StkVal %stk.2, %Limit %limit, 1, 2
-    %stk.4 = insertvalue %StkVal %stk.3, %Region %region, 2
-    %stk.5 = insertvalue %StkVal %stk.4, %Stk %rest, 3
+    %stack.0 = insertvalue %StackValue undef, %ReferenceCount 0, 0
+    %stack.1 = insertvalue %StackValue %stack.0, %StackPointer %stackPointer, 1, 0
+    %stack.2 = insertvalue %StackValue %stack.1, %Base %base, 1, 1
+    %stack.3 = insertvalue %StackValue %stack.2, %Limit %limit, 1, 2
+    %stack.4 = insertvalue %StackValue %stack.3, %Region %region, 2
+    %stack.5 = insertvalue %StackValue %stack.4, %Stack %rest, 3
 
-    ret %StkVal %stk.5
+    ret %StackValue %stack.5
 }
 
-define void @setStk(%StkVal %stk) alwaysinline {
-    %base = extractvalue %StkVal %stk, 1, 1
-    %limit = extractvalue %StkVal %stk, 1, 2
-    %region = extractvalue %StkVal %stk, 2
-    %rest = extractvalue %StkVal %stk, 3
+define void @setStack(%StackValue %stack) alwaysinline {
+    %base = extractvalue %StackValue %stack, 1, 1
+    %limit = extractvalue %StackValue %stack, 1, 2
+    %region = extractvalue %StackValue %stack, 2
+    %rest = extractvalue %StackValue %stack, 3
 
     store %Base %base, ptr @base
     store %Limit %limit, ptr @limit
     store %Region %region, ptr @region
-    store %Stk %rest, ptr @rest
+    store %Stack %rest, ptr @rest
     ret void
 }
 
@@ -145,32 +145,32 @@ declare void @exit(i64)
 
 ; Garbage collection
 
-define %Obj @newObject(%Eraser %eraser, i64 %envsize) alwaysinline {
+define %Object @newObject(%Eraser %eraser, i64 %environmentSize) alwaysinline {
     ; This magical 16 is the size of the object header
-    %size = add i64 %envsize, 16
-    %obj = call ptr @malloc(i64 %size)
-    %objrc = getelementptr %Header, ptr %obj, i64 0, i32 0
-    %objeraser = getelementptr %Header, ptr %obj, i64 0, i32 1
-    store %Rc 0, ptr %objrc
-    store %Eraser %eraser, ptr %objeraser
-    ret %Obj %obj
+    %size = add i64 %environmentSize, 16
+    %object = call ptr @malloc(i64 %size)
+    %objectReferenceCount = getelementptr %Header, ptr %object, i64 0, i32 0
+    %objectEraser = getelementptr %Header, ptr %object, i64 0, i32 1
+    store %ReferenceCount 0, ptr %objectReferenceCount
+    store %Eraser %eraser, ptr %objectEraser
+    ret %Object %object
 }
 
-define %Env @objectEnvironment(%Obj %obj) alwaysinline {
+define %Environment @objectEnvironment(%Object %object) alwaysinline {
     ; Environment is stored right after header
-    %env = getelementptr %Header, ptr %obj, i64 1
-    ret %Env %env
+    %environment = getelementptr %Header, ptr %object, i64 1
+    ret %Environment %environment
 }
 
-define void @shareObject(%Obj %obj) alwaysinline {
-    %isnull = icmp eq %Obj %obj, null
-    br i1 %isnull, label %done, label %next
+define void @shareObject(%Object %object) alwaysinline {
+    %isNull = icmp eq %Object %object, null
+    br i1 %isNull, label %done, label %next
 
     next:
-    %objrc = getelementptr %Header, ptr %obj, i64 0, i32 0
-    %rc = load %Rc, ptr %objrc
-    %rc.1 = add %Rc %rc, 1
-    store %Rc %rc.1, ptr %objrc
+    %objectReferenceCount = getelementptr %Header, ptr %object, i64 0, i32 0
+    %referenceCount = load %ReferenceCount, ptr %objectReferenceCount
+    %referenceCount.1 = add %ReferenceCount %referenceCount, 1
+    store %ReferenceCount %referenceCount.1, ptr %objectReferenceCount
     br label %done
 
     done:
@@ -178,37 +178,37 @@ define void @shareObject(%Obj %obj) alwaysinline {
 }
 
 define void @sharePositive(%Pos %val) alwaysinline {
-    %obj = extractvalue %Pos %val, 1
-    tail call void @shareObject(%Obj %obj)
+    %object = extractvalue %Pos %val, 1
+    tail call void @shareObject(%Object %object)
     ret void
 }
 
 define void @shareNegative(%Neg %val) alwaysinline {
-    %obj = extractvalue %Neg %val, 1
-    tail call void @shareObject(%Obj %obj)
+    %object = extractvalue %Neg %val, 1
+    tail call void @shareObject(%Object %object)
     ret void
 }
 
-define void @eraseObject(%Obj %obj) alwaysinline {
-    %isnull = icmp eq %Obj %obj, null
-    br i1 %isnull, label %done, label %next
+define void @eraseObject(%Object %object) alwaysinline {
+    %isNull = icmp eq %Object %object, null
+    br i1 %isNull, label %done, label %next
 
     next:
-    %objrc = getelementptr %Header, ptr %obj, i64 0, i32 0
-    %rc = load %Rc, ptr %objrc
-    switch %Rc %rc, label %decr [%Rc 0, label %free]
+    %objectReferenceCount = getelementptr %Header, ptr %object, i64 0, i32 0
+    %referenceCount = load %ReferenceCount, ptr %objectReferenceCount
+    switch %ReferenceCount %referenceCount, label %decr [%ReferenceCount 0, label %free]
 
     decr:
-    %rc.1 = sub %Rc %rc, 1
-    store %Rc %rc.1, ptr %objrc
+    %referenceCount.1 = sub %ReferenceCount %referenceCount, 1
+    store %ReferenceCount %referenceCount.1, ptr %objectReferenceCount
     ret void
 
     free:
-    %objeraser = getelementptr %Header, ptr %obj, i64 0, i32 1
-    %eraser = load %Eraser, ptr %objeraser
-    %env = call %Env @objectEnvironment(%Obj %obj)
-    call fastcc void %eraser(%Env %env)
-    call void @free(%Obj %obj)
+    %objectEraser = getelementptr %Header, ptr %object, i64 0, i32 1
+    %eraser = load %Eraser, ptr %objectEraser
+    %environment = call %Environment @objectEnvironment(%Object %object)
+    call fastcc void %eraser(%Environment %environment)
+    call void @free(%Object %object)
     br label %done
 
     done:
@@ -216,14 +216,14 @@ define void @eraseObject(%Obj %obj) alwaysinline {
 }
 
 define void @erasePositive(%Pos %val) alwaysinline {
-    %obj = extractvalue %Pos %val, 1
-    tail call void @eraseObject(%Obj %obj)
+    %object = extractvalue %Pos %val, 1
+    tail call void @eraseObject(%Object %object)
     ret void
 }
 
 define void @eraseNegative(%Neg %val) alwaysinline {
-    %obj = extractvalue %Neg %val, 1
-    tail call void @eraseObject(%Obj %obj)
+    %object = extractvalue %Neg %val, 1
+    tail call void @eraseObject(%Object %object)
     ret void
 }
 
@@ -237,340 +237,340 @@ here:
     ret ptr @region
 
 loop:
-    %stkp = phi ptr [@rest, %entry], [%nextp, %loop]
-    %i = phi i64 [%evidence, %entry], [%nexti, %loop]
-    %stk = load %Stk, ptr %stkp
-    %regionp = getelementptr %StkVal, %Stk %stk, i64 0, i32 2
-    %nextp = getelementptr %StkVal, %Stk %stk, i64 0, i32 3
-    %nexti = sub i64 %i, 1
-    %cmp = icmp eq i64 %nexti, 0
+    %stackPointer = phi ptr [@rest, %entry], [%nextPointer, %loop]
+    %index = phi i64 [%evidence, %entry], [%nextIndex, %loop]
+    %stack = load %Stack, ptr %stackPointer
+    %regionPointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
+    %nextPointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
+    %nextIndex = sub i64 %index, 1
+    %cmp = icmp eq i64 %nextIndex, 0
 
     br i1 %cmp, label %done, label %loop
 
 done:
-    ret ptr %regionp
+    ret ptr %regionPointer
 
 }
 
 
 
-define { ptr, %Ref } @alloc(i64 %idx, i64 %evidence) alwaysinline {
-    %regionp = call ptr @getRegionPointer(i64 %evidence)
-    %spp = getelementptr %Region, ptr %regionp, i64 0, i64 %idx, i32 0
-    %basep = getelementptr %Region, ptr %regionp, i64 0, i64 %idx, i32 1
-    %limitp = getelementptr %Region, ptr %regionp, i64 0, i64 %idx, i32 2
+define { ptr, %Reference } @alloc(i64 %index, i64 %evidence) alwaysinline {
+    %regionPointer = call ptr @getRegionPointer(i64 %evidence)
+    %stackPointerPointer = getelementptr %Region, ptr %regionPointer, i64 0, i64 %index, i32 0
+    %basePointer = getelementptr %Region, ptr %regionPointer, i64 0, i64 %index, i32 1
+    %limitPointer = getelementptr %Region, ptr %regionPointer, i64 0, i64 %index, i32 2
 
-    %sp = load %Sp, ptr %spp
-    %base = load %Base, ptr %basep
-    %limit = load %Limit, ptr %limitp
+    %stackPointer = load %StackPointer, ptr %stackPointerPointer
+    %base = load %Base, ptr %basePointer
+    %limit = load %Limit, ptr %limitPointer
 
-    %obj = icmp ne i64 %idx, 0
-    %size = select i1 %obj, i64 16, i64 8
+    %object = icmp ne i64 %index, 0
+    %size = select i1 %object, i64 16, i64 8
 
-    %nextsp = getelementptr i8, %Sp %sp, i64 %size
+    %nextStackPointer = getelementptr i8, %StackPointer %stackPointer, i64 %size
 
-    %cmp = icmp ule %Sp %nextsp, %limit
+    %cmp = icmp ule %StackPointer %nextStackPointer, %limit
     br i1 %cmp, label %continue, label %realloc
 
 continue:
-    store %Sp %nextsp, ptr %spp
-    %intb = ptrtoint %Base %base to i64
-    %intsp = ptrtoint %Sp %sp to i64
-    %offset = sub i64 %intsp, %intb
+    store %StackPointer %nextStackPointer, ptr %stackPointerPointer
+    %intBase = ptrtoint %Base %base to i64
+    %intStackPointer = ptrtoint %StackPointer %stackPointer to i64
+    %offset = sub i64 %intStackPointer, %intBase
 
-    %ret.0 = insertvalue { ptr, %Ref } undef, %Sp %sp, 0
-    %ret.1 = insertvalue { ptr, %Ref } %ret.0, %Ref %offset, 1
-    ret { ptr, %Ref } %ret.1
+    %ret.0 = insertvalue { ptr, %Reference } undef, %StackPointer %stackPointer, 0
+    %ret.1 = insertvalue { ptr, %Reference } %ret.0, %Reference %offset, 1
+    ret { ptr, %Reference } %ret.1
 
 realloc:
-    %intbase = ptrtoint %Base %base to i64
-    %intlimit = ptrtoint %Limit %limit to i64
-    %arenasize = sub i64 %intlimit, %intbase
-    %empty = icmp eq i64 %arenasize, 0
-    %double = mul i64 %arenasize, 2
-    %newarenasize = select i1 %empty, i64 1024, i64 %double
+    %intBase_2 = ptrtoint %Base %base to i64
+    %intLimit = ptrtoint %Limit %limit to i64
+    %arenaSize = sub i64 %intLimit, %intBase_2
+    %empty = icmp eq i64 %arenaSize, 0
+    %double = mul i64 %arenaSize, 2
+    %newArenaSize = select i1 %empty, i64 1024, i64 %double
 
-    %newbase = call ptr @realloc(ptr %base, i64 %newarenasize)
-    %newlimit = getelementptr i8, %Base %newbase, i64 %newarenasize
-    %newsp = getelementptr i8, %Base %newbase, i64 %arenasize
-    %newnextsp = getelementptr i8, %Sp %newsp, i64 %size
+    %newBase = call ptr @realloc(ptr %base, i64 %newArenaSize)
+    %newlimit = getelementptr i8, %Base %newBase, i64 %newArenaSize
+    %newStackPointer = getelementptr i8, %Base %newBase, i64 %arenaSize
+    %newNextStackPointer = getelementptr i8, %StackPointer %newStackPointer, i64 %size
 
-    store %Base %newbase, ptr %basep
-    store %Limit %newlimit, ptr %limitp
-    store %Sp %newnextsp, ptr %spp
+    store %Base %newBase, ptr %basePointer
+    store %Limit %newlimit, ptr %limitPointer
+    store %StackPointer %newNextStackPointer, ptr %stackPointerPointer
 
-    %ret..0 = insertvalue { ptr, %Ref } undef, %Sp %newsp, 0
-    %ret..1 = insertvalue { ptr, %Ref } %ret..0, %Ref %arenasize, 1
-    ret { ptr, %Ref } %ret..1
+    %ret..0 = insertvalue { ptr, %Reference } undef, %StackPointer %newStackPointer, 0
+    %ret..1 = insertvalue { ptr, %Reference } %ret..0, %Reference %arenaSize, 1
+    ret { ptr, %Reference } %ret..1
 
 }
 
-define ptr @getPtr(%Ref %ref, i64 %idx, i64 %evidence) alwaysinline {
-    %regionp = call ptr @getRegionPointer(i64 %evidence)
-    %basep = getelementptr %Region, ptr %regionp, i64 0, i64 %idx, i32 1
-    %base = load %Base, ptr %basep
-    %ptr = getelementptr i8, ptr %base, %Ref %ref
-    ret ptr %ptr
+define ptr @getPointer(%Reference %reference, i64 %index, i64 %evidence) alwaysinline {
+    %regionPointer = call ptr @getRegionPointer(i64 %evidence)
+    %basePointer = getelementptr %Region, ptr %regionPointer, i64 0, i64 %index, i32 1
+    %base = load %Base, ptr %basePointer
+    %pointer = getelementptr i8, ptr %base, %Reference %reference
+    ret ptr %pointer
 }
 
 ; Meta-stack management
 
-define %Mem @newMem() alwaysinline {
-    %sp = call %Sp @malloc(i64 268435456)
-    %limit = getelementptr i8, ptr %sp, i64 268435456
+define %Memory @newMemory() alwaysinline {
+    %stackPointer = call %StackPointer @malloc(i64 268435456)
+    %limit = getelementptr i8, ptr %stackPointer, i64 268435456
 
-    %mem.0 = insertvalue %Mem undef, %Sp %sp, 0
-    %mem.1 = insertvalue %Mem %mem.0, %Base %sp, 1
-    %mem.2 = insertvalue %Mem %mem.1, %Limit %limit, 2
+    %memory.0 = insertvalue %Memory undef, %StackPointer %stackPointer, 0
+    %memory.1 = insertvalue %Memory %memory.0, %Base %stackPointer, 1
+    %memory.2 = insertvalue %Memory %memory.1, %Limit %limit, 2
 
-    ret %Mem %mem.2
+    ret %Memory %memory.2
 }
 
-define %Stk @newStack() alwaysinline {
+define %Stack @newStack() alwaysinline {
 
     ; TODO find actual size of stack
-    %stk = call ptr @malloc(i64 112)
+    %stack = call ptr @malloc(i64 112)
 
     ; TODO initialize to zero and grow later
-    %stackmem = call %Mem @newMem()
+    %stackMemory = call %Memory @newMemory()
 
-    %stk.0 = insertvalue %StkVal undef, %Rc 0, 0
-    %stk.1 = insertvalue %StkVal %stk.0, %Mem %stackmem, 1
-    %stk.2 = insertvalue %StkVal %stk.1, %Region zeroinitializer, 2
-    %stk.3 = insertvalue %StkVal %stk.2, %Stk %stk, 3
+    %stack.0 = insertvalue %StackValue undef, %ReferenceCount 0, 0
+    %stack.1 = insertvalue %StackValue %stack.0, %Memory %stackMemory, 1
+    %stack.2 = insertvalue %StackValue %stack.1, %Region zeroinitializer, 2
+    %stack.3 = insertvalue %StackValue %stack.2, %Stack %stack, 3
 
-    store %StkVal %stk.3, %Stk %stk
+    store %StackValue %stack.3, %Stack %stack
 
-    ret %Stk %stk
+    ret %Stack %stack
 }
 
-define %Sp @pushStack(%Stk %stk, %Sp %oldsp) alwaysinline {
-    %newstk = load %StkVal, %Stk %stk
+define %StackPointer @pushStack(%Stack %stack, %StackPointer %oldStackPointer) alwaysinline {
+    %newStack = load %StackValue, %Stack %stack
 
-    %oldstk = call %StkVal @getStk(%Sp %oldsp)
+    %oldStack = call %StackValue @getStack(%StackPointer %oldStackPointer)
 
-    call void @setStk(%StkVal %newstk)
+    call void @setStack(%StackValue %newStack)
 
-    store %StkVal %oldstk, %Stk %stk
+    store %StackValue %oldStack, %Stack %stack
 
-    %newsp = extractvalue %StkVal %newstk, 1, 0
-    ret %Sp %newsp
+    %newStackPointer = extractvalue %StackValue %newStack, 1, 0
+    ret %StackPointer %newStackPointer
 }
 
 ; pop n+1 stacks
-define {%Stk, %Sp} @popStacks(%Sp %oldsp, i64 %n) alwaysinline {
+define {%Stack, %StackPointer} @popStacks(%StackPointer %oldStackPointer, i64 %n) alwaysinline {
 entry:
-    %oldstk = call %StkVal @getStk(%Sp %oldsp)
+    %oldStack = call %StackValue @getStack(%StackPointer %oldStackPointer)
     br label %loop
 
 loop:
-    %stkval = phi %StkVal [%oldstk, %entry], [%newstk, %loop]
-    %i = phi i64 [%n, %entry], [%nexti, %loop]
+    %stackValue = phi %StackValue [%oldStack, %entry], [%newStack, %loop]
+    %index = phi i64 [%n, %entry], [%nextIndex, %loop]
 
-    %newstkp = extractvalue %StkVal %stkval, 3
-    %newstk = load %StkVal, %Stk %newstkp
+    %newStackPointer = extractvalue %StackValue %stackValue, 3
+    %newStack = load %StackValue, %Stack %newStackPointer
 
-    %nexti = sub i64 %i, 1
+    %nextIndex = sub i64 %index, 1
 
-    %cmp = icmp eq i64 %i, 0
+    %cmp = icmp eq i64 %index, 0
     br i1 %cmp, label %done, label %loop
 
 done:
-    call void @setStk(%StkVal %newstk)
+    call void @setStack(%StackValue %newStack)
 
-    store %StkVal %oldstk, %Stk %newstkp
+    store %StackValue %oldStack, %Stack %newStackPointer
 
-    %newsp = extractvalue %StkVal %newstk, 1, 0
-    %ret.0 = insertvalue {%Stk, %Sp} undef, %Stk %newstkp, 0
-    %ret.1 = insertvalue {%Stk, %Sp} %ret.0, %Sp %newsp, 1
+    %newStackPointer_2 = extractvalue %StackValue %newStack, 1, 0
+    %ret.0 = insertvalue {%Stack, %StackPointer} undef, %Stack %newStackPointer, 0
+    %ret.1 = insertvalue {%Stack, %StackPointer} %ret.0, %StackPointer %newStackPointer_2, 1
 
-    ret {%Stk, %Sp} %ret.1
+    ret {%Stack, %StackPointer} %ret.1
 }
 
-define %Sp @underflowStack(%Sp %sp) alwaysinline {
-    %stk = load %Stk, ptr @rest
-    %newstk = load %StkVal, %Stk %stk
+define %StackPointer @underflowStack(%StackPointer %stackPointer) alwaysinline {
+    %stack = load %Stack, ptr @rest
+    %newStack = load %StackValue, %Stack %stack
 
     %region = load %Region, ptr @region
     call void @eraseRegion(%Region %region)
 
-    call void @setStk(%StkVal %newstk)
+    call void @setStack(%StackValue %newStack)
 
-    call void @free(%Sp %sp)
-    call void @free(%Stk %stk)
+    call void @free(%StackPointer %stackPointer)
+    call void @free(%Stack %stack)
 
-    %newsp = extractvalue %StkVal %newstk, 1, 0
-    ret %Sp %newsp
+    %newStackPointer = extractvalue %StackValue %newStack, 1, 0
+    ret %StackPointer %newStackPointer
 }
 
-define %Mem @copyMem(%Mem %mem) alwaysinline {
-    %sp = extractvalue %Mem %mem, 0
-    %base = extractvalue %Mem %mem, 1
-    %limit = extractvalue %Mem %mem, 2
+define %Memory @copyMemory(%Memory %memory) alwaysinline {
+    %stackPointer = extractvalue %Memory %memory, 0
+    %base = extractvalue %Memory %memory, 1
+    %limit = extractvalue %Memory %memory, 2
 
-    %intsp = ptrtoint %Sp %sp to i64
-    %intbase = ptrtoint %Base %base to i64
-    %intlimit = ptrtoint %Limit %limit to i64
-    %used = sub i64 %intsp, %intbase
-    %size = sub i64 %intlimit, %intbase
+    %intStackPointer = ptrtoint %StackPointer %stackPointer to i64
+    %intBase = ptrtoint %Base %base to i64
+    %intLimit = ptrtoint %Limit %limit to i64
+    %used = sub i64 %intStackPointer, %intBase
+    %size = sub i64 %intLimit, %intBase
 
-    %newbase = call ptr @malloc(i64 %size)
-    %intnewbase = ptrtoint %Base %newbase to i64
-    %intnewsp = add i64 %intnewbase, %used
-    %intnewlimit = add i64 %intnewbase, %size
-    %newsp = inttoptr i64 %intnewsp to %Sp
-    %newlimit = inttoptr i64 %intnewlimit to %Limit
+    %newBase = call ptr @malloc(i64 %size)
+    %intNewBase = ptrtoint %Base %newBase to i64
+    %intNewStackPointer = add i64 %intNewBase, %used
+    %intNewLimit = add i64 %intNewBase, %size
+    %newStackPointer = inttoptr i64 %intNewStackPointer to %StackPointer
+    %newLimit = inttoptr i64 %intNewLimit to %Limit
 
-    call void @memcpy(ptr %newbase, ptr %base, i64 %used)
+    call void @memcpy(ptr %newBase, ptr %base, i64 %used)
 
-    %mem.0 = insertvalue %Mem undef, %Sp %newsp, 0
-    %mem.1 = insertvalue %Mem %mem.0, %Base %newbase, 1
-    %mem.2 = insertvalue %Mem %mem.1, %Limit %newlimit, 2
+    %memory.0 = insertvalue %Memory undef, %StackPointer %newStackPointer, 0
+    %memory.1 = insertvalue %Memory %memory.0, %Base %newBase, 1
+    %memory.2 = insertvalue %Memory %memory.1, %Limit %newLimit, 2
 
-    ret %Mem %mem.2
+    ret %Memory %memory.2
 }
 
 define %Region @copyRegion(%Region %region) alwaysinline {
-    %mem.0 = extractvalue %Region %region, 0
-    %mem.1 = extractvalue %Region %region, 1
-    %mem.2 = extractvalue %Region %region, 2
+    %memory.0 = extractvalue %Region %region, 0
+    %memory.1 = extractvalue %Region %region, 1
+    %memory.2 = extractvalue %Region %region, 2
 
-    %objectsbase = extractvalue %Region %region, 1, 1
-    %objectssp = extractvalue %Region %region, 1, 0
-    call void @forEachObject(%Base %objectsbase, %Sp %objectssp, %Eraser @sharePositive)
+    %objectsBase = extractvalue %Region %region, 1, 1
+    %objectsStackPointer = extractvalue %Region %region, 1, 0
+    call void @forEachObject(%Base %objectsBase, %StackPointer %objectsStackPointer, %Eraser @sharePositive)
 
-    %stringsbase = extractvalue %Region %region, 2, 1
-    %stringssp = extractvalue %Region %region, 2, 0
-    call void @forEachObject(%Base %stringsbase, %Sp %stringssp, %Eraser @sharePositive)
+    %stringsBase = extractvalue %Region %region, 2, 1
+    %stringsStackPointer = extractvalue %Region %region, 2, 0
+    call void @forEachObject(%Base %stringsBase, %StackPointer %stringsStackPointer, %Eraser @sharePositive)
 
-    %newmem.0 = call %Mem @copyMem(%Mem %mem.0)
-    %newmem.1 = call %Mem @copyMem(%Mem %mem.1)
-    %newmem.2 = call %Mem @copyMem(%Mem %mem.2)
+    %newMemory.0 = call %Memory @copyMemory(%Memory %memory.0)
+    %newMemory.1 = call %Memory @copyMemory(%Memory %memory.1)
+    %newMemory.2 = call %Memory @copyMemory(%Memory %memory.2)
 
-    %region.0 = insertvalue %Region undef, %Mem %newmem.0, 0
-    %region.1 = insertvalue %Region %region.0, %Mem %newmem.1, 1
-    %region.2 = insertvalue %Region %region.1, %Mem %newmem.2, 2
+    %region.0 = insertvalue %Region undef, %Memory %newMemory.0, 0
+    %region.1 = insertvalue %Region %region.0, %Memory %newMemory.1, 1
+    %region.2 = insertvalue %Region %region.1, %Memory %newMemory.2, 2
 
     ret %Region %region.2
 }
 
-define %Stk @uniqueStack(%Stk %stk) alwaysinline {
+define %Stack @uniqueStack(%Stack %stack) alwaysinline {
 
 entry:
-    %stkrc = getelementptr %StkVal, %Stk %stk, i64 0, i32 0
-    %rc = load %Rc, ptr %stkrc
-    switch %Rc %rc, label %copy [%Rc 0, label %done]
+    %stackReferenceCount = getelementptr %StackValue, %Stack %stack, i64 0, i32 0
+    %referenceCount = load %ReferenceCount, ptr %stackReferenceCount
+    switch %ReferenceCount %referenceCount, label %copy [%ReferenceCount 0, label %done]
 
 done:
-    ret %Stk %stk
+    ret %Stack %stack
 
 copy:
-    %newoldrc = sub %Rc %rc, 1
-    store %Rc %newoldrc, ptr %stkrc
+    %newOldReferenceCount = sub %ReferenceCount %referenceCount, 1
+    store %ReferenceCount %newOldReferenceCount, ptr %stackReferenceCount
 
-    %newhead = call ptr @malloc(i64 112)
+    %newHead = call ptr @malloc(i64 112)
     br label %loop
 
 loop:
-    %old = phi %Stk [%stk, %copy], [%rest, %next]
-    %newstk = phi %Stk [%newhead, %copy], [%nextnew, %next]
+    %old = phi %Stack [%stack, %copy], [%rest, %next]
+    %newStack = phi %Stack [%newHead, %copy], [%nextNew, %next]
 
-    %stkmem = getelementptr %StkVal, %Stk %old, i64 0, i32 1
-    %stkregion = getelementptr %StkVal, %Stk %old, i64 0, i32 2
-    %stkrest = getelementptr %StkVal, %Stk %old, i64 0, i32 3
+    %stackMemory = getelementptr %StackValue, %Stack %old, i64 0, i32 1
+    %stackRegion = getelementptr %StackValue, %Stack %old, i64 0, i32 2
+    %stackRest = getelementptr %StackValue, %Stack %old, i64 0, i32 3
 
-    %mem = load %Mem, ptr %stkmem
-    %region = load %Region, ptr %stkregion
-    %rest = load %Stk, ptr %stkrest
+    %memory = load %Memory, ptr %stackMemory
+    %region = load %Region, ptr %stackRegion
+    %rest = load %Stack, ptr %stackRest
 
-    %newstkrc = getelementptr %StkVal, %Stk %newstk, i64 0, i32 0
-    %newstkmem = getelementptr %StkVal, %Stk %newstk, i64 0, i32 1
-    %newstkregion = getelementptr %StkVal, %Stk %newstk, i64 0, i32 2
-    %newstkrest = getelementptr %StkVal, %Stk %newstk, i64 0, i32 3
+    %newStackReferenceCount = getelementptr %StackValue, %Stack %newStack, i64 0, i32 0
+    %newStackMemory = getelementptr %StackValue, %Stack %newStack, i64 0, i32 1
+    %newStackRegion = getelementptr %StackValue, %Stack %newStack, i64 0, i32 2
+    %newStackRest = getelementptr %StackValue, %Stack %newStack, i64 0, i32 3
 
-    %newmem = call %Mem @copyMem(%Mem %mem)
+    %newMemory = call %Memory @copyMemory(%Memory %memory)
 
-    %newsp = extractvalue %Mem %newmem, 0
-    call fastcc void @shareFrames(%Sp %newsp)
+    %newStackPointer = extractvalue %Memory %newMemory, 0
+    call fastcc void @shareFrames(%StackPointer %newStackPointer)
 
-    %newregion = call %Region @copyRegion(%Region %region)
+    %newRegion = call %Region @copyRegion(%Region %region)
 
-    store %Rc 0, ptr %newstkrc
-    store %Mem %newmem, ptr %newstkmem
-    store %Region %newregion, ptr %newstkregion
+    store %ReferenceCount 0, ptr %newStackReferenceCount
+    store %Memory %newMemory, ptr %newStackMemory
+    store %Region %newRegion, ptr %newStackRegion
 
-    %last = icmp eq %Stk %rest, %stk
-    br i1 %last, label %closecycle, label %next
+    %last = icmp eq %Stack %rest, %stack
+    br i1 %last, label %closeCycle, label %next
 
 next:
-    %nextnew = call ptr @malloc(i64 112)
-    store %Stk %nextnew, ptr %newstkrest
+    %nextNew = call ptr @malloc(i64 112)
+    store %Stack %nextNew, ptr %newStackRest
     br label %loop
 
-closecycle:
-    store %Stk %newhead, ptr %newstkrest
-    ret %Stk %newhead
+closeCycle:
+    store %Stack %newHead, ptr %newStackRest
+    ret %Stack %newHead
 
 }
 
-define void @shareStack(%Stk %stk) alwaysinline {
-    %stkrc = getelementptr %StkVal, %Stk %stk, i64 0, i32 0
-    %rc = load %Rc, ptr %stkrc
-    %rc.1 = add %Rc %rc, 1
-    store %Rc %rc.1, ptr %stkrc
+define void @shareStack(%Stack %stack) alwaysinline {
+    %stackReferenceCount = getelementptr %StackValue, %Stack %stack, i64 0, i32 0
+    %referenceCount = load %ReferenceCount, ptr %stackReferenceCount
+    %referenceCount.1 = add %ReferenceCount %referenceCount, 1
+    store %ReferenceCount %referenceCount.1, ptr %stackReferenceCount
     ret void
 }
 
-define void @eraseStack(%Stk %stk) alwaysinline {
-    %stkrc = getelementptr %StkVal, %Stk %stk, i64 0, i32 0
-    %rc = load %Rc, ptr %stkrc
-    switch %Rc %rc, label %decr [%Rc 0, label %free]
+define void @eraseStack(%Stack %stack) alwaysinline {
+    %stackReferenceCount = getelementptr %StackValue, %Stack %stack, i64 0, i32 0
+    %referenceCount = load %ReferenceCount, ptr %stackReferenceCount
+    switch %ReferenceCount %referenceCount, label %decr [%ReferenceCount 0, label %free]
 
     decr:
-    %rc.1 = sub %Rc %rc, 1
-    store %Rc %rc.1, ptr %stkrc
+    %referenceCount.1 = sub %ReferenceCount %referenceCount, 1
+    store %ReferenceCount %referenceCount.1, ptr %stackReferenceCount
     ret void
 
     free:
-    %stksp = getelementptr %StkVal, %Stk %stk, i64 0, i32 1, i32 0
-    %sp = load %Sp, ptr %stksp
-    call fastcc void @eraseFrames(%Sp %sp)
+    %stackStackPointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 1, i32 0
+    %stackPointer = load %StackPointer, ptr %stackStackPointer
+    call fastcc void @eraseFrames(%StackPointer %stackPointer)
 
-    %regionp = getelementptr %StkVal, %Stk %stk, i64 0, i32 2
-    %region = load %Region, ptr %regionp
+    %regionPointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
+    %region = load %Region, ptr %regionPointer
 
     call void @eraseRegion(%Region %region)
 
-    call void @free(%Stk %stk)
+    call void @free(%Stack %stack)
     ret void
 }
 
-define fastcc void @shareFrames(%Sp %sp) alwaysinline {
-    %newsp = getelementptr %FrameHeader, %Sp %sp, i64 -1
-    %stksharer = getelementptr %FrameHeader, %Sp %newsp, i64 0, i32 1
-    %sharer = load %Sharer, ptr %stksharer
-    tail call fastcc void %sharer(%Sp %newsp)
+define fastcc void @shareFrames(%StackPointer %stackPointer) alwaysinline {
+    %newStackPointer = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 -1
+    %stackSharer = getelementptr %FrameHeader, %StackPointer %newStackPointer, i64 0, i32 1
+    %sharer = load %Sharer, ptr %stackSharer
+    tail call fastcc void %sharer(%StackPointer %newStackPointer)
     ret void
 }
 
-define fastcc void @eraseFrames(%Sp %sp) alwaysinline {
-    %newsp = getelementptr %FrameHeader, %Sp %sp, i64 -1
-    %stkeraser = getelementptr %FrameHeader, %Sp %newsp, i64 0, i32 2
-    %eraser = load %Eraser, ptr %stkeraser
-    tail call fastcc void %eraser(%Sp %newsp)
+define fastcc void @eraseFrames(%StackPointer %stackPointer) alwaysinline {
+    %newStackPointer = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 -1
+    %stackEraser = getelementptr %FrameHeader, %StackPointer %newStackPointer, i64 0, i32 2
+    %eraser = load %Eraser, ptr %stackEraser
+    tail call fastcc void %eraser(%StackPointer %newStackPointer)
     ret void
 }
 
-define void @forEachObject(ptr %elementp, ptr %end, ptr %f) alwaysinline {
-    %done = icmp uge ptr %elementp, %end
+define void @forEachObject(ptr %elementPointer, ptr %end, ptr %f) alwaysinline {
+    %done = icmp uge ptr %elementPointer, %end
     br i1 %done, label %return, label %erase
 
 erase:
-    %element = load %Pos, ptr %elementp
+    %element = load %Pos, ptr %elementPointer
     call void %f(%Pos %element)
 
-    %nextelementp = getelementptr %Pos, ptr %elementp, i64 1
-    tail call void @forEachObject(ptr %nextelementp, ptr %end, ptr %f)
+    %nextElementPointer = getelementptr %Pos, ptr %elementPointer, i64 1
+    tail call void @forEachObject(ptr %nextElementPointer, ptr %end, ptr %f)
     ret void
 
 return:
@@ -578,25 +578,25 @@ return:
 }
 
 define void @eraseRegion(%Region %region) alwaysinline {
-    %valuesbase = extractvalue %Region %region, 0, 1
-    call void @free(%Base %valuesbase)
+    %valuesBase = extractvalue %Region %region, 0, 1
+    call void @free(%Base %valuesBase)
 
-    %objectsbase = extractvalue %Region %region, 1, 1
-    %objectssp = extractvalue %Region %region, 1, 0
-    call void @forEachObject(%Base %objectsbase, %Sp %objectssp, %Eraser @erasePositive)
-    call void @free(%Base %objectsbase)
+    %objectsBase = extractvalue %Region %region, 1, 1
+    %objectsStackPointer = extractvalue %Region %region, 1, 0
+    call void @forEachObject(%Base %objectsBase, %StackPointer %objectsStackPointer, %Eraser @erasePositive)
+    call void @free(%Base %objectsBase)
 
-    %stringsbase = extractvalue %Region %region, 2, 1
-    %stringssp = extractvalue %Region %region, 2, 0
-    call void @forEachObject(%Base %stringsbase, %Sp %stringssp, %Eraser @erasePositive)
-    call void @free(%Base %stringsbase)
+    %stringsBase = extractvalue %Region %region, 2, 1
+    %stringsStackPointer = extractvalue %Region %region, 2, 0
+    call void @forEachObject(%Base %stringsBase, %StackPointer %stringsStackPointer, %Eraser @erasePositive)
+    call void @free(%Base %stringsBase)
 
     ret void
 }
 
 ; RTS initialization
 
-define fastcc void @topLevel(%Env %env, %Sp noalias %sp) {
+define fastcc void @topLevel(%Environment %environment, %StackPointer noalias %stackPointer) {
     %base = load %Base, ptr @base
     call void @free(%Base %base)
 
@@ -609,31 +609,31 @@ define fastcc void @topLevel(%Env %env, %Sp noalias %sp) {
     call void @free(%Base %base.1)
     call void @free(%Base %base.2)
 
-    call void @free(%Env %env)
+    call void @free(%Environment %environment)
     ret void
 }
 
-define fastcc void @topLevelSharer(%Env %env) {
+define fastcc void @topLevelSharer(%Environment %environment) {
     ; TODO this should never be called
     ret void
 }
 
-define fastcc void @topLevelEraser(%Env %env) {
+define fastcc void @topLevelEraser(%Environment %environment) {
     ; TODO this should never be called
     ret void
 }
 
-define %Sp @withEmptyStack() {
-    %sp = call %Sp @malloc(i64 268435456)
-    store %Sp %sp, ptr @base
-    %retadrp_1 = getelementptr %FrameHeader, %Sp %sp, i64 0, i32 0
-    %sharerp_2 = getelementptr %FrameHeader, %Sp %sp, i64 0, i32 1
-    %eraserp_3 = getelementptr %FrameHeader, %Sp %sp, i64 0, i32 2
-    store %RetAdr @topLevel, ptr %retadrp_1
-    store %Sharer @topLevelSharer, ptr %sharerp_2
-    store %Eraser @topLevelEraser, ptr %eraserp_3
-    %sp2 = getelementptr %FrameHeader, %Sp %sp, i64 1
-    ret %Sp %sp2
+define %StackPointer @withEmptyStack() {
+    %stackPointer = call %StackPointer @malloc(i64 268435456)
+    store %StackPointer %stackPointer, ptr @base
+    %returnAddressPointer_1 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 0
+    %sharerPointer_2 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 1
+    %eraserPointer_3 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 2
+    store %ReturnAddress @topLevel, ptr %returnAddressPointer_1
+    store %Sharer @topLevelSharer, ptr %sharerPointer_2
+    store %Eraser @topLevelEraser, ptr %eraserPointer_3
+    %stackPointer_2 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 1
+    ret %StackPointer %stackPointer_2
 }
 
 define fastcc void @run_i64(%Neg %f, i64 %arg) {
@@ -641,30 +641,30 @@ define fastcc void @run_i64(%Neg %f, i64 %arg) {
     %base = load %Base, ptr @base
     %region = load %Region, ptr @region
     %limit = load %Limit, ptr @limit
-    %rest = load %Stk, ptr @rest
+    %rest = load %Stack, ptr @rest
 
     ; fresh stack
-    %sp = call %Sp @withEmptyStack()
+    %stackPointer = call %StackPointer @withEmptyStack()
 
     ; prepare call
-    %arrayp = extractvalue %Neg %f, 0
-    %obj = extractvalue %Neg %f, 1
-    %fpp = getelementptr ptr, ptr %arrayp, i64 0
-    %fp = load ptr, ptr %fpp
+    %arrayPointer = extractvalue %Neg %f, 0
+    %object = extractvalue %Neg %f, 1
+    %functionPointerPointer = getelementptr ptr, ptr %arrayPointer, i64 0
+    %functionPointer = load ptr, ptr %functionPointerPointer
 
     ; Store the argument (0th index is evidence)
-    %env = call %Env @malloc(i64 1048576)
-    %ev2 = getelementptr {%Int, %Int}, %Env %env, i64 0, i32 1
-    store i64 %arg, ptr %ev2
+    %environment = call %Environment @malloc(i64 1048576)
+    %evidence2 = getelementptr {%Int, %Int}, %Environment %environment, i64 0, i32 1
+    store i64 %arg, ptr %evidence2
 
     ; call
-    %result = call fastcc %Pos %fp(%Obj %obj, %Env %env, %Sp %sp)
+    %result = call fastcc %Pos %functionPointer(%Object %object, %Environment %environment, %StackPointer %stackPointer)
 
     ; restore stack (TODO this shouldn't be necessary, the moment we pass stacks...; then this is a tail-call again)
-    store %Sp %base, ptr @base
+    store %StackPointer %base, ptr @base
     store %Region %region, ptr @region
     store %Limit %limit, ptr @limit
-    store %Stk %rest, ptr @rest
+    store %Stack %rest, ptr @rest
 
     ret void
 }
@@ -675,30 +675,30 @@ define fastcc void @run_Pos(%Neg %f, %Pos %arg) {
     %base = load %Base, ptr @base
     %region = load %Region, ptr @region
     %limit = load %Limit, ptr @limit
-    %rest = load %Stk, ptr @rest
+    %rest = load %Stack, ptr @rest
 
     ; fresh stack
-    %sp = call %Sp @withEmptyStack()
+    %stackPointer = call %StackPointer @withEmptyStack()
 
     ; prepare call
-    %arrayp = extractvalue %Neg %f, 0
-    %obj = extractvalue %Neg %f, 1
-    %fpp = getelementptr ptr, ptr %arrayp, i64 0
-    %fp = load ptr, ptr %fpp
+    %arrayPointer = extractvalue %Neg %f, 0
+    %object = extractvalue %Neg %f, 1
+    %functionPointerPointer = getelementptr ptr, ptr %arrayPointer, i64 0
+    %functionPointer = load ptr, ptr %functionPointerPointer
 
     ; Store the argument (0th index is evidence)
-    %env = call %Env @malloc(i64 1048576)
-    %arg_pos = getelementptr {%Int, %Pos}, %Env %env, i64 0, i32 1
+    %environment = call %Environment @malloc(i64 1048576)
+    %arg_pos = getelementptr {%Int, %Pos}, %Environment %environment, i64 0, i32 1
     store %Pos %arg, ptr %arg_pos
 
     ; call
-    %result = call fastcc %Pos %fp(%Obj %obj, %Env %env, %Sp %sp)
+    %result = call fastcc %Pos %functionPointer(%Object %object, %Environment %environment, %StackPointer %stackPointer)
 
     ; restore stack (TODO this shouldn't be necessary, the moment we pass stacks...; then this is a tail-call again)
-    store %Sp %base, ptr @base
+    store %StackPointer %base, ptr @base
     store %Region %region, ptr @region
     store %Limit %limit, ptr @limit
-    store %Stk %rest, ptr @rest
+    store %Stack %rest, ptr @rest
 
     ret void
 }
@@ -708,26 +708,26 @@ define void @run(%Neg %f) {
     %base = load %Base, ptr @base
     %region = load %Region, ptr @region
     %limit = load %Limit, ptr @limit
-    %rest = load %Stk, ptr @rest
+    %rest = load %Stack, ptr @rest
 
     ; fresh stack
-    %sp = call %Sp @withEmptyStack()
+    %stackPointer = call %StackPointer @withEmptyStack()
 
     ; prepare call
-    %arrayp = extractvalue %Neg %f, 0
-    %obj = extractvalue %Neg %f, 1
-    %fpp = getelementptr ptr, ptr %arrayp, i64 0
-    %fp = load ptr, ptr %fpp
+    %arrayPointer = extractvalue %Neg %f, 0
+    %object = extractvalue %Neg %f, 1
+    %functionPointerPointer = getelementptr ptr, ptr %arrayPointer, i64 0
+    %functionPointer = load ptr, ptr %functionPointerPointer
 
     ; call
-    %env = call %Env @malloc(i64 1048576)
-    %result = call fastcc %Pos %fp(%Obj %obj, %Env %env, %Sp %sp)
+    %environment = call %Environment @malloc(i64 1048576)
+    %result = call fastcc %Pos %functionPointer(%Object %object, %Environment %environment, %StackPointer %stackPointer)
 
     ; restore stack (TODO this shouldn't be necessary, the moment we pass stacks...; then this is a tail-call again)
-    store %Sp %base, ptr @base
+    store %StackPointer %base, ptr @base
     store %Region %region, ptr @region
     store %Limit %limit, ptr @limit
-    store %Stk %rest, ptr @rest
+    store %Stack %rest, ptr @rest
 
     ret void
 }


### PR DESCRIPTION
This refactoring fixes several small annoyances that occured while trying to debug/understand the generated LLVM code:

- previously we switched between different naming schemes, so I chose camelCase for the names (in accordance to other code in the project). This is up for discussion.
- confusingly shortened names are expanded fully, e.g. `retadrp`->`returnAddressPointer`, `fpp`->`functionPointerPointer`. I realize I may have overdone this, so I'd happily revert some of it after discussion.
- arbitrary fresh names are named according to its general purpose, e.g. `k_123`->`returnAddress_123` or `x_4234`->`intLiteral_4234`
- comments indicate the source in relation to the machine/llvm structs

I believe these changes can massively speed up the process of trying to understand the LLVM code generation (e.g. for new students).

Some ugly fresh names still remain, especially ones that are overloaded from previous phases (e.g. `%l65_3658p_89 = ...`). Fixing this would require additional refactoring across phases.
