### PR TITLE
Use a relative path for loading the JS main

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -147,8 +147,9 @@ object JSNodeRunner extends Runner[String] {
   def build(path: String)(using C: Context): String =
     val out = C.config.outputPath().getAbsolutePath
     val jsFilePath = (out / path).canonicalPath.escape
+    val jsFileName = jsFilePath.split("/").last
     // create "executable" using shebang besides the .js file
-    val jsScript = s"require('${jsFilePath}').main()"
+    val jsScript = s"require('./${jsFileName}').main()"
     os match {
       case OS.POSIX =>
         val shebang = "#!/usr/bin/env node"

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -147,9 +147,10 @@ object JSNodeRunner extends Runner[String] {
   def build(path: String)(using C: Context): String =
     val out = C.config.outputPath().getAbsolutePath
     val jsFilePath = (out / path).canonicalPath.escape
-    val jsFileName = jsFilePath.split("/").last
+    val jsFileName = path.unixPath.split("/").last
     // create "executable" using shebang besides the .js file
     val jsScript = s"require('./${jsFileName}').main()"
+
     os match {
       case OS.POSIX =>
         val shebang = "#!/usr/bin/env node"
@@ -184,7 +185,7 @@ object JSWebRunner extends Runner[String] {
     import java.nio.file.Path
     val out = C.config.outputPath().getAbsolutePath
     val jsFilePath = (out / path).unixPath
-    val jsFileName = jsFilePath.split("/").last
+    val jsFileName = path.unixPath.split("/").last
     val htmlFilePath = jsFilePath.stripSuffix(s".$extension") + ".html"
     val mainName = "$" + jsFileName.stripSuffix(".js") + ".main"
     val htmlContent =


### PR DESCRIPTION
Currently, the generated script for loading the compiled JavaScript uses an absolute path.
This prevents moving the generated files.

This makes it so a relative path is used instead.