### PR TITLE
Also refer to main files and chez using a relative path

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -42,15 +42,44 @@ trait Runner[Executable] {
   /**
    * Creates a OS-specific script file that will execute the command when executed,
    * forwarding command line arguments.
+   * `$SCRIPT_DIR` refers to the directory the script is in.
+   * 
    * @return the actual name of the generated script (might be `!= name`)
    */
   def createScript(name: String, command: String*): String = os match {
     case OS.POSIX =>
-      IO.createFile(name, s"#!/bin/sh\n${command.mkString(" ")} \"$$@\"", true)
+      val computeScriptDir =
+        """# Determine the directory of the script
+          |if [ -n "$BASH_SOURCE" ]; then
+          |    # Bash
+          |    SCRIPT_DIR=$(dirname "$BASH_SOURCE")
+          |elif [ -n "$ZSH_VERSION" ]; then
+          |    # Zsh
+          |    SCRIPT_DIR=$(dirname "$0")
+          |elif [ -n "$KSH_VERSION" ]; then
+          |    # Ksh
+          |    SCRIPT_DIR=$(dirname "${.sh.file}")
+          |else
+          |    # POSIX shells (sh, dash, etc.)
+          |    SCRIPT_DIR=$(dirname "$0")
+          |fi
+          |""".stripMargin
+      IO.createFile(name, s"#!/bin/sh\n${computeScriptDir}\n${command.mkString(" ")} \"$$@\"", true)
       name
     case OS.Windows =>
+      val computeScriptDir =
+        """setlocal enabledelayedexpansion
+          |
+          |:: Get the directory of the batch file
+          |set "SCRIPT_DIR=%~dp0"
+          |
+          |:: Remove trailing backslash
+          |set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+          |""".stripMargin
       val batName = name + ".bat"
-      IO.createFile(batName, "@echo off\r\n" + command.mkString(" ") + " %*")
+      // replace UNIX-style variables in command: $SCRIPT_DIR  -->  %SCRIPT_DIR%
+      val cmd = command.mkString(" ").replaceAll("\\$([A-Za-z_][A-Za-z0-9_]*)", "%$1%")
+      IO.createFile(batName, s"@echo off\r\n${computeScriptDir}\r\n${cmd} %*")
       batName
   }
 
@@ -160,9 +189,10 @@ object JSNodeRunner extends Runner[String] {
 
       case OS.Windows =>
         val jsMainFilePath = jsFilePath.stripSuffix(s".$extension") + "__main.js"
+        val jsMainFileName = jsFileName.stripSuffix(s".$extension") + "__main.js"
         val exePath = jsFilePath.stripSuffix(s".$extension")
         IO.createFile(jsMainFilePath, jsScript)
-        createScript(exePath, "node", jsMainFilePath)
+        createScript(exePath, "node", "$SCRIPT_DIR/" + jsMainFileName)
     }
 }
 object JSWebRunner extends Runner[String] {
@@ -222,7 +252,8 @@ trait ChezRunner extends Runner[String] {
     val out = C.config.outputPath().getAbsolutePath
     val schemeFilePath = (out / path).canonicalPath.escape
     val exeScriptPath = schemeFilePath.stripSuffix(s".$extension")
-    createScript(exeScriptPath, "scheme", "--script", schemeFilePath)
+    val schemeFileName = ("./" + (path.unixPath.split('/').last)).escape
+    createScript(exeScriptPath, "scheme", "--script", "$SCRIPT_DIR/" + schemeFileName)
 }
 
 object ChezMonadicRunner extends ChezRunner {

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -50,7 +50,7 @@ trait Runner[Executable] {
     case OS.POSIX =>
       val computeScriptDir =
         """# Determine the directory of the script
-          |SCRIPT_DIR=$(dirname "$0")
+          |SCRIPT_DIR=$(dirname "$(realpath "$0")")
           |""".stripMargin
       IO.createFile(name, s"#!/bin/sh\n${computeScriptDir}\n${command.mkString(" ")} \"$$@\"", true)
       name

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -50,19 +50,7 @@ trait Runner[Executable] {
     case OS.POSIX =>
       val computeScriptDir =
         """# Determine the directory of the script
-          |if [ -n "$BASH_SOURCE" ]; then
-          |    # Bash
-          |    SCRIPT_DIR=$(dirname "$BASH_SOURCE")
-          |elif [ -n "$ZSH_VERSION" ]; then
-          |    # Zsh
-          |    SCRIPT_DIR=$(dirname "$0")
-          |elif [ -n "$KSH_VERSION" ]; then
-          |    # Ksh
-          |    SCRIPT_DIR=$(dirname "${.sh.file}")
-          |else
-          |    # POSIX shells (sh, dash, etc.)
-          |    SCRIPT_DIR=$(dirname "$0")
-          |fi
+          |SCRIPT_DIR=$(dirname "$0")
           |""".stripMargin
       IO.createFile(name, s"#!/bin/sh\n${computeScriptDir}\n${command.mkString(" ")} \"$$@\"", true)
       name


### PR DESCRIPTION
This continues the work from #566 to also work for scheme and also use relative paths in the generated bat/sh scripts.
For this to work, in some cases we want to be relative to the directory that contains the script (as opposed to cwd), which we compute dynamically.