### PR TITLE
Add `--version` CLI flag

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -6,8 +6,8 @@ import kiama.util.REPLConfig
 import org.rogach.scallop.{ ScallopOption, fileConverter, fileListConverter, longConverter, stringConverter, stringListConverter }
 
 class EffektConfig(args: Seq[String]) extends REPLConfig(args.takeWhile(_ != "--")) {
-  // Print version on `--version`
-  version(effekt.util.Version.effektVersion)
+  // Print version information on `--version` and `--help`
+  version(s"Effekt ${effekt.util.Version.effektVersion}")
 
   // Common
   // ------

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -6,6 +6,8 @@ import kiama.util.REPLConfig
 import org.rogach.scallop.{ ScallopOption, fileConverter, fileListConverter, longConverter, stringConverter, stringListConverter }
 
 class EffektConfig(args: Seq[String]) extends REPLConfig(args.takeWhile(_ != "--")) {
+  // Print version on `--version`
+  version(effekt.util.Version.effektVersion)
 
   // Common
   // ------


### PR DESCRIPTION
Resolves #540

Scallop already supports printing out a version just by calling `version(<your version identifier>)` (see docs [here](https://github.com/scallop/scallop/wiki/Help-information-printing#version-summary)), let's just use it :)

### Usage
```
$ effekt --version
Effekt 0.99.99+nightly
```
(I changed my version in `build.sbt` in order to make this very visible)

### Help page

The version also gets printed out on `--help`:
```
$ effekt --help
Effekt 0.99.99+nightly
 Common Options
  -c, --compile                  Compile the Effekt program to the backend
                                 specific representation
      --no-compile
  -b, --build                    Compile the Effekt program and build a backend
                                 specific executable
      --nobuild
  -o, --out  <arg>               Path to write generated files to (defaults to
                                 ./out)
      --includes  <arg>...       Path to consider for includes (can be set
                                 multiple times)
  -l, --lib  <arg>               Path to the standard library to be used
      --backend  <arg>           The backend that should be used Choices: js,
                                 js-web, chez-callcc, chez-monadic, chez-lift,
                                 llvm, ml
```

Note that we could add a larger "Usage: effekt ..."-style banner, see [here](https://github.com/scallop/scallop/wiki/Help-information-printing#help-page).