### PR TITLE
Use direct pointers as prompt

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -96,6 +96,10 @@ class LLVMTests extends EffektTests {
 
     // Generic equality
     examplesDir / "pos" / "issue429.effekt",
+
+    // Global region
+    examplesDir / "pos" / "capture" / "selfregion.effekt",
+    examplesDir / "benchmarks" / "are_we_fast_yet" / "storage.effekt",
   )
 
   override lazy val ignored: List[File] = bugs ++ missingFeatures

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -473,10 +473,6 @@ object Transformer {
         emit(Call(name, Ccc(), stackType, freshPrompt, Nil))
         transform(rest)
 
-      case machine.CurrentPrompt(machine.Variable(name, _), rest) =>
-        emit(Call(name, Ccc(), stackType, currentPrompt, List(getStack())))
-        transform(rest)
-
       case machine.LiteralInt(machine.Variable(name, _), n, rest) =>
         emit(Comment(s"literalInt $name, n=$n"))
         emit(Add(name, ConstantInt(n), ConstantInt(0)));
@@ -837,7 +833,6 @@ object Transformer {
   val pushStack = ConstantGlobal(PointerType(), "pushStack");
   val popStacks = ConstantGlobal(PointerType(), "popStacks");
   val freshPrompt = ConstantGlobal(PointerType(), "freshPrompt");
-  val currentPrompt = ConstantGlobal(PointerType(), "currentPrompt");
   val underflowStack = ConstantGlobal(PointerType(), "underflowStack");
   val uniqueStack = ConstantGlobal(PointerType(), "uniqueStack");
   val withEmptyStack = ConstantGlobal(PointerType(), "withEmptyStack");

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -35,7 +35,7 @@ def freeVariables(statement: Statement): Set[Variable] =
       Set(ref) ++ freeVariables(rest) -- Set(name)
     case Store(ref, value, rest) =>
       Set(ref, value) ++ freeVariables(rest)
-    case Var(name, init, tpe, rest) => 
+    case Var(name, init, tpe, rest) =>
       freeVariables(rest) ++ Set(init) -- Set(name)
     case LoadVar(name, ref, rest) =>
       Set(ref) ++ freeVariables(rest) -- Set(name)
@@ -52,8 +52,6 @@ def freeVariables(statement: Statement): Set[Variable] =
     case PopStacks(name, prompt, rest) =>
       freeVariables(rest) -- Set(name) ++ Set(prompt)
     case FreshPrompt(name, rest) =>
-      freeVariables(rest) -- Set(name)
-    case CurrentPrompt(name, rest) =>
       freeVariables(rest) -- Set(name)
     case LiteralInt(name, value, rest) =>
       freeVariables(rest) - name

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -96,9 +96,6 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case FreshPrompt(name, rest) =>
       "let" <+> name <+> "=" <+> "freshPrompt" <> ";" <> line <> toDoc(rest)
 
-    case CurrentPrompt(name, rest) =>
-      "let" <+> name <+> "=" <+> "currentPrompt" <> ";" <> line <> toDoc(rest)
-
     case ForeignCall(name, builtin, arguments, rest) =>
       "let" <+> name <+> "=" <+> builtin <> parens(arguments map toDoc) <> ";" <> line <> toDoc(rest)
 

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -243,9 +243,10 @@ object Transformer {
               // TODO currently we use prompt 1 as a quick fix...
               //    However, this will not work when reinstalling a fresh stack
               //    We need to truly special case global memory!
-              LiteralInt(prompt, 1L,
-                Allocate(reference, value, prompt,
-                  transform(body)))
+              // LiteralInt(prompt, 1L,
+              //   Allocate(reference, value, prompt,
+              //     transform(body)))
+              ???
             case _ =>
               Allocate(reference, value, prompt,
                   transform(body))

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -190,12 +190,6 @@ enum Statement {
   case FreshPrompt(name: Variable, rest: Statement)
 
   /**
-   * Retrieves the prompt of the currently mounted stack
-   * let n = currentPrompt; s
-   */
-  case CurrentPrompt(name: Variable, rest: Statement)
-
-  /**
    * e.g. let k = stack(p) { (x, ...) => s }; s
    */
   case NewStack(name: Variable, prompt: Variable, frame: Clause, rest: Statement)

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -114,10 +114,6 @@ declare void @exit(i64)
 
 ; Prompts
 
-define private %MetaStackPointer @currentPrompt(%MetaStackPointer %stack) alwaysinline {
-    ret %MetaStackPointer %stack
-}
-
 define private %MetaStackPointer @freshPrompt() alwaysinline {
     %prompt = call ptr @malloc(i64 112)
     %memory = call %Memory @newMemory()

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -75,11 +75,12 @@
 ; fresh prompt generation
 @lastPrompt = private global %Prompt 0
 
-; This is used for two purposes:
-;   - a refied first-class list of stacks (cyclic linked-list)
-;   - as part of an intrusive linked-list of stacks (meta stack)
-%MetaStack = type { %ReferenceCount, %Memory, %Region, %Prompt, %MetaStackPointer }
+; This is used as part of an intrusive linked-list of stacks (meta stack)
+%MetaStack = type { %ReferenceCount, %Memory, %Region, %MetaStackPointer }
 
+%ResumptionPointer = type ptr
+
+%Resumption = type { %ReferenceCount, %MetaStackPointer, %Memory, %Region, %Resumption }
 
 
 


### PR DESCRIPTION
Separates the meta-stack (now in stable address) from first class stacks.

This gets slower in some cases. Likely because we now copy the spine eagerly, and it might get better with lazy captures.

This breaks global variables. Do we still need them? cc @phischu 