### PR TITLE
Use splices in LLVM templates

### DIFF
--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -46,15 +46,12 @@ object Transformer {
     case core.Extern.Def(name, tps, cparams, vparams, bparams, ret, capture, body) =>
       if (bparams.nonEmpty) then ErrorReporter.abort("Foreign functions currently cannot take block arguments.")
 
-      val transformedParams = vparams.map {
-        //  we do not use transform(ValueParam) here because we use the original name (e.g. %x and not %x1234)
-        case core.ValueParam(id, tpe) => Variable(id.name.name, transform(tpe))
-      }
-      noteDefinition(name, transformedParams, Nil) // TODO maybe use vparams.map(transform) here
+      val transformedParams = vparams.map(transform)
+      noteDefinition(name, transformedParams, Nil)
       val tBody = body match {
         case core.ExternBody.StringExternBody(ff, Template(strings, args)) =>
           ExternBody.StringExternBody(ff, Template(strings, args map {
-            case core.ValueVar(id, tpe) => Variable(id.name.name, transform(tpe))
+            case core.ValueVar(id, tpe) => Variable(transform(id), transform(tpe))
             case _ => ErrorReporter.abort("In the LLVM backend, only variables are allowed in templates")
           }))
         case core.ExternBody.Unsupported(err) =>

--- a/examples/llvm/unbox_let_nothing.effekt
+++ b/examples/llvm/unbox_let_nothing.effekt
@@ -3,7 +3,7 @@ type EMPTY {}
 extern io def exit(errorCode: Int): Unit =
   js   "(function() { process.exit(${errorCode}) })()"
   llvm """
-    call void @exit(i64 %errorCode)
+    call void @exit(i64 ${errorCode})
     ret %Pos zeroinitializer ;
   """
 

--- a/libraries/common/args.effekt
+++ b/libraries/common/args.effekt
@@ -81,7 +81,7 @@ namespace llvm {
 
   extern io def argument(i: Int): String =
     llvm """
-      %s = call %Pos @c_get_arg(%Int %i)
+      %s = call %Pos @c_get_arg(%Int ${i})
       ret %Pos %s
     """
 

--- a/libraries/common/array.effekt
+++ b/libraries/common/array.effekt
@@ -17,7 +17,7 @@ extern global def allocate[T](size: Int): Array[T] =
   js "(new Array(${size}))"
   chez "(make-vector ${size})" // creates an array filled with 0s on CS
   llvm """
-    %z = call %Pos @c_array_new(%Int %size)
+    %z = call %Pos @c_array_new(%Int ${size})
     ret %Pos %z
   """
 
@@ -55,7 +55,7 @@ extern pure def size[T](arr: Array[T]): Int =
   chez "(vector-length ${arr})"
   ml "Array.length ${arr}"
   llvm """
-    %z = call %Int @c_array_size(%Pos %arr)
+    %z = call %Int @c_array_size(%Pos ${arr})
     ret %Int %z
   """
 
@@ -70,7 +70,7 @@ extern global def unsafeGet[T](arr: Array[T], index: Int): T =
   chez "(vector-ref ${arr} ${index})"
   ml "Array.sub (${arr}, ${index})"
   llvm """
-    %z = call %Pos @c_array_get(%Pos %arr, %Int %index)
+    %z = call %Pos @c_array_get(%Pos ${arr}, %Int ${index})
     ret %Pos %z
   """
 
@@ -92,7 +92,7 @@ extern global def unsafeSet[T](arr: Array[T], index: Int, value: T): Unit =
   chez "(begin (vector-set! ${arr} ${index} ${value}) #f)"
   ml "Array.update (${arr}, ${index}, ${value})"
   llvm """
-    %z = call %Pos @c_array_set(%Pos %arr, %Int %index, %Pos %value)
+    %z = call %Pos @c_array_set(%Pos ${arr}, %Int ${index}, %Pos ${value})
     ret %Pos %z
   """
 

--- a/libraries/common/bytes.effekt
+++ b/libraries/common/bytes.effekt
@@ -13,7 +13,7 @@ extern type Bytes
 extern io def bytes(capacity: Int): Bytes =
   js "(new Uint8Array(${capacity}))"
   llvm """
-    %buf = call %Pos @c_buffer_construct_uninitialized(i64 %capacity)
+    %buf = call %Pos @c_buffer_construct_uninitialized(i64 ${capacity})
     ret %Pos %buf
   """
 
@@ -27,7 +27,7 @@ def copy(b: Bytes): Bytes = {
 extern io def copy(from: Bytes, to: Bytes, startFrom: Int, startTo: Int, length: Int): Unit =
   js "bytes$copy(${from}, ${to}, ${startFrom}, ${startTo}, ${length})"
   llvm """
-    call void @c_buffer_copy(%Pos %from, %Pos %to, i64 %startFrom, i64 %startTo, i64 %length)
+    call void @c_buffer_copy(%Pos ${from}, %Pos ${to}, i64 ${startFrom}, i64 ${startTo}, i64 ${length})
     ; return Unit
     ret %Pos zeroinitializer
   """
@@ -35,14 +35,14 @@ extern io def copy(from: Bytes, to: Bytes, startFrom: Int, startTo: Int, length:
 extern pure def size(b: Bytes): Int =
   js "${b}.length"
   llvm """
-    %size = call i64 @c_buffer_length(%Pos %b)
+    %size = call i64 @c_buffer_length(%Pos ${b})
     ret i64 %size
   """
 
 extern io def read(b: Bytes, index: Int): Byte =
   js "(${b})[${index}]"
   llvm """
-    %byte = call i8 @c_buffer_index(%Pos %b, i64 %index)
+    %byte = call i8 @c_buffer_index(%Pos ${b}, i64 ${index})
     ret i8 %byte
   """
 
@@ -50,7 +50,7 @@ extern io def read(b: Bytes, index: Int): Byte =
 extern io def write(b: Bytes, index: Int, value: Byte): Unit =
   js "bytes$set(${b}, ${index}, ${value})"
   llvm """
-    call void @c_buffer_set(%Pos %b, i64 %index, i8 %value)
+    call void @c_buffer_set(%Pos ${b}, i64 ${index}, i8 ${value})
     ; return Unit
     ret %Pos zeroinitializer
   """
@@ -75,7 +75,7 @@ def truncated(b: Bytes, n: Int): Bytes =
 extern pure def fromUTF8(s: String): Bytes =
   js "(new TextEncoder().encode(${s}))"
   llvm """
-    %copy = call %Pos @c_buffer_clone(%Pos %s)
+    %copy = call %Pos @c_buffer_clone(%Pos ${s})
     ret %Pos %copy
   """
 
@@ -83,7 +83,7 @@ extern pure def toUTF8(b: Bytes): String =
   js "(new TextDecoder('utf-8').decode(${b}))"
   // assuming the buffer is already in UTF-8
   llvm """
-    %copy = call %Pos @c_buffer_clone(%Pos %b)
+    %copy = call %Pos @c_buffer_clone(%Pos ${b})
     ret %Pos %copy
   """
 
@@ -94,7 +94,7 @@ namespace unsafe {
   extern io def slice(b: Bytes, offset: Int, length: Int): Bytes =
     js "new Uint8Array(${b}.buffer, ${offset}, ${length})"
     llvm """
-      %buf = call %Pos @c_buffer_slice(%Pos %b, i64 %offset, i64 %length)
+      %buf = call %Pos @c_buffer_slice(%Pos ${b}, i64 ${offset}, i64 ${length})
       ret %Pos %buf
     """
 

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -46,7 +46,7 @@ extern def println(value: String): Unit =
   js "$effekt.println(${value})"
   chez "(println_impl ${value})"
   llvm """
-    call void @c_io_println_String(%Pos %value)
+    call void @c_io_println_String(%Pos ${value})
     ret %Pos zeroinitializer ; Unit
   """
   ml { print(value); print("\n") }
@@ -65,7 +65,7 @@ extern pure def show(value: Int): String =
   chez "(show-number ${value})"
   ml "show'int ${value}"
   llvm """
-    %z = call %Pos @c_buffer_show_Int(%Int %value)
+    %z = call %Pos @c_buffer_show_Int(%Int ${value})
     ret %Pos %z
   """
 
@@ -76,7 +76,7 @@ extern pure def show(value: Double): String =
   chez "(show-number ${value})"
   ml "show'real ${value}"
   llvm """
-    %z = call %Pos @c_buffer_show_Double(%Double %value)
+    %z = call %Pos @c_buffer_show_Double(%Double ${value})
     ret %Pos %z
   """
 
@@ -91,13 +91,13 @@ extern pure def show(value: Char): String =
   chez "(string (integer->char ${value}))"
   ml "str (chr ${value})"
   llvm """
-    %z = call %Pos @c_buffer_show_Char(%Int %value)
+    %z = call %Pos @c_buffer_show_Char(%Int ${value})
     ret %Pos %z
   """
 
 extern pure def show(value: Byte): String =
   llvm """
-    %z = call %Pos @c_buffer_show_Byte(i8 %value)
+    %z = call %Pos @c_buffer_show_Byte(i8 ${value})
     ret %Pos %z
   """
 
@@ -117,7 +117,7 @@ extern pure def infixConcat(s1: String, s2: String): String =
   chez "(string-append ${s1} ${s2})"
   ml "${s1} ^ ${s2}"
   llvm """
-    %spz = call %Pos @c_buffer_concatenate(%Pos %s1, %Pos %s2)
+    %spz = call %Pos @c_buffer_concatenate(%Pos ${s1}, %Pos ${s2})
     ret %Pos %spz
   """
 
@@ -126,7 +126,7 @@ extern pure def length(str: String): Int =
   chez "(string-length ${str})"
   ml "String.size ${str}"
   llvm """
-    %x = call %Int @c_buffer_length(%Pos %str)
+    %x = call %Int @c_buffer_length(%Pos ${str})
     ret %Int %x
   """
 
@@ -135,7 +135,7 @@ extern pure def unsafeSubstring(str: String, from: Int, to: Int): String =
   chez "(substring ${str} ${from} ${to})" // potentially raises: "Exception in substring: ..."
   ml "String.extract (${str}, ${from}, SOME (${to} - ${from}))"
   llvm """
-    %x = call %Pos @c_buffer_substring(%Pos %str, i64 %from, i64 %to)
+    %x = call %Pos @c_buffer_substring(%Pos ${str}, i64 ${from}, i64 ${to})
     ret %Pos %x
   """
 
@@ -218,7 +218,7 @@ extern pure def infixEq(x: Int, y: Int): Bool =
   chez "(equal? ${x} ${y})"
   ml "${x} = ${y}"
   llvm """
-    %z = icmp eq %Int %x, %y
+    %z = icmp eq %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -229,7 +229,7 @@ extern pure def infixNeq(x: Int, y: Int): Bool =
   chez "(not (equal? ${x} ${y}))"
   ml "${x} <> ${y}"
   llvm """
-    %z = icmp ne %Int %x, %y
+    %z = icmp ne %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -240,7 +240,7 @@ extern pure def infixEq(x: Char, y: Char): Bool =
   chez "(equal? ${x} ${y})"
   ml "${x} = ${y}"
   llvm """
-    %z = icmp eq %Int %x, %y
+    %z = icmp eq %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -251,7 +251,7 @@ extern pure def infixNeq(x: Char, y: Char): Bool =
   chez "(not (equal? ${x} ${y}))"
   ml "${x} <> ${y}"
   llvm """
-    %z = icmp ne %Int %x, %y
+    %z = icmp ne %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -262,7 +262,7 @@ extern pure def infixEq(x: String, y: String): Bool =
   chez "(equal? ${x} ${y})"
   ml "${x} = ${y}"
   llvm """
-    %res = call %Pos @c_buffer_eq(%Pos %x, %Pos %y)
+    %res = call %Pos @c_buffer_eq(%Pos ${x}, %Pos ${y})
     ret %Pos %res
   """
 
@@ -273,8 +273,8 @@ extern pure def infixEq(x: Bool, y: Bool): Bool =
   chez "(equal? ${x} ${y})"
   ml "${x} = ${y}"
   llvm """
-    %slim_x = extractvalue %Pos %x, 0
-    %slim_y = extractvalue %Pos %y, 0
+    %slim_x = extractvalue %Pos ${x}, 0
+    %slim_y = extractvalue %Pos ${y}, 0
     %slim_z = icmp eq i64 %slim_x, %slim_y
     %fat_z = zext i1 %slim_z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
@@ -286,8 +286,8 @@ extern pure def infixNeq(x: Bool, y: Bool): Bool =
   chez "(not (equal? ${x} ${y}))"
   ml "${x} <> ${y}"
   llvm """
-    %slim_x = extractvalue %Pos %x, 0
-    %slim_y = extractvalue %Pos %y, 0
+    %slim_x = extractvalue %Pos ${x}, 0
+    %slim_y = extractvalue %Pos ${y}, 0
     %slim_z = icmp ne i64 %slim_x, %slim_y
     %fat_z = zext i1 %slim_z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
@@ -375,7 +375,7 @@ extern pure def sqrt(x: Double): Double =
   js "Math.sqrt(${x})"
   chez "(sqrt ${x})"
   ml "Math.sqrt ${x}"
-  llvm "%z = call %Double @llvm.sqrt.f64(double %x) ret %Double %z"
+  llvm "%z = call %Double @llvm.sqrt.f64(double ${x}) ret %Double %z"
 
 extern llvm """
 declare double @llvm.sqrt.f64(double %x)
@@ -419,13 +419,13 @@ extern pure def toInt(d: Double): Int =
   js "Math.trunc(${d})"
   chez "(flonum->fixnum ${d})"
   ml "Real.trunc ${d}"
-  llvm "%z = fptosi double %d to %Int ret %Int %z"
+  llvm "%z = fptosi double ${d} to %Int ret %Int %z"
 
 extern pure def toDouble(d: Int): Double =
   js "${d}"
   chez "${d}"
   ml "Real.fromInt ${d}"
-  llvm "%z = sitofp i64 %d to double ret double %z"
+  llvm "%z = sitofp i64 ${d} to double ret double %z"
 
 extern pure def round(d: Double): Int =
   js "Math.round(${d})"
@@ -460,7 +460,7 @@ extern pure def infixLt(x: Int, y: Int): Bool =
   chez "(< ${x} ${y})"
   ml "(${x}: int) < ${y}"
   llvm """
-    %z = icmp slt %Int %x, %y
+    %z = icmp slt %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -471,7 +471,7 @@ extern pure def infixLte(x: Int, y: Int): Bool =
   chez "(<= ${x} ${y})"
   ml "(${x}: int) <= ${y}"
   llvm """
-    %z = icmp sle %Int %x, %y
+    %z = icmp sle %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -482,7 +482,7 @@ extern pure def infixGt(x: Int, y: Int): Bool =
   chez "(> ${x} ${y})"
   ml "(${x}: int) > ${y}"
   llvm """
-    %z = icmp sgt %Int %x, %y
+    %z = icmp sgt %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -493,7 +493,7 @@ extern pure def infixGte(x: Int, y: Int): Bool =
   chez "(>= ${x} ${y})"
   ml "(${x}: int) >= ${y}"
   llvm """
-    %z = icmp sge %Int %x, %y
+    %z = icmp sge %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -514,7 +514,7 @@ extern pure def infixLt(x: Double, y: Double): Bool =
   chez "(< ${x} ${y})"
   ml "(${x}: real) < ${y}"
   llvm """
-    %z = fcmp olt %Double %x, %y
+    %z = fcmp olt %Double ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -530,7 +530,7 @@ extern pure def infixGt(x: Double, y: Double): Bool =
   chez "(> ${x} ${y})"
   ml "(${x}: real) > ${y}"
   llvm """
-    %z = fcmp ogt %Double %x, %y
+    %z = fcmp ogt %Double ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -570,7 +570,7 @@ extern pure def not(b: Bool): Bool =
   chez "(not ${b})"
   ml "not ${b}"
   llvm """
-    %p = extractvalue %Pos %b, 0
+    %p = extractvalue %Pos ${b}, 0
     %q = xor i64 1, %p
     %adt_q = insertvalue %Pos zeroinitializer, i64 %q, 0
     ret %Pos %adt_q
@@ -588,28 +588,28 @@ def infixAnd { first: => Bool } { second: => Bool }: Bool =
 extern pure def bitwiseShl(x: Int, y: Int): Int =
   js "(${x} << ${y})"
   chez "(ash ${x} ${y})"
-  llvm "%z = shl %Int %x, %y ret %Int %z"
+  llvm "%z = shl %Int ${x}, ${y} ret %Int %z"
 
 extern pure def bitwiseAnd(x: Int, y: Int): Int =
   js "(${x} & ${y})"
   chez "(logand ${x} ${y})"
-  llvm "%z = and %Int %x, %y ret %Int %z"
+  llvm "%z = and %Int ${x}, ${y} ret %Int %z"
 
 extern pure def bitwiseXor(x: Int, y: Int): Int =
   js "(${x} ^ ${y})"
   chez "(logxor ${x} ${y})"
-  llvm "%z = xor %Int %x, %y ret %Int %z"
+  llvm "%z = xor %Int ${x}, ${y} ret %Int %z"
 
 
 // Byte operations
 // ===============
 extern pure def toByte(n: Int): Byte =
   js "${n}"
-  llvm "%z = trunc %Int %n to %Byte ret %Byte %z"
+  llvm "%z = trunc %Int ${n} to %Byte ret %Byte %z"
 
 extern pure def toInt(n: Byte): Int =
   js "${n}"
-  llvm "%z = zext %Byte %n to %Int ret %Int %z"
+  llvm "%z = zext %Byte ${n} to %Int ret %Int %z"
 
 
 // Undefined and Null
@@ -703,27 +703,27 @@ namespace internal {
     extern type BoxedInt
     extern pure def boxInt(n: Int): BoxedInt =
       llvm """
-        %boxed1 = insertvalue %Pos zeroinitializer, i64 %n, 0
+        %boxed1 = insertvalue %Pos zeroinitializer, i64 ${n}, 0
         %boxed2 = insertvalue %Pos %boxed1, %Object null, 1
         ret %Pos %boxed2
       """
     extern pure def unboxInt(b: BoxedInt): Int =
       llvm """
-        %unboxed = extractvalue %Pos %b, 0
+        %unboxed = extractvalue %Pos ${b}, 0
         ret %Int %unboxed
       """
 
     extern type BoxedByte
     extern pure def boxByte(n: Byte): BoxedByte =
       llvm """
-        %extended = sext i8 %n to i64
+        %extended = sext i8 ${n} to i64
         %boxed1 = insertvalue %Pos zeroinitializer, i64 %extended, 0
         %boxed2 = insertvalue %Pos %boxed1, %Object null, 1
         ret %Pos %boxed2
       """
     extern pure def unboxByte(b: BoxedByte): Byte =
       llvm """
-        %unboxed = extractvalue %Pos %b, 0
+        %unboxed = extractvalue %Pos ${b}, 0
         %truncated = trunc i64 %unboxed to i8
         ret i8 %truncated
       """
@@ -731,13 +731,13 @@ namespace internal {
     extern type BoxedChar
     extern pure def boxChar(c: Char): BoxedChar =
       llvm """
-        %boxed1 = insertvalue %Pos zeroinitializer, i64 %c, 0
+        %boxed1 = insertvalue %Pos zeroinitializer, i64 ${c}, 0
         %boxed2 = insertvalue %Pos %boxed1, %Object null, 1
         ret %Pos %boxed2
       """
     extern pure def unboxChar(b: BoxedChar): Char =
       llvm """
-        %unboxed = extractvalue %Pos %b, 0
+        %unboxed = extractvalue %Pos ${b}, 0
         ret %Int %unboxed
       """
 
@@ -748,14 +748,14 @@ namespace internal {
     extern type BoxedDouble
     extern pure def boxDouble(d: Double): BoxedDouble =
       llvm """
-        %n = bitcast double %d to i64
+        %n = bitcast double ${d} to i64
         %boxed1 = insertvalue %Pos zeroinitializer, i64 %n, 0
         %boxed2 = insertvalue %Pos %boxed1, %Object null, 1
         ret %Pos %boxed2
       """
     extern pure def unboxDouble(b: BoxedDouble): Double =
       llvm """
-        %unboxed = extractvalue %Pos %b, 0
+        %unboxed = extractvalue %Pos ${b}, 0
         %d = bitcast i64 %unboxed to double
         ret %Double %d
       """

--- a/libraries/common/exception.effekt
+++ b/libraries/common/exception.effekt
@@ -55,7 +55,7 @@ extern io def panic[R](msg: String): R =
   chez "(raise ${msg})"
   ml "raise Fail ${msg}"
   llvm """
-    call void @c_io_println_String(%Pos %msg)
+    call void @c_io_println_String(%Pos ${msg})
     call void @exit(i32 1)
     ret %Pos zeroinitializer ; Unit
   """

--- a/libraries/common/io.effekt
+++ b/libraries/common/io.effekt
@@ -72,7 +72,7 @@ namespace promise {
     js "${p}.resolve(${value})"
     llvm """
       ; Get the default loop and run it.
-      call void @c_promise_resolve(%Pos %p, %Pos %value)
+      call void @c_promise_resolve(%Pos ${p}, %Pos ${value})
       ret %Pos zeroinitializer
     """
 
@@ -80,7 +80,7 @@ namespace promise {
     js "${p}.promise.then(res => (${callback})(res).run())"
     llvm """
       ; Get the default loop and run it.
-      call void @c_promise_await(%Pos %p, %Neg %callback)
+      call void @c_promise_await(%Pos ${p}, %Neg ${callback})
       ret %Pos zeroinitializer
     """
 }
@@ -129,7 +129,7 @@ namespace eventloop {
   extern io def schedule(program: () => Unit at {io, global}): Unit =
     js "setTimeout(() => (${program})().run(), 0)"
     llvm """
-      call void @c_timer_wait(i64 0, %Neg %program)
+      call void @c_timer_wait(i64 0, %Neg ${program})
       ret %Pos zeroinitializer
     """
 

--- a/libraries/common/io/files.effekt
+++ b/libraries/common/io/files.effekt
@@ -181,7 +181,7 @@ extern io def closeFile(fd: FileDescriptor): Unit =
   js "fs.close(${fd}, () => $effekt.unit)"
   llvm """
     ; extract the filedescriptor from the tag of the Pos
-    %tag = extractvalue %Pos %fd, 0
+    %tag = extractvalue %Pos ${fd}, 0
     %fd_int = trunc i64 %tag to i32
 
     call void @c_file_close(i32 %fd_int)
@@ -218,7 +218,7 @@ namespace callback {
       %onFailure_ptr = alloca %Neg
       store %Neg %onFailure, %Neg* %onFailure_ptr
 
-      call void @c_file_open(%Pos %path, %Pos %mode, ptr %onSuccess_ptr, ptr %onFailure_ptr) #0
+      call void @c_file_open(%Pos ${path}, %Pos ${mode}, ptr %onSuccess_ptr, ptr %onFailure_ptr) #0
       ret %Pos zeroinitializer
     """
 
@@ -228,17 +228,17 @@ namespace callback {
     js "readFile(${fd}, ${buffer}, ${offset}, ${onSuccess}, ${onFailure})"
     llvm """
       ; extract the filedescriptor from the tag of the Pos
-      %tag = extractvalue %Pos %fd, 0
+      %tag = extractvalue %Pos %${fd}, 0
       %fd_int = trunc i64 %tag to i32
 
       ; stack allocate
       %onSuccess_ptr = alloca %Neg
-      store %Neg %onSuccess, %Neg* %onSuccess_ptr
+      store %Neg ${onSuccess}, %Neg* %onSuccess_ptr
 
       %onFailure_ptr = alloca %Neg
-      store %Neg %onFailure, %Neg* %onFailure_ptr
+      store %Neg ${onFailure}, %Neg* %onFailure_ptr
 
-      call void @c_file_read(i32 %fd_int, %Pos %buffer, i64 noundef %offset, ptr %onSuccess_ptr, ptr %onFailure_ptr) #0
+      call void @c_file_read(i32 %fd_int, %Pos ${buffer}, i64 noundef ${offset}, ptr %onSuccess_ptr, ptr %onFailure_ptr) #0
       ret %Pos zeroinitializer
     """
 
@@ -248,17 +248,17 @@ namespace callback {
     js "writeFile(${fd}, ${buffer}, ${offset}, ${onSuccess}, ${onFailure})"
     llvm """
       ; extract the filedescriptor from the tag of the Pos
-      %tag = extractvalue %Pos %fd, 0
+      %tag = extractvalue %Pos ${fd}, 0
       %fd_int = trunc i64 %tag to i32
 
       ; stack allocate
       %onSuccess_ptr = alloca %Neg
-      store %Neg %onSuccess, %Neg* %onSuccess_ptr
+      store %Neg ${onSuccess}, %Neg* %onSuccess_ptr
 
       %onFailure_ptr = alloca %Neg
-      store %Neg %onFailure, %Neg* %onFailure_ptr
+      store %Neg ${onFailure}, %Neg* %onFailure_ptr
 
-      call void @c_file_write(i32 %fd_int, %Pos %buffer, i64 noundef %offset, ptr %onSuccess_ptr, ptr %onFailure_ptr) #0
+      call void @c_file_write(i32 %fd_int, %Pos ${buffer}, i64 noundef ${offset}, ptr %onSuccess_ptr, ptr %onFailure_ptr) #0
       ret %Pos zeroinitializer
     """
 }

--- a/libraries/common/io/time.effekt
+++ b/libraries/common/io/time.effekt
@@ -9,7 +9,7 @@ namespace callback {
   extern io def wait(millis: Int, onTimeout: () => Unit at {io, global}): Unit =
     js "setTimeout(() => (${onTimeout})().run(), ${millis})"
     llvm """
-      call void @c_timer_wait(i64 %millis, %Neg %onTimeout)
+      call void @c_timer_wait(i64 ${millis}, %Neg ${onTimeout})
       ret %Pos zeroinitializer
     """
 }

--- a/libraries/common/process.effekt
+++ b/libraries/common/process.effekt
@@ -3,7 +3,7 @@ module process
 extern io def exit(errorCode: Int): Nothing =
   js   "(function() { process.exit(${errorCode}) })()"
   llvm """
-    call void @exit(i64 %errorCode)
+    call void @exit(i64 ${errorCode})
     ret %Pos zeroinitializer
   """
   chez "(exit ${errorCode})"

--- a/libraries/common/ref.effekt
+++ b/libraries/common/ref.effekt
@@ -34,7 +34,7 @@ extern global def ref[T](init: T): Ref[T] =
   chez "(box ${init})"
   ml "ref ${init}"
   llvm """
-    %z = call %Pos @c_ref_fresh(%Pos %init)
+    %z = call %Pos @c_ref_fresh(%Pos ${init})
     ret %Pos %z
   """
 
@@ -46,7 +46,7 @@ extern global def get[T](ref: Ref[T]): T =
   chez "(unbox ${ref})"
   ml "!${ref}"
   llvm """
-    %z = call %Pos @c_ref_get(%Pos %ref)
+    %z = call %Pos @c_ref_get(%Pos ${ref})
     ret %Pos %z
   """
 
@@ -58,6 +58,6 @@ extern global def set[T](ref: Ref[T], value: T): Unit =
   chez "(set-box! ${ref} ${value})"
   ml "${ref} := ${value}"
   llvm """
-    %z = call %Pos @c_ref_set(%Pos %ref, %Pos %value)
+    %z = call %Pos @c_ref_set(%Pos ${ref}, %Pos ${value})
     ret %Pos %z
   """

--- a/libraries/common/string.effekt
+++ b/libraries/common/string.effekt
@@ -279,7 +279,7 @@ extern pure def toString(ch: Char): String =
   js "String.fromCodePoint(${ch})"
   chez "(string (integer->char ${ch}))"
   llvm """
-    %z = call %Pos @c_buffer_show_Char(%Int %ch)
+    %z = call %Pos @c_buffer_show_Char(%Int ${ch})
     ret %Pos %z
   """
 
@@ -302,7 +302,7 @@ extern pure def infixLt(x: Char, y: Char): Bool =
   chez "(< ${x} ${y})"
   ml "(${x}: int) < ${y}"
   llvm """
-    %z = icmp slt %Int %x, %y
+    %z = icmp slt %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -313,7 +313,7 @@ extern pure def infixLte(x: Char, y: Char): Bool =
   chez "(<= ${x} ${y})"
   ml "(${x}: int) <= ${y}"
   llvm """
-    %z = icmp sle %Int %x, %y
+    %z = icmp sle %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -324,7 +324,7 @@ extern pure def infixGt(x: Char, y: Char): Bool =
   chez "(> ${x} ${y})"
   ml "(${x}: int) > ${y}"
   llvm """
-    %z = icmp sgt %Int %x, %y
+    %z = icmp sgt %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -335,7 +335,7 @@ extern pure def infixGte(x: Char, y: Char): Bool =
   chez "(>= ${x} ${y})"
   ml "(${x}: int) >= ${y}"
   llvm """
-    %z = icmp sge %Int %x, %y
+    %z = icmp sge %Int ${x}, ${y}
     %fat_z = zext i1 %z to i64
     %adt_boolean = insertvalue %Pos zeroinitializer, i64 %fat_z, 0
     ret %Pos %adt_boolean
@@ -390,6 +390,6 @@ extern pure def unsafeCharAt(str: String, n: Int): Char =
   chez "(char->integer (string-ref ${str} ${n}))"
   ml "(Char.ord (String.sub (${str}, ${n})))"
   llvm """
-    %x = call %Int @c_buffer_character_at(%Pos %str, i64 %n)
+    %x = call %Int @c_buffer_character_at(%Pos ${str}, i64 ${n})
     ret %Int %x
   """


### PR DESCRIPTION
Note that we only splice the names of variables (e.g., `%x17`) and not their type (e.g., `%Pos %x17`). This is mostly due to instructions like

```
 %z = icmp sge %Int %x, %y
 ```
 
 where generating
 
 ```
  %z = icmp sge %Int %x, %Int %y
  ```
  would be wrong.