### PR TITLE
JS: Parenthesize arguments of raw expresions

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -24,7 +24,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def toDoc(expr: Expr): Doc = expr match {
     case Call(callee, args)           => toDocParens(callee) <> parens(args map toDoc)
     case New(callee, args)            => "new" <+> toDocParens(callee) <> parens(args map toDoc)
-    case RawExpr(strings, args)       => hcat(intercalate(strings.map(string), args.map(toDoc)))
+    case RawExpr(strings, args)       => hcat(intercalate(strings.map(string), args.map(toDocAsAtom)))
     case Member(callee, selection)    => toDocParens(callee) <> "." <> toDoc(selection)
     case IfExpr(cond, thn, els)       => parens(toDoc(cond)) <+> "?" <+> toDoc(thn) <+> ":" <+> toDoc(els)
     case Lambda(params, Return(expr)) => parens(params map toDoc) <+> "=>" <> nested(toDoc(expr))
@@ -40,6 +40,14 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case e: IfExpr => parens(toDoc(e))
     case e: Lambda => parens(toDoc(e))
     case e => toDoc(e)
+  }
+
+  // to be used in really low precedence positions
+  def toDocAsAtom(e: Expr): Doc = e match {
+    case e: Variable => toDoc(e)
+    case e: Object => toDoc(e)
+    case e: ArrayLiteral => toDoc(e)
+    case e => parens(toDoc(e))
   }
 
   def toDoc(stmt: Stmt): Doc = stmt match {

--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -26,7 +26,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case New(callee, args)            => "new" <+> toDocParens(callee) <> parens(args map toDoc)
     case RawExpr(strings, args)       => hcat(intercalate(strings.map(string), args.map(toDoc)))
     case Member(callee, selection)    => toDocParens(callee) <> "." <> toDoc(selection)
-    case IfExpr(cond, thn, els)       => parens(parens(toDoc(cond)) <+> "?" <+> toDoc(thn) <+> ":" <+> toDoc(els))
+    case IfExpr(cond, thn, els)       => parens(toDoc(cond)) <+> "?" <+> toDoc(thn) <+> ":" <+> toDoc(els)
     case Lambda(params, Return(expr)) => parens(params map toDoc) <+> "=>" <> nested(toDoc(expr))
     case Lambda(params, Block(stmts)) => parens(params map toDoc) <+> "=>" <+> jsBlock(stmts.map(toDoc))
     case Lambda(params, body)         => parens(params map toDoc) <+> "=>" <> jsBlock(toDoc(body))

--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -25,6 +25,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Call(callee, args)           => toDocParens(callee) <> parens(args map toDoc)
     case New(callee, args)            => "new" <+> toDocParens(callee) <> parens(args map toDoc)
     case RawExpr(strings, args)       => hcat(intercalate(strings.map(string), args.map(toDocAsAtom)))
+    case RawLiteral(content)          => string(content)
     case Member(callee, selection)    => toDocParens(callee) <> "." <> toDoc(selection)
     case IfExpr(cond, thn, els)       => parens(toDoc(cond)) <+> "?" <+> toDoc(thn) <+> ":" <+> toDoc(els)
     case Lambda(params, Return(expr)) => parens(params map toDoc) <+> "=>" <> nested(toDoc(expr))
@@ -47,6 +48,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case e: Variable => toDoc(e)
     case e: Object => toDoc(e)
     case e: ArrayLiteral => toDoc(e)
+    case e: RawLiteral => toDoc(e)
     case e => parens(toDoc(e))
   }
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
@@ -127,7 +127,7 @@ object TransformerDirect extends Transformer {
   def toJS(expr: core.Expr)(using TransformerContext): js.Expr = expr match {
     case Literal((), _) => $effekt.field("unit")
     case Literal(s: String, _) => JsString(escape(s))
-    case literal: Literal => js.RawExpr(literal.value.toString)
+    case literal: Literal => js.RawLiteral(literal.value.toString)
     case ValueVar(id, tpe) => nameRef(id)
     case DirectApp(b, targs, vargs, bargs) => js.Call(toJS(b), vargs.map(toJS) ++ bargs.map(toJS))
     case PureApp(b, targs, vargs) => js.Call(toJS(b), vargs map toJS)

--- a/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
@@ -100,6 +100,10 @@ enum Expr {
   //   raw JS splices, always start with a prefix string, then interleaved with arguments
   case RawExpr(raw: List[String], args: List[Expr])
 
+  // e.g. 42
+  //   raw JS literal, already converted to a string. Similar to RawExpr but will not be parenthesized
+  case RawLiteral(raw: String)
+
   // e.g. (<EXPR> ? <EXPR> : <EXPR>)
   case IfExpr(cond: Expr, thn: Expr, els: Expr)
 
@@ -196,7 +200,7 @@ def MethodCall(receiver: Expr, method: JSName, args: Expr*): Expr = Call(Member(
 
 def Lambda(params: List[JSName], body: Expr): Expr = Lambda(params, Return(body))
 
-def JsString(scalaString: String): Expr = RawExpr(s"\"${scalaString}\"")
+def JsString(scalaString: String): Expr = RawLiteral(s"\"${scalaString}\"")
 
 def Object(properties: (JSName, Expr)*): Expr = Object(properties.toList)
 
@@ -206,7 +210,7 @@ def MaybeBlock(stmts: List[Stmt]): Stmt = stmts match {
   case head :: next => js.Block(stmts)
 }
 
-val Undefined = RawExpr("undefined")
+val Undefined = RawLiteral("undefined")
 
 object monadic {
 

--- a/examples/pos/issue505.check
+++ b/examples/pos/issue505.check
@@ -1,0 +1,4 @@
+false
+true
+true
+true

--- a/examples/pos/issue505.effekt
+++ b/examples/pos/issue505.effekt
@@ -1,0 +1,7 @@
+def main() = {
+  println("abc" == "def");
+  println(("abc" == "def").not);
+  println(not ("abc" == "def"));
+  val huh = "abc" == "def";
+  println(huh.not);
+}


### PR DESCRIPTION
Fixes #505 by parenthesizing the arguments of `RawExpr`s unless they are already atomic expressions.

Also tries to add few parentheses into the generated code.