### PR TITLE
Implement a proper wellformedness check

### DIFF
--- a/effekt/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Annotations.scala
@@ -134,6 +134,14 @@ object Annotations {
   )
 
   /**
+   * Existential type parameters inferred by the typer when type-checking pattern matches.
+   */
+  val TypeParameters = Annotation[source.TagPattern | source.OpClause, List[symbols.TypeVar]](
+    "TypeParameters",
+    "the existentials of the constructor pattern or operation clause"
+  )
+
+  /**
    * Value type of symbols like value binders or value parameters
    */
   val ValueType = Annotation[symbols.ValueSymbol, symbols.ValueType](

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -22,6 +22,7 @@ object TypePrinter extends ParenPrettyPrinter {
     case name: QualifiedName => name.qualifiedName
   }
   def show(t: Type): String = pretty(toDoc(t), 80).layout
+  def show(t: TypeVar): String = pretty(toDoc(t), 80).layout
   def show(t: Capture): String = pretty(toDoc(t), 80).layout
   def show(t: Captures): String = pretty(toDoc(t), 80).layout
   def show(t: Effects): String = pretty(toDoc(t), 80).layout
@@ -32,6 +33,7 @@ object TypePrinter extends ParenPrettyPrinter {
     case id: source.IdDef   => TypePrinter.show(id)
     case n: Name            => TypePrinter.show(n)
     case t: symbols.Type    => TypePrinter.show(t)
+    case t: symbols.TypeVar => TypePrinter.show(t)
     case t: Capture         => TypePrinter.show(t)
     case t: Captures        => TypePrinter.show(t)
     case t: Effects         => TypePrinter.show(t)

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -322,9 +322,6 @@ sealed trait CaptVar extends TypeSymbol
 /**
  * "Tracked" capture parameters. Like [[TypeParam]] used to abstract
  * over capture. Also see [[BlockParam.capture]].
- *
- * Can be either
- * - [[LexicalRegion]] to model self regions of functions
  */
 enum Capture extends CaptVar {
 

--- a/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
@@ -67,6 +67,16 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
           types =>
             pp"Type variable(s) ${showTypes(types)} escape their scope as part of the return type ${tpe}"
         }
+
+        val varTpe = Context.inferredTypeOf(rhs)
+
+        wellformed(varTpe, stmt) {
+          case captures =>
+            pp"Capture(s) ${showCaptures(captures)} escape their scope as part of the inferred type ${varTpe} of mutable variable ${id}"
+        } {
+          types =>
+            pp"Type variable(s) ${showTypes(types)} escape their scope as part of the inferred type ${varTpe} of mutable variable ${id}"
+        }
       }
   }
 

--- a/examples/neg/issue512.effekt
+++ b/examples/neg/issue512.effekt
@@ -1,0 +1,14 @@
+interface Ref[T] {
+  def get(): T
+}
+
+def main() = {
+  var myref =
+    region r1 { // ERROR r1
+      var x in r1 = "hoho";
+      new Ref[String] {
+        def get() = x
+      }
+    }
+  println(myref.get())
+}

--- a/examples/neg/issue537.effekt
+++ b/examples/neg/issue537.effekt
@@ -1,0 +1,8 @@
+interface Greet { def sayHello(): Unit }
+
+def main() = {
+  var f = box { () } // ERROR escape
+  try { f = box { g.sayHello() } }
+  with g: Greet { def sayHello() = println("hello!") }
+  f()
+}

--- a/examples/neg/issue548a.effekt
+++ b/examples/neg/issue548a.effekt
@@ -1,0 +1,18 @@
+interface Time {
+  def now(): Int
+}
+
+def withTime[A] { prog: { Time } => A }: A =
+  try {
+    prog {timeCap}
+  } with timeCap: Time {
+    def now() = resume(1)
+  }
+
+def main() = {
+  def b { t: Time }: Time at {t} = box t;  // this is fine
+  val cap = withTime {b} // ERROR escape
+  def t2: Time = unbox cap
+  t2.now();
+  ()
+}

--- a/examples/neg/issue548b.effekt
+++ b/examples/neg/issue548b.effekt
@@ -1,0 +1,6 @@
+def hof[A] { prog: [B](B) => A }: A = prog[String]("hello")
+
+def main() = {
+  val res = hof { [C](x: C) => x }; // ERROR escape
+  println(res.genericShow)
+}

--- a/examples/neg/issue548c.effekt
+++ b/examples/neg/issue548c.effekt
@@ -1,0 +1,10 @@
+type Box { Wrap[X](x: X) }
+
+def main() = {
+  val res = Wrap[Int](5) match {
+    case Wrap(y) => // ERROR escape
+      val res = y;
+      res
+  };
+  ()
+}

--- a/examples/neg/issue548c.effekt
+++ b/examples/neg/issue548c.effekt
@@ -1,8 +1,8 @@
 type Box { Wrap[X](x: X) }
 
 def main() = {
-  val res = Wrap[Int](5) match {
-    case Wrap(y) => // ERROR escape
+  val res = Wrap[Int](5) match { // ERROR escape
+    case Wrap(y) =>
       val res = y;
       res
   };

--- a/examples/neg/lambdas/capability_closure.check
+++ b/examples/neg/lambdas/capability_closure.check
@@ -1,3 +1,3 @@
-[error] examples/neg/lambdas/capability_closure.effekt:14:17: Captures {Get$capability} escape through return type () => Int at {Get$capability}
+[error] examples/neg/lambdas/capability_closure.effekt:14:17: Capture Get$capability escapes through type () => Int at {Get$capability} inferred as return type of operation get.
     def get() = resume(42)
                 ^^^^^^^^^^

--- a/examples/neg/lambdas/capability_closure.check
+++ b/examples/neg/lambdas/capability_closure.check
@@ -1,3 +1,3 @@
-[error] examples/neg/lambdas/capability_closure.effekt:11:15: The return type () => Int at {Get$capability} of the handled statement is not allowed to refer to any of the bound capabilities, but mentions: {Get$capability}
-  val f = try { //@Get =>
-              ^
+[error] examples/neg/lambdas/capability_closure.effekt:14:17: Captures {Get$capability} escape through return type () => Int at {Get$capability}
+    def get() = resume(42)
+                ^^^^^^^^^^

--- a/examples/neg/lambdas/closure.check
+++ b/examples/neg/lambdas/closure.check
@@ -1,3 +1,3 @@
-[error] examples/neg/lambdas/closure.effekt:12:18: Captures {Yield$capability} escape through return type () => Unit at {Yield$capability}
+[error] examples/neg/lambdas/closure.effekt:12:18: Capture Yield$capability escapes through type () => Unit at {Yield$capability} inferred as return type of operation Yield.
   } with Yield { println("yielded!"); resume(()) }
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/neg/lambdas/closure.check
+++ b/examples/neg/lambdas/closure.check
@@ -1,3 +1,3 @@
-[error] examples/neg/lambdas/closure.effekt:6:15: The return type () => Unit at {Yield$capability} of the handled statement is not allowed to refer to any of the bound capabilities, but mentions: {Yield$capability}
-  val f = try { // @Yield =>
-              ^
+[error] examples/neg/lambdas/closure.effekt:12:18: Captures {Yield$capability} escape through return type () => Unit at {Yield$capability}
+  } with Yield { println("yielded!"); resume(()) }
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/neg/lambdas/localstate.check
+++ b/examples/neg/lambdas/localstate.check
@@ -1,3 +1,3 @@
-[error] examples/neg/lambdas/localstate.effekt:4:3: Local variable y escapes through the returned value of type () => Unit at {x, y, io}.
-  var y = 1
-  ^
+[error] examples/neg/lambdas/localstate.effekt:5:17: Captures {x} escape through return type () => Unit at {x, y, io}
+  def local() = {
+                ^

--- a/examples/neg/lambdas/localstate.check
+++ b/examples/neg/lambdas/localstate.check
@@ -1,3 +1,3 @@
-[error] examples/neg/lambdas/localstate.effekt:5:17: Captures {x} escape through return type () => Unit at {x, y, io}
+[error] examples/neg/lambdas/localstate.effekt:5:17: Capture x escapes through type () => Unit at {x, y, io} inferred as return type of local.
   def local() = {
                 ^

--- a/examples/neg/lambdas/simpleescape.check
+++ b/examples/neg/lambdas/simpleescape.check
@@ -1,3 +1,3 @@
--[error] examples/neg/lambdas/simpleescape.effekt:15:5: Capture Raise$capability escapes through type () => Unit at {Raise$capability} inferred as return type of operation Raise.
+[error] examples/neg/lambdas/simpleescape.effekt:15:5: Capture Raise$capability escapes through type () => Unit at {Raise$capability} inferred as return type of operation Raise.
     println("exception" ++ msg); resume(())
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/neg/lambdas/simpleescape.check
+++ b/examples/neg/lambdas/simpleescape.check
@@ -1,3 +1,3 @@
-[error] examples/neg/lambdas/simpleescape.effekt:15:5: Captures {Raise$capability} escape through return type () => Unit at {Raise$capability}
+-[error] examples/neg/lambdas/simpleescape.effekt:15:5: Capture Raise$capability escapes through type () => Unit at {Raise$capability} inferred as return type of operation Raise.
     println("exception" ++ msg); resume(())
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/neg/lambdas/simpleescape.check
+++ b/examples/neg/lambdas/simpleescape.check
@@ -1,3 +1,3 @@
-[error] examples/neg/lambdas/simpleescape.effekt:6:7: The return type () => Unit at {Raise$capability} of the handled statement is not allowed to refer to any of the bound capabilities, but mentions: {Raise$capability}
-  try {
-      ^
+[error] examples/neg/lambdas/simpleescape.effekt:15:5: Captures {Raise$capability} escape through return type () => Unit at {Raise$capability}
+    println("exception" ++ msg); resume(())
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This is an attempt at fixing #548

Create a proper context tracking which bindings (types and captures) are in scope and then run the wellformedness check on inferred types.

TODO:

- [x] make sure that we catch all binding occurrences
- [x] make sure that we check all inferred types (type arguments, return types of functions and matches, ...)
- [x] treat existentials properly