### PR TITLE
JS: Strip trailing/leading whitespace in externs (+ warn)

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
@@ -134,6 +134,17 @@ trait Transformer {
       }
     }.toString()
 
+  // Externs
+  // -------
+  def normalizeExternStrings(l: List[String])(using Context): List[String] = {
+    val start = l.head
+    val end = l.last
+    val mid = l.tail.init
+    if (start.matches("""^\s.*""") || end.matches(""".*\s$""")) {
+      Context.warning("Extern string in js has trailing / leading whitespace. This will be removed.")
+    }
+    start.stripLeading() +: mid :+ end.stripTrailing()
+  }
 
   // Separate Compilation (Website)
   // ------------------------------

--- a/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
@@ -136,14 +136,21 @@ trait Transformer {
 
   // Externs
   // -------
-  def normalizeExternStrings(l: List[String])(using Context): List[String] = {
-    val start = l.head
-    val end = l.last
-    val mid = l.tail.init
-    if (start.matches("""^\s.*""") || end.matches(""".*\s$""")) {
-      Context.warning("Extern string in js has trailing / leading whitespace. This will be removed.")
-    }
-    start.stripLeading() +: mid :+ end.stripTrailing()
+  def normalizeExternStrings(l: List[String])(using Context): List[String] = l match {
+    case Nil => Nil
+    case List(s) =>
+      if (s.matches("""^\s.*""") || s.matches(""".*\s$""")) {
+        Context.warning("Extern string in js has trailing / leading whitespace. This will be removed.")
+      }
+      List(s.strip())
+    case l =>
+      val start = l.head
+      val end = l.last
+      val mid = l.tail.init
+      if (start.matches("""^\s.*""") || end.matches(""".*\s$""")) {
+        Context.warning("Extern string in js has trailing / leading whitespace. This will be removed.")
+      }
+      start.stripLeading() +: mid :+ end.stripTrailing()
   }
 
   // Separate Compilation (Website)

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerDirect.scala
@@ -101,7 +101,8 @@ object TransformerDirect extends Transformer {
       js.RawStmt(contents)
   }
 
-  def toJS(t: Template[Pure])(using TransformerContext): js.Expr = js.RawExpr(t.strings, t.args.map(toJS))
+  def toJS(t: Template[Pure])(using TransformerContext): js.Expr = 
+    js.RawExpr(normalizeExternStrings(t.strings), t.args.map(toJS))
 
   def toJS(b: core.Block)(using C: TransformerContext): js.Expr = b match {
     // [[ f ]] = f

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerMonadic.scala
@@ -126,7 +126,7 @@ trait TransformerMonadic extends Transformer {
   }
 
   def toJS(t: Template[Pure])(using DeclarationContext, Context): js.Expr =
-    js.RawExpr(t.strings, t.args.map(toJS))
+    js.RawExpr(normalizeExternStrings(t.strings), t.args.map(toJS))
 
   def toJS(b: core.Block)(using DeclarationContext, Context): js.Expr = b match {
     case BlockVar(v, _, _) =>


### PR DESCRIPTION
Fixes #569.

This basically applies this suggestion: https://github.com/effekt-lang/effekt/issues/569#issuecomment-2326363108
but generates a warning instead of an error.

We do not seem to use this anywhere.