### PR TITLE
Update NodeJS to 16.x

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   JAVA_VERSION: '11'
-  NODE_VERSION: '12.x'
+  NODE_VERSION: '16.x'
 
 jobs:
   run-tests: # redux of usual CI defined in `ci.yml`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   JAVA_VERSION: '11'
-  NODE_VERSION: '12.x'
+  NODE_VERSION: '16.x'
 
 jobs:
   run-hello-world:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   JAVA_VERSION: '11'
-  NODE_VERSION: '12.x'
+  NODE_VERSION: '16.x'
 
 jobs:
   build-jar:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ play with it and give us your feedback :)
 
 ## Installation
 
-You need to have Java (>= 11) and Node (>= 12) and npm installed.
+You need to have Java (>= 11) and Node (>= 16) and npm installed.
 
 The recommended way of installing Effekt is by running:
 


### PR DESCRIPTION
Might require changes on the website https://github.com/effekt-lang/effekt-website/issues/63 ~~and in the VSCode extension~~.
Let's see if the tests run through before merging :)

`effekt-plots` & `effekt-nix` seem to use newer versions anyways, so the ecosystem should keep on breathing fine.

Related to #592