### PR TITLE
Cleanup for #531

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -48,7 +48,6 @@ object PrettyPrinter extends ParenPrettyPrinter {
   // to be used in really low precedence positions
   def toDocAsAtom(e: Expr): Doc = e match {
     case e: Variable => toDoc(e)
-    case e: Object => toDoc(e)
     case e: ArrayLiteral => toDoc(e)
     case e: RawLiteral => toDoc(e)
     case e => parens(toDoc(e))

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -110,7 +110,7 @@ extern io def inspect[R](value: R): Unit =
 // Strings
 // =======
 extern pure def infixConcat(s1: String, s2: String): String =
-  js "((${s1}) + (${s2}))"
+  js "${s1} + ${s2}"
   chez "(string-append ${s1} ${s2})"
   llvm """
     %spz = call %Pos @c_bytearray_concatenate(%Pos ${s1}, %Pos ${s2})


### PR DESCRIPTION
This fixes the things noted in #531 (mostly a draft PR so I don't forget):

- [x] Double-check whether we need to parenthesize objects or literals in certain places.
    - Yes, we have to:
        - [x] objects
        - [ ] int and double literals
- [x] Delete double-parens in stdlib (hotfixes from earlier).