### PR TITLE
Even more descriptive LLVM codegen

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/DirectStyleMutableState.scala
+++ b/effekt/shared/src/main/scala/effekt/core/DirectStyleMutableState.scala
@@ -36,12 +36,12 @@ object DirectStyleMutableState extends Phase[CoreTransformed, CoreTransformed] {
       case Stmt.Val(y, ytpe, Put(x, tpe, v), s) => Let(y, ytpe, Put(x, tpe, rewrite(v)), rewrite(s))
 
       case Get(x, tpe) =>
-        val id = Id("tmp")
+        val id = Id("temporary_get")
         val binding = Get(x, tpe)
         Let(id, binding.tpe, binding, Stmt.Return(Pure.ValueVar(id, tpe.result)))
 
       case Put(x, tpe, v) =>
-        val id = Id("tmp")
+        val id = Id("temporary_put")
         val binding = Put(x, tpe, v)
         Let(id, binding.tpe, binding, Stmt.Return(Pure.ValueVar(id, Type.TUnit)))
     }

--- a/effekt/shared/src/main/scala/effekt/core/LambdaLifting.scala
+++ b/effekt/shared/src/main/scala/effekt/core/LambdaLifting.scala
@@ -84,8 +84,8 @@ class LambdaLifting(m: core.ModuleDecl)(using Context) extends core.Tree.Rewrite
     // e.g. f : (Int) => Unit @ {io,exc}   ===>   { (n) => f(n, exc) }
     //   the type of f after transformation is `(Int, Exc) => Unit @ {io}`
     case f @ core.BlockVar(id, core.BlockType.Function(tps, cps, vps, bps, res), capt) if needsCallsiteAdaptation(id) =>
-      val vparams: List[core.ValueParam] = vps map { tpe => core.ValueParam(Id("x"), tpe) }
-      val bparams: List[core.BlockParam] = (cps zip bps) map { case (capt, tpe) => core.BlockParam(Id("f"), tpe, Set(capt)) }
+      val vparams: List[core.ValueParam] = vps map { tpe => core.ValueParam(Id("valueParam"), tpe) }
+      val bparams: List[core.BlockParam] = (cps zip bps) map { case (capt, tpe) => core.BlockParam(Id("blockParam"), tpe, Set(capt)) }
 
       val targs = tps map { tpe => core.ValueType.Var(tpe) }
       val vargs = vparams.map { p => core.ValueVar(p.id, p.tpe) } ++ infos(id).valueArgs

--- a/effekt/shared/src/main/scala/effekt/core/MakeStackSafe.scala
+++ b/effekt/shared/src/main/scala/effekt/core/MakeStackSafe.scala
@@ -57,5 +57,5 @@ object MakeStackSafe extends Phase[CoreTransformed, CoreTransformed] {
   }
 
   // [[ s ]] = val tmp = return (); s
-  def thunk(s: Stmt): Stmt = Stmt.Val(TmpValue(), core.Type.TUnit, Stmt.Return(Literal((), core.Type.TUnit)), s)
+  def thunk(s: Stmt): Stmt = Stmt.Val(TmpValue("thunk"), core.Type.TUnit, Stmt.Return(Literal((), core.Type.TUnit)), s)
 }

--- a/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
@@ -180,7 +180,7 @@ object PatternMatchingCompiler {
       // used to make up new scrutinees
       val varsFor = mutable.Map.empty[Id, List[ValueVar]]
       def fieldVarsFor(constructor: Id, fieldTypes: List[ValueType]): List[ValueVar] =
-        varsFor.getOrElseUpdate(constructor, fieldTypes.map { tpe => ValueVar(TmpValue(), tpe) })
+        varsFor.getOrElseUpdate(constructor, fieldTypes.map { tpe => ValueVar(TmpValue("fieldValue"), tpe) })
 
       normalized.foreach {
         case Clause(Split(Pattern.Tag(constructor, patternsAndTypes), restPatterns, restConds), label, args) =>

--- a/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
@@ -198,7 +198,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
       if (coerce.isIdentity) {
         List(Definition.Let(id, transform(tpe), transform(binding)))
       } else {
-        val orig = TmpValue()
+        val orig = TmpValue("letDefinition")
         val origTpe = binding.tpe
         List(
           Definition.Let(orig, origTpe, transform(binding)),
@@ -248,7 +248,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
       if (coerce.isIdentity) {
         Stmt.Val(id, transform(tpe), transform(binding), transform(body))
       } else {
-        val orig = TmpValue()
+        val orig = TmpValue("valStatement")
         Stmt.Val(orig, binding.tpe, transform(binding),
           Let(id, transform(binding.tpe), coerce(Pure.ValueVar(orig, binding.tpe)),
             transform(body)))
@@ -508,9 +508,9 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
         override def to = totpe
 
         override def apply(block: B): B = {
-          val vparams: List[Param.ValueParam] = vcoercers.map { c => Param.ValueParam(TmpValue(), transform(c.from)) }
-          val bparams: List[Param.BlockParam] = bcoercers.map { c => val id = TmpBlock(); Param.BlockParam(id, transform(c.from), Set(id)) }
-          val result = TmpValue()
+          val vparams: List[Param.ValueParam] = vcoercers.map { c => Param.ValueParam(TmpValue("valueParam"), transform(c.from)) }
+          val bparams: List[Param.BlockParam] = bcoercers.map { c => val id = TmpBlock("blockParam"); Param.BlockParam(id, transform(c.from), Set(id)) }
+          val result = TmpValue("applicationResult")
           val inner = TmpBlock()
           val vargs = (vcoercers zip vparams).map { case (c, p) => c(Pure.ValueVar(p.id, p.tpe)) }
           val bargs = (bcoercers zip bparams).map { case (c, p) => c(Block.BlockVar(p.id, p.tpe, Set.empty)) }
@@ -525,7 +525,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
         }
 
         override def callDirect(block: B, vargs: List[Pure], bargs: List[Block])(using PContext): Expr = {
-          val result = TmpValue()
+          val result = TmpValue("callDirectResult")
           Run(Let(result, rcoercer.from, DirectApp(block, targs map transformArg,
             (vcoercers zip vargs).map {case (c,v) => c(v)},
             (bcoercers zip bargs).map {case (c,b) => c(b)}),
@@ -533,7 +533,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
         }
 
         override def call(block: B, vargs: List[Pure], bargs: List[Block])(using PContext): Stmt = {
-          val result = TmpValue()
+          val result = TmpValue("callResult")
           Stmt.Val(result, rcoercer.from, Stmt.App(block, targs map transformArg,
             (vcoercers zip vargs).map { case (c, v) => c(v) },
             (bcoercers zip bargs).map { case (c, b) => c(b) }),

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -427,7 +427,7 @@ object normal {
       case x: Block.BlockVar => bvars = bvars :+ x
       // introduce a binding
       case block =>
-        val id = symbols.TmpBlock()
+        val id = symbols.TmpBlock("blockBinding")
         bindings = bindings :+ Definition.Def(id, block)
         bvars = bvars :+ Block.BlockVar(id, block.tpe, block.capt)
         ids += id

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -97,9 +97,11 @@ ${indentedLines(instructions.map(show).mkString("\n"))}
     case ExtractValue(result, aggregate, index) =>
       s"${localName(result)} = extractvalue ${show(aggregate)}, $index"
 
-    case Comment(msg) =>
+    case Comment(msg) if C.config.debug() =>
       val sanitized = msg.map((c: Char) => if (' ' <= c && c != '\\' && c <= '~') c else '?').mkString
       s"\n; $sanitized"
+
+    case Comment(msg) => ""
   }
 
   def show(terminator: Terminator): LLVMString = terminator match {

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -99,7 +99,7 @@ ${indentedLines(instructions.map(show).mkString("\n"))}
 
     case Comment(msg) =>
       val sanitized = msg.map((c: Char) => if (' ' <= c && c != '\\' && c <= '~') c else '?').mkString
-      s"; $sanitized"
+      s"\n; $sanitized"
   }
 
   def show(terminator: Terminator): LLVMString = terminator match {

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -604,7 +604,7 @@ object Transformer {
     val `type` = environmentType(environment)
     environment.zipWithIndex.foreach {
       case (machine.Variable(name, tpe), i) =>
-        val field = LocalReference(PointerType(), freshName(name + "p"));
+        val field = LocalReference(PointerType(), freshName(name + "_pointer"));
         emit(GetElementPtr(field.name, `type`, pointer, List(0, i)));
         emit(Store(field, transform(machine.Variable(name, tpe))))
     }
@@ -614,7 +614,7 @@ object Transformer {
     val `type` = environmentType(environment)
     environment.zipWithIndex.foreach {
       case (machine.Variable(name, tpe), i) =>
-        val field = LocalReference(PointerType(), freshName(name + "p"));
+        val field = LocalReference(PointerType(), freshName(name + "_pointer"));
         emit(GetElementPtr(field.name, `type`, pointer, List(0, i)));
         emit(Load(name, transform(tpe), field))
     }

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -100,7 +100,7 @@ object Transformer {
       case machine.Construct(variable, tag, values, rest) =>
         emit(Comment("statement construct"))
         val `object` = produceObject(values, freeVariables(rest))
-        val temporaryName = freshName("temporary")
+        val temporaryName = "temporary_" + variable.name
         emit(InsertValue(temporaryName, ConstantAggregateZero(positiveType), ConstantInt(tag), 0))
         emit(InsertValue(variable.name, LocalReference(positiveType, temporaryName), `object`, 1))
 
@@ -170,7 +170,7 @@ object Transformer {
         emit(GlobalConstant(arrayName, ConstantArray(methodType, clauseNames)))
 
         val `object` = produceObject(closureEnvironment, freeVariables(rest));
-        val temporaryName = freshName("temporary");
+        val temporaryName = "temporary_" + arrayName;
         emit(InsertValue(temporaryName, ConstantAggregateZero(negativeType), ConstantGlobal(PointerType(), arrayName), 0));
         emit(InsertValue(variable.name, LocalReference(negativeType, temporaryName), `object`, 1));
 
@@ -198,7 +198,7 @@ object Transformer {
         emit(Comment("statement allocate"))
         val idx = regionIndex(ref.tpe)
 
-        val temporary = freshName("temporary")
+        val temporary = freshName("temporaryEvidence")
         val temporaryRef = LocalReference(StructureType(List(PointerType(), referenceType)), temporary)
         emit(Call(temporary, temporaryRef.tpe, alloc, List(ConstantInt(idx), transform(evidence))));
 
@@ -364,7 +364,7 @@ object Transformer {
         emit(Comment("statement popStacks"))
         // TODO Handle n (n+1 = number of stacks to pop)
         val newStackPointerName = freshName("stackPointer");
-        val temporaryName = freshName("temporary");
+        val temporaryName = "temporary_" + newStackPointerName;
         val temporaryReference = LocalReference(StructureType(List(stackType, stackPointerType)), temporaryName);
         emit(Call(temporaryName, StructureType(List(stackType, stackPointerType)), popStacks, List(getStackPointer(), transform(n))));
         emit(ExtractValue(variable.name, temporaryReference, 0));

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -212,8 +212,8 @@ case class CallTarget(symbols: List[Set[BlockSymbol]]) extends BlockSymbol { val
  * Introduced by Transformer
  */
 case class Wildcard() extends ValueSymbol { val name = Name.local("_") }
-case class TmpValue() extends ValueSymbol { val name = Name.local("tmp" + Symbol.fresh.next()) }
-case class TmpBlock() extends BlockSymbol { val name = Name.local("tmp" + Symbol.fresh.next()) }
+case class TmpValue(hint: String = "temporary") extends ValueSymbol { val name = Name.local(hint + "_" + Symbol.fresh.next()) }
+case class TmpBlock(hint: String = "temporary") extends BlockSymbol { val name = Name.local(hint + "_" + Symbol.fresh.next()) }
 
 /**
  * Type Symbols


### PR DESCRIPTION
This is a follow-up from #509 and therefore closes #513.

I believe descriptive code generation to be the one of the most important aspects in making LLVM debugging simpler and more approachable to new contributors/students. This PR extends upon my previous improvements:

- refactor previously missed abbreviations
- name temporary and single-letter variables according to their rough context in source/core
- add context to comments (e.g. for substitution as suggested by @jiribenes)
- add newlines before comments (as suggested by @b-studios)
- only generate comments in `--debug` mode (as suggested by @jiribenes)

I think some of the "doubly freshened" variables could be removed since previous stages already give some guarantees about their distinctness. I didn't touch that though as this seems rather risky.

Comparing the snippet from the previous PR from `triples.effekt` shows some of the improvements:


<table>
<tr>
<th>Previously</th>
<th>Now</th>
</tr>
<tr>
<td>

```llvm
define fastcc void @returnAddress_27(%Environment %environment, %StackPointer %stackPointer) {
        
    entry:
        ; statement pushFrame / return address
        %stackPointer_28 = getelementptr {%Stack}, %StackPointer %stackPointer, i64 -1
        %resume12_7430p_29 = getelementptr {%Stack}, %StackPointer %stackPointer_28, i64 0, i32 0
        %resume12_7430 = load %Stack, ptr %resume12_7430p_29
        %run_7511p_30 = getelementptr {%Pos}, %Environment %environment, i64 0, i32 0
        %run_7511 = load %Pos, ptr %run_7511p_30
        ; statement substitution
        ; statement literalEvidence
        %evidenceZero_7509 = add i64 0, 0
        ; statement construct
        %tmp_31 = insertvalue %Pos zeroinitializer, i64 0, 0
        %booleanLiteral_7510 = insertvalue %Pos %tmp_31, %Object null, 1
        ; statement pushStack
        %stack_32 = call %Stack @uniqueStack(%Stack %resume12_7430)
        %stackPointer_33 = call %StackPointer @pushStack(%Stack %stack_32, %StackPointer %stackPointer_28)
        ; statement return
        %booleanLiteral_7510p_34 = getelementptr {%Pos}, %Environment %environment, i64 0, i32 0
        store %Pos %booleanLiteral_7510, ptr %booleanLiteral_7510p_34
        %stackPointer_36 = getelementptr %FrameHeader, %StackPointer %stackPointer_33, i64 -1
        %returnAddressPointer_37 = getelementptr %FrameHeader, %StackPointer %stackPointer_36, i64 0, i32 0
        %returnAddress_35 = load %ReturnAddress, ptr %returnAddressPointer_37
        tail call fastcc void %returnAddress_35(%Environment %environment, %StackPointer %stackPointer_36)
        ret void
}

...

define fastcc void @effektMain() {
        
    entry:
        ; program
        %environment = call %Environment @malloc(i64 1048576)
        %stackPointer = call %StackPointer @malloc(i64 268435456)
        store %StackPointer %stackPointer, ptr @base
        %returnAddressPointer_1 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 0
        %sharerPointer_2 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 1
        %eraserPointer_3 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 2
        store %ReturnAddress @topLevel, ptr %returnAddressPointer_1
        store %Sharer @topLevelSharer, ptr %sharerPointer_2
        store %Eraser @topLevelEraser, ptr %eraserPointer_3
        %stackPointer_4 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 1
        ; statement jump
        tail call fastcc void @main_7256(%Environment %environment, %StackPointer %stackPointer_4)
        ret void
}
```
</td>
<td>

```llvm
define fastcc void @returnAddress_27(%Environment %environment, %StackPointer %stackPointer) {
        
    entry:
        
        ; statement pushFrame / return address, 1 free variables
        %stackPointer_28 = getelementptr {%Stack}, %StackPointer %stackPointer, i64 -1
        %resume12_3393_pointer_29 = getelementptr {%Stack}, %StackPointer %stackPointer_28, i64 0, i32 0
        %resume12_3393 = load %Stack, ptr %resume12_3393_pointer_29
        %run_3475_pointer_30 = getelementptr {%Pos}, %Environment %environment, i64 0, i32 0
        %run_3475 = load %Pos, ptr %run_3475_pointer_30
        
        ; statement substitution
        
        ; substitution [_13_3390 !-> run_3475]
        
        ; statement literalEvidence evidenceZero_3473, n=0
        %evidenceZero_3473 = add i64 0, 0
        
        ; statement construct booleanLiteral_3474, tag 0, 0 values
        %booleanLiteral_3474_temporary_31 = insertvalue %Pos zeroinitializer, i64 0, 0
        %booleanLiteral_3474 = insertvalue %Pos %booleanLiteral_3474_temporary_31, %Object null, 1
        
        ; statement pushStack resume12_3393
        %stack_32 = call %Stack @uniqueStack(%Stack %resume12_3393)
        %stackPointer_33 = call %StackPointer @pushStack(%Stack %stack_32, %StackPointer %stackPointer_28)
        
        ; statement return, 1 values
        %booleanLiteral_3474_pointer_34 = getelementptr {%Pos}, %Environment %environment, i64 0, i32 0
        store %Pos %booleanLiteral_3474, ptr %booleanLiteral_3474_pointer_34
        %stackPointer_36 = getelementptr %FrameHeader, %StackPointer %stackPointer_33, i64 -1
        %returnAddressPointer_37 = getelementptr %FrameHeader, %StackPointer %stackPointer_36, i64 0, i32 0
        %returnAddress_35 = load %ReturnAddress, ptr %returnAddressPointer_37
        tail call fastcc void %returnAddress_35(%Environment %environment, %StackPointer %stackPointer_36)
        ret void
}

...

define fastcc void @effektMain() {
        
    entry:
        
        ; program, 10 declarations
        %environment = call %Environment @malloc(i64 1048576)
        %stackPointer = call %StackPointer @malloc(i64 268435456)
        store %StackPointer %stackPointer, ptr @base
        %returnAddressPointer_1 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 0
        %sharerPointer_2 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 1
        %eraserPointer_3 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 2
        store %ReturnAddress @topLevel, ptr %returnAddressPointer_1
        store %Sharer @topLevelSharer, ptr %sharerPointer_2
        store %Eraser @topLevelEraser, ptr %eraserPointer_3
        %stackPointer_4 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 1
        
        ; statement jump main_2244
        tail call fastcc void @main_2244(%Environment %environment, %StackPointer %stackPointer_4)
        ret void
}
```

</td>
</tr>
</table>

Let me know if you have further ideas to make the generated code more readable.