### PR TITLE
CI: Update actions/setup-java to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         submodules: 'true'
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'zulu'
@@ -47,7 +47,7 @@ jobs:
         submodules: 'true'
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'zulu'


### PR DESCRIPTION
This should get rid of these annoying annotations in the `Actions` tab:
<img width="912" alt="Screenshot 2024-09-10 at 16 27 49" src="https://github.com/user-attachments/assets/7b539950-6546-4c06-b963-1275c33015aa">
