### PR TITLE
Add 'process' module with 'exit' function

### DIFF
--- a/libraries/common/process.effekt
+++ b/libraries/common/process.effekt
@@ -7,4 +7,4 @@ extern io def exit(errorCode: Int): Nothing =
     ret %Pos zeroinitializer
   """
   chez "(exit ${errorCode})"
-  ml "(POSIX.Process.exit (Word8.fromInt ${errorCode}))"
+  ml "(Posix.Process.exit (Word8.fromInt ${errorCode}))"

--- a/libraries/common/process.effekt
+++ b/libraries/common/process.effekt
@@ -7,3 +7,4 @@ extern io def exit(errorCode: Int): Nothing =
     ret %Pos zeroinitializer
   """
   chez "(exit ${errorCode})"
+  ml "(POSIX.Process.exit (Word8.fromInt ${errorCode}))"

--- a/libraries/common/process.effekt
+++ b/libraries/common/process.effekt
@@ -1,0 +1,9 @@
+module process
+
+extern io def exit(errorCode: Int): Nothing =
+  js   "(function() { process.exit(${errorCode}) })()"
+  llvm """
+    call void @exit(i64 %errorCode)
+    ret %Pos zeroinitializer
+  """
+  chez "(exit ${errorCode})"

--- a/libraries/common/test.effekt
+++ b/libraries/common/test.effekt
@@ -93,6 +93,6 @@ def suite(name: String) { body: => Unit / Test }: Bool = {
 /// Use as `def main() = mainSuite("...") { ... }`
 def mainSuite(name: String) { body: => Unit / Test }: Unit = {
   val result = suite(name) { body() }
-  val exitCode = if (result) { 0 } else { 1 }
+  val exitCode = if (result) 0 else 1
   exit(exitCode)
 }

--- a/libraries/common/test.effekt
+++ b/libraries/common/test.effekt
@@ -1,4 +1,5 @@
 import string
+import process
 
 interface Assertion {
   def assert(condition: Bool, msg: String): Unit
@@ -87,4 +88,11 @@ def suite(name: String) { body: => Unit / Test }: Bool = {
     println(ANSI::GREEN ++ "All tests passed (" ++ passed.show ++ " passed)" ++ ANSI::RESET)
     true
   }
+}
+
+/// Use as `def main() = mainSuite("...") { ... }`
+def mainSuite(name: String) { body: => Unit / Test }: Unit = {
+  val result = suite(name) { body() }
+  val exitCode = if (result) { 0 } else { 1 }
+  exit(exitCode)
 }


### PR DESCRIPTION
Added a quick way to exit the running process by calling `exit(exitCode: Int)`.
I don't know what should the module name here should be:
- `process`
- `io/process`
- `sys`
- `os`
- `exit`

Should the capture be just `io`, or should there also be some other `exit` resource so that we know nothing weird happens inside of promises?