### PR TITLE
Fix: Lexer crashes on unmatched `}`

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LexerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LexerTests.scala
@@ -19,7 +19,7 @@ class LexerTests extends munit.FunSuite {
     try {
       Lexer(StringSource(prog, "")).run()
     } catch {
-        case LexerError(msg, _, _) => fail(msg)
+        case LexerError(msg, start, end) => fail(s"$msg at $start...$end")
     }
 
   def assertFailure(prog: String)(using Location): Unit =
@@ -43,6 +43,18 @@ class LexerTests extends munit.FunSuite {
       `return`, `box`, `{`, `(`, `)`, `=>`, `(`, Ident("x"), `,`, Ident("y"), `)`, `}`, Newline,
       EOF
     )
+  }
+
+  test("braces") {
+    assertFailure("${}")
+    assertFailure("\" before ${ ${} } after\"")
+
+    assertSuccess("}")
+    assertSuccess("{}}")
+    assertSuccess("{ 42 ")
+    assertSuccess("\"${}}}}\"")
+    assertSuccess("\"}\"")
+    assertSuccess("\" before ${ \"${ 42 }\" } after\"")
   }
 
   test("numbers") {


### PR DESCRIPTION
Currently, the compiler crashes if the lexer encounters the program consisting of
- just a single `}`
- an unmatched `}`, that is without a matching `{` or `${`
- and probably more complex cases

This is due to these unsafe lines here 
https://github.com/effekt-lang/effekt/blob/d96a17b70f99099d9a77e7059ccde99be6511421/effekt/shared/src/main/scala/effekt/Lexer.scala#L296-L298
I forgot to fix when writing lexer.