### PR TITLE
Add debug and valgrind to LLVM tests and config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: sudo apt-get install llvm-15
 
+    - name: Install Valgrind
+      if: matrix.os != 'windows-latest'
+      run: sudo apt-get install valgrind
+
     - name: Install libuv
       run: sudo apt-get install libuv1-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         node-version: '12.x'
 
     - name: Run tests
-      run: sbt clean test
+      run: EFFEKT_VALGRIND=1 sbt clean test
 
     - name: Assemble fully optimized js file
       run: sbt effektJS/fullOptJS

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -154,6 +154,16 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args.takeWhile(_ != "--
     group = debugging
   )
 
+  lazy val valgrind = toggle(
+    "valgrind",
+    descrYes = "Execute files using valgrind",
+    descrNo = "Don't execute files using valgrind",
+    default = Some(false),
+    noshort = true,
+    prefix = "no-",
+    group = debugging
+  )
+
   /**
    * Tries to find the path to the standard library. Proceeds in the following
    * order:

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -268,7 +268,11 @@ object LLVMRunner extends Runner[String] {
 
     val gccMainFile = (C.config.libPath / ".." / "llvm" / "main.c").unixPath
     val executableFile = basePath
-    val gccArgs = Seq(gcc, gccMainFile, "-o", executableFile, objPath) ++ libuvArgs
+    var gccArgs = Seq(gcc, gccMainFile, "-o", executableFile, objPath) ++ libuvArgs
+
+    if (C.config.debug())
+      gccArgs ++= Seq("-fsanitize=address,leak,undefined", "-fstack-protector-all", "-Og", "-g")
+
     exec(gccArgs: _*)
 
     executableFile

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -71,8 +71,9 @@ trait Runner[Executable] {
    */
   def eval(executable: Executable)(using C: Context): Unit = {
     val execFile = build(executable)
+    val valgrindArgs = Seq("--leak-check=full", "--quiet", "--log-file=valgrind.log", "--error-exitcode=1")
     val process = if (C.config.valgrind())
-      Process("valgrind", "--leak-check=full" +: "--log-file=valgrind.log" +: "--error-exitcode=1" +: execFile +: Context.config.runArgs())
+      Process("valgrind", valgrindArgs ++ (execFile +: Context.config.runArgs()))
     else
       Process(execFile, Context.config.runArgs())
 
@@ -90,7 +91,7 @@ trait Runner[Executable] {
 
     if (exitCode != 0) {
       C.error(s"Process exited with non-zero exit code ${exitCode}.")
-      if (C.config.valgrind()) C.error(s"Valgrind log: " ++ scala.io.Source.fromFile("valgrind.log").mkString)
+      if (C.config.valgrind()) C.error(s"Valgrind log:\n" ++ scala.io.Source.fromFile("valgrind.log").mkString)
     }
   }
 

--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -18,7 +18,7 @@ trait EffektTests extends munit.FunSuite {
   def backendName: String
 
   // Whether to execute using valgrind
-  def valgrind = sys.env.get("EFFEKT_VALGRIND").nonEmpty
+  def valgrind = false
 
   def output: File = new File(".") / "out" / "tests" / getClass.getName.toLowerCase
 

--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -17,6 +17,9 @@ trait EffektTests extends munit.FunSuite {
   // The name of the backend as it is passed to the --backend flag.
   def backendName: String
 
+  // Whether to execute using valgrind
+  def valgrind: Boolean = false
+
   def output: File = new File(".") / "out" / "tests" / getClass.getName.toLowerCase
 
   // The sources of all testfiles are stored here:
@@ -55,11 +58,13 @@ trait EffektTests extends munit.FunSuite {
 
   def run(input: File): String =
     val compiler = driver
-    val configs = compiler.createConfig(Seq(
+    var options = Seq(
       "--Koutput", "string",
       "--backend", backendName,
-      "--out", output.getPath
-    ))
+      "--out", output.getPath,
+    )
+    if (valgrind) options = options :+ "--valgrind"
+    val configs = compiler.createConfig(options)
     configs.verify()
 
     // reuse state after compiling a trivial file

--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -18,7 +18,7 @@ trait EffektTests extends munit.FunSuite {
   def backendName: String
 
   // Whether to execute using valgrind
-  def valgrind: Boolean = false
+  def valgrind = sys.env.get("EFFEKT_VALGRIND").nonEmpty
 
   def output: File = new File(".") / "out" / "tests" / getClass.getName.toLowerCase
 

--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -35,6 +35,27 @@ class LLVMTests extends EffektTests {
 
     // unclear
     examplesDir / "pos" / "higher_rank_polymorphism.effekt",
+
+    // Valgrind leak/failure
+    examplesDir / "llvm" / "nested.effekt",
+    examplesDir / "llvm" / "strings.effekt",
+    examplesDir / "llvm" / "polymorphism_map.effekt",
+    examplesDir / "pos" / "parser.effekt",
+    examplesDir / "pos" / "matchdef.effekt",
+    examplesDir / "pos" / "type_parameters_blocks.effekt",
+    examplesDir / "pos" / "long_string.effekt",
+    examplesDir / "pos" / "matchblock.effekt",
+    examplesDir / "pos" / "overloading.effekt",
+    examplesDir / "pos" / "withstatement.effekt",
+    examplesDir / "pos" / "dequeue.effekt",
+    examplesDir / "pos" / "higherorder_io_control.effekt",
+    examplesDir / "pos" / "infer" / "infer_overload.effekt",
+    examplesDir / "pos" / "bug1.effekt",
+    examplesDir / "pos" / "string_concat_pr493.effekt",
+    examplesDir / "pos" / "string" / "substring.effekt",
+    examplesDir / "pos" / "string" / "indexOf.effekt",
+    examplesDir / "benchmarks" / "tree.effekt",
+    examplesDir / "benchmarks" / "variadic_combinators.effekt",
   )
 
   /**

--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -56,8 +56,14 @@ class LLVMTests extends EffektTests {
     examplesDir / "pos" / "string_concat_pr493.effekt",
     examplesDir / "pos" / "string" / "substring.effekt",
     examplesDir / "pos" / "string" / "indexOf.effekt",
-    examplesDir / "benchmarks" / "tree.effekt",
-    examplesDir / "benchmarks" / "variadic_combinators.effekt",
+    examplesDir / "benchmarks" / "other" / "variadic_combinators.effekt",
+    examplesDir / "benchmarks" / "are_we_fast_yet" / "sieve.effekt",
+    examplesDir / "benchmarks" / "are_we_fast_yet" / "nbody.effekt",
+    examplesDir / "benchmarks" / "are_we_fast_yet" / "bounce.effekt",
+    examplesDir / "benchmarks" / "are_we_fast_yet" / "towers.effekt",
+    examplesDir / "benchmarks" / "are_we_fast_yet" / "permute.effekt",
+    examplesDir / "benchmarks" / "are_we_fast_yet" / "queens.effekt",
+    examplesDir / "benchmarks" / "effect_handlers_bench" / "tree_explore.effekt",
   )
 
   /**

--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -10,6 +10,8 @@ class LLVMTests extends EffektTests {
 
   def backendName = "llvm"
 
+  override def valgrind = sys.env.get("EFFEKT_VALGRIND").nonEmpty
+
   override lazy val positives: List[File] = List(
     examplesDir / "llvm",
     examplesDir / "pos",

--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -10,8 +10,6 @@ class LLVMTests extends EffektTests {
 
   def backendName = "llvm"
 
-  override def valgrind = true
-
   override lazy val positives: List[File] = List(
     examplesDir / "llvm",
     examplesDir / "pos",

--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -10,6 +10,8 @@ class LLVMTests extends EffektTests {
 
   def backendName = "llvm"
 
+  override def valgrind = true
+
   override lazy val positives: List[File] = List(
     examplesDir / "llvm",
     examplesDir / "pos",

--- a/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
@@ -53,6 +53,8 @@ class StdlibMLTests extends StdlibTests {
 class StdlibLLVMTests extends StdlibTests {
   def backendName: String = "llvm"
 
+  override def valgrind = sys.env.get("EFFEKT_VALGRIND").nonEmpty
+
   override def ignored: List[File] = List(
     // For every function tested using `immutable/result`:
     // [error] Unsupported coercion from Exception47234[E48288] to Exception47234[OutOfBounds47515]

--- a/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
@@ -52,7 +52,6 @@ class StdlibMLTests extends StdlibTests {
 }
 class StdlibLLVMTests extends StdlibTests {
   def backendName: String = "llvm"
-  override def valgrind: Boolean = true
 
   override def ignored: List[File] = List(
     // For every function tested using `immutable/result`:

--- a/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
@@ -52,6 +52,7 @@ class StdlibMLTests extends StdlibTests {
 }
 class StdlibLLVMTests extends StdlibTests {
   def backendName: String = "llvm"
+  override def valgrind: Boolean = true
 
   override def ignored: List[File] = List(
     // For every function tested using `immutable/result`:

--- a/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
@@ -60,5 +60,23 @@ class StdlibLLVMTests extends StdlibTests {
     examplesDir / "stdlib" / "list" / "modifyat.effekt",
     // Toplevel let-bindings (for ANSI-color-codes in output) not supported
     examplesDir / "stdlib" / "test" / "test.effekt",
+
+    // Valgrind leak/failure
+    examplesDir / "stdlib" / "bytes" / "bytes.effekt",
+    examplesDir / "stdlib" / "io" / "files" / "async_file_io.effekt",
+    examplesDir / "stdlib" / "io" / "files" / "filesystem.effekt",
+    examplesDir / "stdlib" / "io" / "time.effekt",
+    examplesDir / "stdlib" / "list" / "flatmap.effekt",
+    examplesDir / "stdlib" / "list" / "zip.effekt",
+    examplesDir / "stdlib" / "list" / "deleteat.effekt",
+    examplesDir / "stdlib" / "list" / "join.effekt",
+    examplesDir / "stdlib" / "list" / "updateat.effekt",
+    examplesDir / "stdlib" / "list" / "insert.effekt",
+    examplesDir / "stdlib" / "list" / "fill.effekt",
+    examplesDir / "stdlib" / "list" / "zipwith.effekt",
+    examplesDir / "stdlib" / "list" / "collect.effekt",
+    examplesDir / "stdlib" / "list" / "build.effekt",
+    examplesDir / "stdlib" / "string" / "strings.effekt",
+    examplesDir / "stdlib" / "string" / "unicode.effekt",
   )
 }


### PR DESCRIPTION
This makes use of the `--debug` flag and adds a new flag `--valgrind`:

- `--debug`: Use GCC's sanitization and other debugging flags (LLVM only for now)
- `--valgrind`: Run the final executable using valgrind and disable optimizations during compilation. This is enabled by default for LLVM tests.

This will make a lot of LLVM tests fail (intended).