### PR TITLE
Improve handling of (unicode) escapes

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LexerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LexerTests.scala
@@ -97,6 +97,7 @@ class LexerTests extends munit.FunSuite {
     assertTokensEq("\" \\t \"", Str(" \t ", false), EOF)
     assertFailure("\"\\k\"")
     assertTokensEq("\"\\u001b\"", Str("\u001b", false), EOF)
+    assertTokensEq("\"\\u{001b}\"", Str("\u001b", false), EOF)
   }
 
   test("characters") {

--- a/effekt/jvm/src/test/scala/effekt/LexerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LexerTests.scala
@@ -109,7 +109,7 @@ class LexerTests extends munit.FunSuite {
     assertTokensEq("\\uFFFF", Chr(0xFFFF), EOF)
     assertTokensEq("\\u10FFFF{ val", Chr(0x10FFFF), `{`, `val`, EOF)
     assertTokensEq("val s =\\u0000+ 1", `val`, Ident("s"), `=`, Chr(0), `+`, Integer(1), EOF)
-    assertFailure("''")
+    assertTokensEq("''", Error(LexerError("Empty character literal", 0, 2)), EOF)
   }
 
   test("multi line strings") {

--- a/effekt/jvm/src/test/scala/effekt/LexerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LexerTests.scala
@@ -102,9 +102,9 @@ class LexerTests extends munit.FunSuite {
   test("characters") {
     assertTokensEq("' '", Chr(' '), EOF)
     assertTokensEq("'😅'", Chr(0x1F605), EOF)
-    assertTokensEq("'\\'", Chr('\\'), EOF)
-    assertTokensEq("'\n'", Chr('\n'), EOF)
-    assertTokensEq("'\t'", Chr('\t'), EOF)
+    assertTokensEq("'\\\\'", Chr('\\'), EOF)
+    assertTokensEq("'\\n'", Chr('\n'), EOF)
+    assertTokensEq("'\\t'", Chr('\t'), EOF)
     assertTokensEq("\\u0000", Chr(0), EOF)
     assertTokensEq("\\uFFFF", Chr(0xFFFF), EOF)
     assertTokensEq("\\u10FFFF{ val", Chr(0x10FFFF), `{`, `val`, EOF)

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -430,7 +430,7 @@ class Lexer(source: Source) {
         case Some('\n') if !delim.isMultiline =>
           return err("Linebreaks are not allowed in single-line strings.")
         // handle escape sequences
-        case Some('\\') => {
+        case Some('\\') if !delim.isMultiline => {
           expect('\\')
           peek() match {
             case Some('"') => consume(); stringContent.addOne('"')

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -462,7 +462,12 @@ class Lexer(source: Source) {
     expect('\'')
     // exclude opening and closing '
     val cs = StringContext.processEscapes(slice(start + 1, current - 1))
-    TokenKind.Chr(cs.codePointAt(0))
+    if (cs.codePointCount(0, cs.length) > 1) {
+      TokenKind.Error(LexerError("Character literal consists " +
+        "of multiple code points.", start, current))
+    } else {
+      TokenKind.Chr(cs.codePointAt(0))
+    }
   }
 
   lazy val hexadecimal = ('a' to 'f') ++ ('A' to 'F') ++ ('0' to '9')

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -305,7 +305,7 @@ class Lexer(source: Source) {
               }
             // Last `}` is not be considered as part of string interpolation. Let the parser fail if braces don't match
             // and just continue lexing
-            case `{{` | `"` | `"""` => nextToken()
+            case `{{` | `"` | `"""` | `'` => nextToken()
           }
         } else nextToken()
       kind match {
@@ -366,26 +366,36 @@ class Lexer(source: Source) {
       this match {
         case `"` => 1
         case `"""` => 3
+        case `'` => 1
+      }
+
+    def first: Char =
+      this match {
+        case `"` | `"""` => '"'
+        case `'` => '\''
       }
 
     override def toString: String =
       this match {
         case `"` => "\""
         case `"""` => "\"\"\""
+        case `'` => "'"
       }
 
     def isMultiline: Boolean =
       this match {
         case `"` => false
         case `"""` => true
+        case `'` => false
       }
   }
   case object `"` extends StrDelim
   case object `"""` extends StrDelim
+  /** Delimiter for characters */
+  case object `'` extends StrDelim
 
   /** Matches a string literal -- both single- and multi-line strings.
-   * Strings may contain space characters (e.g. \n, \t, \r), which are stored unescaped for single-line strings and
-   * escaped for multi-line strings.
+   * Strings may contain space characters (e.g. \n, \t, \r), which are stored unescaped.
    * Strings may also contain unquotes, i.e., "f = ${x + 1}" that include arbitrary expressions.
    */
   def matchString(delim: StrDelim, continued: Boolean = false): TokenKind = {
@@ -393,80 +403,80 @@ class Lexer(source: Source) {
     val offset = delim.offset
     val st = if (continued) start else start + offset
     var endString = false
+    val stringContent = StringBuilder()
+
     delimiters.push(delim)
     while (!endString) {
       peek() match {
-        case Some('\"') => {
+        case Some(c) if c == delim.first => {
           consume()
           delim match {
-            case `"""` => {
-              if (peekN(1).contains('\"') && peekN(2).contains('\"')) {
-                consume(); consume()
-                delimiters.pop()
-                endString = true
-              }
+            case `"""`  if (peekN(1).contains('\"') && peekN(2).contains('\"')) => {
+              consume(); consume()
+              delimiters.pop()
+              endString = true
             }
             case `"` => {
               delimiters.pop()
               endString = true
             }
+            case `'` => {
+              delimiters.pop()
+              endString = true
+            }
+            case _ => stringContent.addOne(c)
           }
         }
-        case Some('\n') if delim == `"` =>
+        case Some('\n') if !delim.isMultiline =>
           return err("Linebreaks are not allowed in single-line strings.")
         // handle escape sequences
         case Some('\\') => {
           expect('\\')
           peek() match {
-            case Some('\"') | Some('\\') | Some('n') | Some('t') | Some('r') => consume()
+            case Some('"') => consume(); stringContent.addOne('"')
+            case Some('n') => consume(); stringContent.addOne('\n')
+            case Some('t') => consume(); stringContent.addOne('\t')
+            case Some('r') => consume(); stringContent.addOne('\r')
+            case Some('\\') => consume(); stringContent.addOne('\\')
             case Some('u') => {
               consume()
-              consumeWhile(c => !c.isWhitespace && c != '"')
+              val escapeStart = current
+              consumeWhile(c => c.isDigit || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))
+              try {
+                val codePoint = Integer.parseInt(slice(escapeStart, current), 16)
+                stringContent.append(String.valueOf(Character.toChars(codePoint)))
+              } catch {
+                case e: NumberFormatException => err(e.toString)
+              }
             }
             case _ => err("Invalid escape sequence.", current - 1, current)
           }
         }
         case Some('$') if peekN(2).contains('{') => {
-          val s = slice(st, current)
-          return TokenKind.Str(s, delim.isMultiline)
+          return TokenKind.Str(stringContent.mkString, delim.isMultiline)
         }
         case None =>
           return err("Unterminated string.", start, start + offset)
-        case _ =>
+        case Some(c) =>
           consume()
+          stringContent.addOne(c)
       }
     }
-    val s = slice(st, current - offset)
 
-    val stringContent =
-      if (delim.isMultiline) {
-        // Do not unescape multiline strings at all for multiline strings (see comments in PR #495)
-        s
-      } else {
-        // Unescape the following sequences: control: `\b`, `\t`, `\n`, `\f`, `\r`; escape:  `\\`, `\"`, `\'`
-        // For now, we only support a subset determined by `StringContext.processEscapes`
-        try {
-          StringContext.processEscapes(s)
-        } catch {
-          case e: StringContext.InvalidEscapeException => err("Contains invalid escape sequence.", e.index, e.index)
-        }
-      }
-
-    TokenKind.Str(stringContent, delim.isMultiline)
+    TokenKind.Str(stringContent.mkString, delim.isMultiline)
   }
 
   /** Matches a character: '.+' */
   def matchChar(): TokenKind = {
-    if (peekMatches(_ == '\'')) err("Empty character literal.")
-    consumeWhile(_ != '\'')
-    expect('\'')
-    // exclude opening and closing '
-    val cs = StringContext.processEscapes(slice(start + 1, current - 1))
-    if (cs.codePointCount(0, cs.length) > 1) {
-      TokenKind.Error(LexerError("Character literal consists " +
-        "of multiple code points.", start, current))
-    } else {
-      TokenKind.Chr(cs.codePointAt(0))
+    matchString(`'`) match {
+      case TokenKind.Str("", _) =>
+        TokenKind.Error(LexerError("Empty character literal", start, current))
+      case TokenKind.Str(cs, _) if (cs.codePointCount(0, cs.length) > 1) =>
+        TokenKind.Error(LexerError("Character literal consists " +
+            "of multiple code points.", start, current))
+      case TokenKind.Str(cs, _) =>
+        TokenKind.Chr(cs.codePointAt(0))
+      case err => err
     }
   }
 

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -461,7 +461,7 @@ class Lexer(source: Source) {
     consumeWhile(_ != '\'')
     expect('\'')
     // exclude opening and closing '
-    val cs = slice(start + 1, current - 1)
+    val cs = StringContext.processEscapes(slice(start + 1, current - 1))
     TokenKind.Chr(cs.codePointAt(0))
   }
 

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -453,7 +453,8 @@ class Lexer(source: Source) {
                   consume()
                   val escapeStart = current
                   consumeWhile(c => c != '}')
-                  slice(escapeStart, current)
+                  expect('}')
+                  slice(escapeStart, current - 1)
                 case _ => err("Invalid escape sequence.", current - 1, current)
               }
 

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -438,6 +438,7 @@ class Lexer(source: Source) {
             case Some('t') => consume(); stringContent.addOne('\t')
             case Some('r') => consume(); stringContent.addOne('\r')
             case Some('\\') => consume(); stringContent.addOne('\\')
+            case Some('$') => consume(); stringContent.addOne('$')
             case Some('u') => {
               consume()
               val escapeStart = current

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -60,7 +60,12 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
   // always points to the latest non-space position
   var position: Int = 0
 
-  def peek: Token = tokens(position)
+  extension(token: Token) def failOnErrorToken: Token = token.kind match {
+    case TokenKind.Error(err) => fail(err.msg)
+    case _ => token
+  }
+
+  def peek: Token = tokens(position).failOnErrorToken
 
   /**
    * Negative lookahead
@@ -76,7 +81,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
     def go(position: Int, offset: Int): Token =
       if position >= tokens.length then fail("Unexpected end of file")
 
-      tokens(position) match {
+      tokens(position).failOnErrorToken match {
         case token if isSpace(token.kind) => go(position + 1, offset)
         case token if offset <= 0 => token
         case _ => go(position + 1, offset - 1)
@@ -94,7 +99,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
 
   def hasNext(): Boolean = position < tokens.length
   def next(): Token =
-    val t = tokens(position)
+    val t = tokens(position).failOnErrorToken
     skip()
     t
 

--- a/effekt/shared/src/main/scala/effekt/generator/chez/package.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/package.scala
@@ -73,16 +73,3 @@ def generateConstructor(id: Symbol, fields: List[Symbol]): List[chez.Def] = {
 
   List(record, matcher)
 }
-
-
-private val unicodeRx = Regex("""[\\]u([0-9a-fA-F]{1,4})""")
-
-// unicode escape sequences \u001b need to be translated to \033
-// where 033 is an octal value left-padded with 0 to exactly three digits.
-def hexToOctal(str: String) =
-  val n = Integer.parseInt(str, 16)
-  val octal = Integer.toString(n, 8)
-  octal.reverse.padTo(3, '0').reverse
-
-def adaptEscapes(str: String) =
-  unicodeRx.replaceAllIn(str, m => "\\\\" + s"${hexToOctal(m.group(1))}")

--- a/examples/pos/unicode_escapes.check
+++ b/examples/pos/unicode_escapes.check
@@ -1,0 +1,2 @@
+\u000A is the Unicode representation of \n
+💩💩

--- a/examples/pos/unicode_escapes.check
+++ b/examples/pos/unicode_escapes.check
@@ -1,2 +1,3 @@
 \u000A is the Unicode representation of \n
 💩💩
+false

--- a/examples/pos/unicode_escapes.effekt
+++ b/examples/pos/unicode_escapes.effekt
@@ -1,4 +1,5 @@
 def main() = {
   println("\\u000A is the Unicode representation of \\n")
   println("💩\u1f4a9")
+  println('\n' == '\t')
 }

--- a/examples/pos/unicode_escapes.effekt
+++ b/examples/pos/unicode_escapes.effekt
@@ -1,0 +1,4 @@
+def main() = {
+  println("\\u000A is the Unicode representation of \\n")
+  println("💩\u1f4a9")
+}


### PR DESCRIPTION
This gets us half-way there for escapes in Strings:
- Allow escapes in character literals, i.e. `'\n'` is a newline character
    - Note: This disallows `'\'` for \, but requires `'\\'`
    - Fixes `'\n' == '\t'`  (cmp. #521)
- Check that character literals consist of only one codepoint
- Report wrong escape sequences in parser, but generate the error in lexer - this only happens for SOME of those
    - We should generate error tokens everywhere instead, different issue
- Escape ourselves in Lexer and build up a string
- Add additional escapes: `\$` (because of unquotes), `\u{...}`
- In chez, escape all characters in one function, use chez's unicode handling functions for characters beyond 3 octals
   - Fixes #596