### PR TITLE
Fix SBT installation

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -27,6 +27,9 @@ jobs:
         distribution: 'zulu'
         cache: 'sbt'
 
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
+
     - name: Set up NodeJS ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
         distribution: 'zulu'
         cache: 'sbt'
 
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
+
     - name: Set up NodeJS ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,9 @@ jobs:
         distribution: 'zulu'
         cache: 'sbt'
 
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
+
     - name: Set up NodeJS ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
Due to updates in the `ubuntu-latest` image, `sbt` is [no longer included](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) in the default installation. Now we also use the [`sbt/setup-sbt`](https://github.com/sbt/setup-sbt) action in all workflows. Closes #639.

CI fails because it still runs with the old config, I believe.