### PR TITLE
CI: Bypass push protection in autorelease.yml

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -93,10 +93,23 @@ jobs:
       - name: Update Effekt version in NPM and MVN via sbt
         run: sbt updateVersions
 
+      # Login as a GitHub App in order to bypass rules about committing to `master` directly
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.EFFEKT_UPDATER_GH_APP_ID }}
+          private-key: ${{ secrets.EFFEKT_UPDATER_GH_CREDENTIALS_TOKEN }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Commit and push changes
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions[bot]"
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
           git add project/EffektVersion.scala
           git add package.json
           git add pom.xml


### PR DESCRIPTION
Autorelease CI fails because we protect pushing directly to `master` by default. Let's use a GitHub App instead!