### PR TITLE
Chez: make floor, ceil return int values

### DIFF
--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -434,12 +434,12 @@ extern pure def round(d: Double): Int =
 
 extern pure def floor(d: Double): Int =
   js "Math.floor(${d})"
-  chez "(floor ${d})"
+  chez "(flonum->fixnum (floor ${d}))"
   ml "Real.floor ${d}"
 
 extern pure def ceil(d: Double): Int =
   js "Math.ceil(${d})"
-  chez "(ceiling ${d})"
+  chez "(flonum->fixnum (ceiling ${d}))"
   ml "Real.ceil ${d}"
 
 def min(n: Int, m: Int): Int =


### PR DESCRIPTION
Currently, e.g., the following code:
```effekt
import array

def main() = {
  val x = allocate[Int]((12.7).ceil)
  ()
}
```
produces the following error on chez backends:
```
Exception in make-vector: 13.0 is not a valid vector length
[error] Process exited with non-zero exit code 255.
```

This PR fixes that.