### PR TITLE
Cache sbt files in CI, update versions of CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,11 @@ jobs:
         submodules: 'true'
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 11
+        distribution: 'zulu'
+        cache: 'sbt'
 
     - name: Set up NodeJS
       uses: actions/setup-node@v1
@@ -45,9 +47,11 @@ jobs:
         submodules: 'true'
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 11
+        distribution: 'zulu'
+        cache: 'sbt'
 
     - name: Install MLton
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,19 @@ jobs:
     name: Build Effekt compiler and run one test
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
 
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: '11'
         distribution: 'zulu'
         cache: 'sbt'
 
     - name: Set up NodeJS
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: '12.x'
 
@@ -42,14 +42,14 @@ jobs:
     name: Build Effekt compiler and run tests
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'true'
 
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: '11'
         distribution: 'zulu'
         cache: 'sbt'
 
@@ -85,7 +85,7 @@ jobs:
       run: sudo apt-get install libuv1-dev
 
     - name: Set up NodeJS
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: '12.x'
 


### PR DESCRIPTION
Investigating #428 since I noticed that `setup-java` allows simple `sbt` caching when playing with https://github.com/effekt-lang/effekt/pull/538 :)