### PR TITLE
Allocate region variables as "local variables" on previous stack

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -58,8 +58,10 @@ ${indentedLines(instructions.map(show).mkString("\n"))}
       s"call ccc void ${globalName(name)}(${commaSeparated(arguments.map(show))})"
     case Call(result, Ccc(), tpe, ConstantGlobal(name), arguments) =>
       s"${localName(result)} = call ccc ${show(tpe)} ${globalName(name)}(${commaSeparated(arguments.map(show))})"
+    case Call(_, Ccc(), VoidType(), LocalReference(_, name), arguments) =>
+      s"call ccc void ${localName(name)}(${commaSeparated(arguments.map(show))})"
     case Call(_, Ccc(), _, nonglobal, _) =>
-      C.abort(s"cannot call non-global operand: $nonglobal")
+      C.abort(s"cannot call non-global operand: $nonglobal") // why not?
     case Call(_, Tailcc(false), VoidType(), ConstantGlobal(name), arguments) =>
       s"call tailcc void ${globalName(name)}(${commaSeparated(arguments.map(show))})"
     case Call(_, Tailcc(false), VoidType(), LocalReference(_, name), arguments) =>

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -352,6 +352,10 @@ object Transformer {
       case machine.Reset(prompt, frame, isRegion, rest) =>
         emit(Comment(s"Reset ${prompt.name}"))
 
+        if (isRegion) {
+          pushReturnAddressOnto(getStack(), "nop", shareFrames.name, eraseFrames.name)
+        }
+
         val newStack = LocalReference(stackType, freshName("stack"))
         emit(Call(newStack.name, Ccc(), stackType, reset, List(getStack())));
         setStack(newStack)
@@ -414,9 +418,6 @@ object Transformer {
         pushEnvironmentOnto(getStack(), frameEnvironment);
         pushReturnAddressOnto(getStack(), returnAddressName, sharerName, eraserName);
 
-        if (isRegion) {
-          pushReturnAddressOnto(getStack(), "nop", shareFrames.name, eraseFrames.name)
-        }
         transform(rest)
 
       case machine.Resume(value, rest) =>

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -195,55 +195,6 @@ object Transformer {
         emit(callLabel(LocalReference(methodType, functionName), LocalReference(objectType, objectName) +: arguments))
         RetVoid()
 
-      case machine.Allocate(reference, init, region, rest) =>
-        emit(Comment(s"allocate ${reference.name}, type ${reference.tpe}, init ${init.name}, region ${region.name}"))
-        val idx = regionIndex(reference.tpe)
-
-        val temporaryRef = LocalReference(StructureType(List(PointerType(), referenceType)), freshName("cell"))
-        emit(Call(temporaryRef.name, Ccc(), temporaryRef.tpe, alloc, List(ConstantInt(idx), transform(region))));
-
-        val ptrRef = LocalReference(PointerType(), freshName("pointer"))
-        emit(ExtractValue(ptrRef.name, temporaryRef, 0))
-
-        emit(ExtractValue(reference.name, temporaryRef, 1))
-
-        emit(Store(ptrRef, transform(init)))
-
-        shareValues(List(init), freeVariables(rest))
-        transform(rest)
-
-      case machine.Load(name, reference, rest) =>
-        emit(Comment(s"load ${name.name}, reference ${reference.name}"))
-
-        val idx = regionIndex(reference.tpe)
-
-        val ptrRef = LocalReference(PointerType(), freshName(name.name + "_pointer"))
-        emit(Call(ptrRef.name, Ccc(), PointerType(), getPointer, List(transform(reference), ConstantInt(idx), getStack())))
-
-        // We have to share the old value since now there exists a new reference to it
-        val oldVal = machine.Variable(freshName(reference.name + "_old"), name.tpe)
-        emit(Load(oldVal.name, transform(oldVal.tpe), ptrRef))
-        shareValue(oldVal)
-
-        emit(Load(name.name, transform(name.tpe), ptrRef))
-        eraseValues(List(name), freeVariables(rest))
-        transform(rest)
-
-      case machine.Store(reference, value, rest) =>
-        emit(Comment(s"store ${reference.name}, value ${value.name}"))
-        val idx = regionIndex(reference.tpe)
-
-        val ptrRef = LocalReference(PointerType(), freshName(reference.name + "pointer"))
-        emit(Call(ptrRef.name, Ccc(), PointerType(), getPointer, List(transform(reference), ConstantInt(idx), getStack())))
-
-        val oldVal = machine.Variable(freshName(reference.name + "_old"), value.tpe)
-        emit(Load(oldVal.name, transform(oldVal.tpe), ptrRef))
-        eraseValue(oldVal)
-
-        emit(Store(ptrRef, transform(value)))
-        shareValues(List(value), freeVariables(rest))
-        transform(rest)
-
       case machine.Var(ref @ machine.Variable(name, machine.Type.Reference(tpe)), init, retType, rest) =>
         val environment = List(init)
         val returnAddressName = freshName("returnAddress")

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -532,16 +532,6 @@ object Transformer {
       case machine.Type.Reference(_) => 16
     }
 
-  def regionIndex(tpe: machine.Type): Int =
-    tpe match {
-      case machine.Type.Reference(machine.Type.Int()) => 0
-      case machine.Type.Reference(machine.Type.Double()) => 0
-      case machine.Type.Reference(machine.Type.Positive()) => 1
-      case machine.Type.Reference(machine.Type.Negative()) => 1
-      case machine.Type.Reference(machine.Type.String()) => 2
-      case _ => ???
-    }
-
   def defineFunction(name: String, parameters: List[Parameter])(prog: (FunctionContext, BlockContext) ?=> Terminator): ModuleContext ?=> Unit = {
     implicit val FC = FunctionContext();
     implicit val BC = BlockContext();

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -29,12 +29,6 @@ def freeVariables(statement: Statement): Set[Variable] =
       freeVariables(clauses) ++ (freeVariables(rest) -- Set(name))
     case Invoke(value, tag, values) =>
       Set(value) ++ Set.from(values)
-    case Allocate(name, init, region, rest) =>
-      freeVariables(rest) ++ Set(init, region) -- Set(name)
-    case Load(name, ref, rest) =>
-      Set(ref) ++ freeVariables(rest) -- Set(name)
-    case Store(ref, value, rest) =>
-      Set(ref, value) ++ freeVariables(rest)
     case Var(name, init, tpe, rest) =>
       freeVariables(rest) ++ Set(init) -- Set(name)
     case LoadVar(name, ref, rest) =>

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -45,7 +45,7 @@ def freeVariables(statement: Statement): Set[Variable] =
       freeVariables(frame) ++ freeVariables(rest)
     case Return(values) =>
       Set.from(values)
-    case Reset(prompt, frame, rest) =>
+    case Reset(prompt, frame, isRegion, rest) =>
       freeVariables(frame) ++ (freeVariables(rest) -- Set(prompt))
     case Resume(value, rest) =>
       Set(value) ++ freeVariables(rest)

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -39,7 +39,7 @@ def freeVariables(statement: Statement): Set[Variable] =
       freeVariables(frame) ++ freeVariables(rest)
     case Return(values) =>
       Set.from(values)
-    case Reset(prompt, frame, isRegion, rest) =>
+    case Reset(prompt, frame, rest) =>
       freeVariables(frame) ++ (freeVariables(rest) -- Set(prompt))
     case Resume(value, rest) =>
       Set(value) ++ freeVariables(rest)

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -84,7 +84,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Return(arguments) =>
       "return" <+> hsep(arguments map toDoc, ",")
 
-    case Reset(prompt, frame, rest) =>
+    case Reset(prompt, frame, isRegion, rest) =>
       "let" <+> prompt <+> "=" <+> "reset" <+> toDoc(frame) <> ";" <> line <> toDoc(rest)
 
     case Resume(stack, rest) =>

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -60,15 +60,6 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Invoke(receiver, tag, arguments) =>
       "invoke" <+> receiver <> "." <> tag.toString <> parens(arguments map toDoc)
 
-    case Allocate(name, init, region, rest) =>
-      "let" <+> name <+> "=" <+> "allocate" <> parens(List(toDoc(init), toDoc(region))) <> ";" <> line <> toDoc(rest)
-
-    case Load(name, reference, rest) =>
-      "let" <+> name <+> "=" <+> "load" <> parens(toDoc(reference)) <> ";" <> line <> toDoc(rest)
-
-    case Store(reference, value, rest) =>
-      "store" <> parens(List(reference, value) map toDoc) <> ";" <> line <> toDoc(rest)
-
     case Var(name, init, _, rest) =>
       "var" <+> name <+> "=" <+> toDoc(init) <> ";" <> line <> toDoc(rest)
 

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -75,7 +75,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Return(arguments) =>
       "return" <+> hsep(arguments map toDoc, ",")
 
-    case Reset(prompt, frame, isRegion, rest) =>
+    case Reset(prompt, frame, rest) =>
       "let" <+> prompt <+> "=" <+> "reset" <+> toDoc(frame) <> ";" <> line <> toDoc(rest)
 
     case Resume(stack, rest) =>

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -235,10 +235,14 @@ object Transformer {
 
           region match {
             case symbols.builtins.globalRegion =>
-              // TODO currently we use prompt 1 as a quick fix...
+              // TODO currently we use prompt 2 as a quick fix...
               //    However, this will not work when reinstalling a fresh stack
               //    We need to truly special case global memory!
-              ???
+              val globalPrompt = Variable(freshName("global"), Type.Prompt())
+              LiteralInt(globalPrompt, 2L,
+                PopStacks(temporary, globalPrompt,
+                  Var(reference, value, None,
+                    PushStack(temporary, transform(body)))))
             case _ =>
               Shift(temporary, prompt,
                 Var(reference, value, None,

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -211,7 +211,7 @@ object Transformer {
         val returnClause = Clause(List(variable), Return(List(variable)))
         val prompt = Variable(freshName("prompt"), Type.Prompt())
 
-        Reset(prompt, returnClause, false,
+        Reset(prompt, returnClause,
           (bparams zip handlers).foldRight(transform(body)){
             case ((id, handler), body) =>
               New(transform(id), transform(handler, Some(prompt)), body)
@@ -222,7 +222,7 @@ object Transformer {
         val returnClause = Clause(List(variable), Return(List(variable)))
         val prompt = transform(region)
 
-        Reset(prompt, returnClause, true, transform(body))
+        Reset(prompt, returnClause, transform(body))
 
       case core.Alloc(id, init, region, body) =>
         transform(init).run { value =>
@@ -241,11 +241,11 @@ object Transformer {
               val globalPrompt = Variable(freshName("global"), Type.Prompt())
               LiteralInt(globalPrompt, 2L,
                 Shift(temporary, globalPrompt,
-                  Var(reference, value, None,
+                  Var(reference, value, Type.Positive(),
                     Resume(temporary, transform(body)))))
             case _ =>
               Shift(temporary, prompt,
-                Var(reference, value, None,
+                Var(reference, value, Type.Positive(),
                   Resume(temporary, transform(body))))
           }
         }
@@ -256,7 +256,7 @@ object Transformer {
         val prompt = Variable(freshName("prompt"), Type.Prompt())
 
         transform(init).run { value =>
-          Var(reference, value, Some(transform(body.tpe)),
+          Var(reference, value, transform(body.tpe),
             transform(body))
         }
 

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -240,9 +240,9 @@ object Transformer {
               //    We need to truly special case global memory!
               val globalPrompt = Variable(freshName("global"), Type.Prompt())
               LiteralInt(globalPrompt, 2L,
-                PopStacks(temporary, globalPrompt,
+                Shift(temporary, globalPrompt,
                   Var(reference, value, None,
-                    PushStack(temporary, transform(body)))))
+                    Resume(temporary, transform(body)))))
             case _ =>
               Shift(temporary, prompt,
                 Var(reference, value, None,

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -235,14 +235,10 @@ object Transformer {
 
           region match {
             case symbols.builtins.globalRegion =>
-              // TODO currently we use prompt 2 as a quick fix...
-              //    However, this will not work when reinstalling a fresh stack
-              //    We need to truly special case global memory!
-              val globalPrompt = Variable(freshName("global"), Type.Prompt())
-              LiteralInt(globalPrompt, 2L,
-                Shift(temporary, globalPrompt,
-                  Var(reference, value, Type.Positive(),
-                    Resume(temporary, transform(body)))))
+              val globalPrompt = Variable("global", Type.Prompt())
+              Shift(temporary, globalPrompt,
+                Var(reference, value, Type.Positive(),
+                  Resume(temporary, transform(body))))
             case _ =>
               Shift(temporary, prompt,
                 Var(reference, value, Type.Positive(),

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -146,7 +146,7 @@ enum Statement {
   /**
    * e.g. var x = 42; s
    */
-  case Var(name: Variable, init: Variable, returnType: Option[Type], rest: Statement)
+  case Var(name: Variable, init: Variable, returnType: Type, rest: Statement)
 
   /**
    * e.g. let y = loadVar(x); s
@@ -171,7 +171,7 @@ enum Statement {
   /**
    * e.g. let prompt = reset { (x, ...) => s }; s
    */
-  case Reset(name: Variable, frame: Clause, isRegion: Boolean, rest: Statement)
+  case Reset(name: Variable, frame: Clause, rest: Statement)
 
   /**
    * e.g. resume k; s

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -144,21 +144,6 @@ enum Statement {
   case Invoke(receiver: Variable, tag: Tag, arguments: Environment)
 
   /**
-   * e.g. let x = allocate(42, region); s
-   */
-  case Allocate(name: Variable, init: Variable, region: Variable, rest: Statement)
-
-  /**
-   * e.g. let y = load(x); s
-   */
-  case Load(name: Variable, reference: Variable, rest: Statement)
-
-  /**
-   * e.g. store(x, 42); s
-   */
-  case Store(reference: Variable, value: Variable, rest: Statement)
-
-  /**
    * e.g. var x = 42; s
    */
   case Var(name: Variable, init: Variable, returnType: Option[Type], rest: Statement)

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -161,7 +161,7 @@ enum Statement {
   /**
    * e.g. var x = 42; s
    */
-  case Var(name: Variable, init: Variable, returnType: Type, rest: Statement)
+  case Var(name: Variable, init: Variable, returnType: Option[Type], rest: Statement)
 
   /**
    * e.g. let y = loadVar(x); s
@@ -186,7 +186,7 @@ enum Statement {
   /**
    * e.g. let prompt = reset { (x, ...) => s }; s
    */
-  case Reset(name: Variable, frame: Clause, rest: Statement)
+  case Reset(name: Variable, frame: Clause, isRegion: Boolean, rest: Statement)
 
   /**
    * e.g. resume k; s

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -680,7 +680,7 @@ define private void @topLevelEraser(%Environment %environment) {
 define private %Stack @withEmptyStack() {
     %globals = call %Stack @reset(%Stack null)
 
-    %globalsStackPointer_pointer = getelementptr %StackValue, %Stack %globalsStack, i64 0, i32 1, i32 0
+    %globalsStackPointer_pointer = getelementptr %StackValue, %Stack %globals, i64 0, i32 1, i32 0
     %globalsStackPointer = load %StackPointer, ptr %globalsStackPointer_pointer
 
     %returnAddressPointer.0 = getelementptr %FrameHeader, %StackPointer %globalsStackPointer, i64 0, i32 0

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -660,7 +660,8 @@ define private void @eraseFrames(%StackPointer %stackPointer) alwaysinline {
 
 define private tailcc void @topLevel(%Pos %val, %Stack %stack) {
     %rest = call %Stack @underflowStack(%Stack %stack)
-    ; assert %rest == null
+    ; rest holds global variables
+    call void @eraseStack(%Stack %rest)
     ret void
 }
 
@@ -678,6 +679,20 @@ define private void @topLevelEraser(%Environment %environment) {
 
 define private %Stack @withEmptyStack() {
     %globals = call %Stack @reset(%Stack null)
+
+    %globalsStackPointer_pointer = getelementptr %StackValue, %Stack %globalsStack, i64 0, i32 1, i32 0
+    %globalsStackPointer = load %StackPointer, ptr %globalsStackPointer_pointer
+
+    %returnAddressPointer.0 = getelementptr %FrameHeader, %StackPointer %globalsStackPointer, i64 0, i32 0
+    %sharerPointer.0 = getelementptr %FrameHeader, %StackPointer %globalsStackPointer, i64 0, i32 1
+    %eraserPointer.0 = getelementptr %FrameHeader, %StackPointer %globalsStackPointer, i64 0, i32 2
+
+    store ptr @nop, ptr %returnAddressPointer.0
+    store ptr @nop, ptr %sharerPointer.0
+    store ptr @free, ptr %eraserPointer.0
+
+    %globalsStackPointer_2 = getelementptr %FrameHeader, %StackPointer %globalsStackPointer, i64 1
+    store %StackPointer %globalsStackPointer_2, ptr %globalsStackPointer_pointer
 
     %stack = call %Stack @reset(%Stack %globals)
 

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -58,14 +58,6 @@
 ; Pointers for a heap allocated stack
 %Memory = type { %StackPointer, %Base, %Limit }
 
-; The garbage collector differentiates three groups of types:
-; - Values (Integer, Double)
-; - Objects (Positive, Negative)
-; - Strings
-; For each group we have an arena where mutable state is allocated.
-;
-%Region = type [ 3 x %Memory ]
-
 ; Unique address for each handler.
 %Prompt = type ptr
 
@@ -82,7 +74,7 @@
 ; This is used for two purposes:
 ;   - a refied first-class list of stacks (cyclic linked-list)
 ;   - as part of an intrusive linked-list of stacks (meta stack)
-%StackValue = type { %ReferenceCount, %Memory, %Region, %Prompt, i1, %Stack }
+%StackValue = type { %ReferenceCount, %Memory, %Prompt, i1, %Stack }
 
 
 
@@ -124,7 +116,7 @@ declare void @exit(i64)
 ; Prompts
 
 define private %Prompt @currentPrompt(%Stack %stack) {
-    %prompt_pointer = getelementptr %StackValue, ptr %stack, i64 0, i32 3
+    %prompt_pointer = getelementptr %StackValue, ptr %stack, i64 0, i32 2
     %prompt = load %Prompt, ptr %prompt_pointer
     ret %Prompt %prompt
 }
@@ -222,77 +214,6 @@ define void @eraseNegative(%Neg %val) alwaysinline {
 
 
 ; Arena management
-define private ptr @getRegionPointer(%Prompt %prompt) {
-    %stack_pointer = getelementptr %PromptValue, %Prompt %prompt, i64 0, i32 1
-    %stack = load %Stack, ptr %stack_pointer
-    %region_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
-    ret ptr %region_pointer
-}
-
-define private { ptr, %Reference } @alloc(i64 %index, %Prompt %prompt) alwaysinline {
-    %region_pointer = call ptr @getRegionPointer(%Prompt %prompt)
-
-    %stackPointer_pointer = getelementptr %Region, ptr %region_pointer, i64 0, i64 %index, i32 0
-    %base_pointer = getelementptr %Region, ptr %region_pointer, i64 0, i64 %index, i32 1
-    %limit_pointer = getelementptr %Region, ptr %region_pointer, i64 0, i64 %index, i32 2
-
-    %stackPointer = load %StackPointer, ptr %stackPointer_pointer
-    %base = load %Base, ptr %base_pointer
-    %limit = load %Limit, ptr %limit_pointer
-
-    %object = icmp ne i64 %index, 0
-    %size = select i1 %object, i64 16, i64 8
-
-    %nextStackPointer = getelementptr i8, %StackPointer %stackPointer, i64 %size
-
-    %cmp = icmp ule %StackPointer %nextStackPointer, %limit
-    br i1 %cmp, label %continue, label %realloc
-
-continue:
-    store %StackPointer %nextStackPointer, ptr %stackPointer_pointer
-    %intBase = ptrtoint %Base %base to i64
-    %intStackPointer = ptrtoint %StackPointer %stackPointer to i64
-    %offset = sub i64 %intStackPointer, %intBase
-
-    %ret.0 = insertvalue { ptr, %Reference } undef, %StackPointer %stackPointer, 0
-    %ret.1 = insertvalue { ptr, %Reference } %ret.0, %Prompt %prompt, 1, 0
-    %ret.2 = insertvalue { ptr, %Reference } %ret.1, i64 %offset, 1, 1
-    ret { ptr, %Reference } %ret.2
-
-realloc:
-    %intBase_2 = ptrtoint %Base %base to i64
-    %intLimit = ptrtoint %Limit %limit to i64
-    %arenaSize = sub i64 %intLimit, %intBase_2
-    %empty = icmp eq i64 %arenaSize, 0
-    %double = mul i64 %arenaSize, 2
-    %newArenaSize = select i1 %empty, i64 1024, i64 %double
-
-    %newBase = call ptr @realloc(ptr %base, i64 %newArenaSize)
-    %newlimit = getelementptr i8, %Base %newBase, i64 %newArenaSize
-    %newStackPointer = getelementptr i8, %Base %newBase, i64 %arenaSize
-    %newNextStackPointer = getelementptr i8, %StackPointer %newStackPointer, i64 %size
-
-    store %Base %newBase, ptr %base_pointer
-    store %Limit %newlimit, ptr %limit_pointer
-    store %StackPointer %newNextStackPointer, ptr %stackPointer_pointer
-
-    %ret..0 = insertvalue { ptr, %Reference } undef, %StackPointer %newStackPointer, 0
-    %ret..1 = insertvalue { ptr, %Reference } %ret..0, %Prompt %prompt, 1, 0
-    %ret..2 = insertvalue { ptr, %Reference } %ret..1, i64 %arenaSize, 1, 1
-    ret { ptr, %Reference } %ret..2
-}
-
-
-define private ptr @getPointer(%Reference %reference, i64 %index, %Stack %stack) {
-    %prompt = extractvalue %Reference %reference, 0
-    %offset = extractvalue %Reference %reference, 1
-
-    %region_pointer = call ptr @getRegionPointer(%Prompt %prompt)
-    %base_pointer = getelementptr %Region, ptr %region_pointer, i64 0, i64 %index, i32 1
-    %base = load %Base, ptr %base_pointer
-    %pointer = getelementptr i8, ptr %base, i64 %offset
-    ret ptr %pointer
-}
 
 define private %Stack @getStack(%Prompt %prompt) {
     %stack_pointer = getelementptr %PromptValue, %Prompt %prompt, i64 0, i32 1
@@ -414,8 +335,8 @@ define private %Stack @reset(%Stack %oldStack) {
     %stackMemory = call %Memory @newMemory()
 
     %stack.0 = insertvalue %StackValue zeroinitializer, %Memory %stackMemory, 1
-    %stack.1 = insertvalue %StackValue %stack.0, %Prompt %prompt, 3
-    %stack.2 = insertvalue %StackValue %stack.1, %Stack %oldStack, 5
+    %stack.1 = insertvalue %StackValue %stack.0, %Prompt %prompt, 2
+    %stack.2 = insertvalue %StackValue %stack.1, %Stack %oldStack, 4
 
     store %StackValue %stack.2, %Stack %stack
 
@@ -522,23 +443,6 @@ return:
     ret void
 }
 
-define private void @eraseRegion(%Region %region) alwaysinline {
-    %valuesBase = extractvalue %Region %region, 0, 1
-    call void @free(%Base %valuesBase)
-
-    %objectsBase = extractvalue %Region %region, 1, 1
-    %objectsStackPointer = extractvalue %Region %region, 1, 0
-    call void @forEachObject(%Base %objectsBase, %StackPointer %objectsStackPointer, %Eraser @erasePositive)
-    call void @free(%Base %objectsBase)
-
-    %stringsBase = extractvalue %Region %region, 2, 1
-    %stringsStackPointer = extractvalue %Region %region, 2, 0
-    call void @forEachObject(%Base %stringsBase, %StackPointer %stringsStackPointer, %Eraser @erasePositive)
-    call void @free(%Base %stringsBase)
-
-    ret void
-}
-
 define void @erasePrompt(%Prompt %prompt, i1 %dirtyBit) alwaysinline {
     br i1 %dirtyBit, label %continue, label %clearPrompt
 
@@ -572,19 +476,16 @@ define void @sharePrompt(%Prompt %prompt) alwaysinline {
 
 define private %Stack @underflowStack(%Stack %stack) {
     %stackMemory = getelementptr %StackValue, %Stack %stack, i64 0, i32 1
-    %stackRegion = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
     %stackPrompt = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
     %stackDirtyBit = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
     %stackRest = getelementptr %StackValue, %Stack %stack, i64 0, i32 5
 
     %memory = load %Memory, ptr %stackMemory
-    %region = load %Region, ptr %stackRegion
     %prompt = load %Prompt, ptr %stackPrompt
     %rest = load %Stack, ptr %stackRest
     %dirtyBit = load i1, ptr %stackDirtyBit
 
     call void @eraseMemory(%Memory %memory)
-    call void @eraseRegion(%Region %region)
     call void @erasePrompt(%Prompt %prompt, i1 false)
     call void @free(%Stack %stack)
 
@@ -622,29 +523,6 @@ define private %Memory @copyMemory(%Memory %memory) alwaysinline {
     ret %Memory %memory.2
 }
 
-define private %Region @copyRegion(%Region %region) alwaysinline {
-    %memory.0 = extractvalue %Region %region, 0
-    %memory.1 = extractvalue %Region %region, 1
-    %memory.2 = extractvalue %Region %region, 2
-
-    %objectsBase = extractvalue %Region %region, 1, 1
-    %objectsStackPointer = extractvalue %Region %region, 1, 0
-    call void @forEachObject(%Base %objectsBase, %StackPointer %objectsStackPointer, %Sharer @sharePositive)
-
-    %stringsBase = extractvalue %Region %region, 2, 1
-    %stringsStackPointer = extractvalue %Region %region, 2, 0
-    call void @forEachObject(%Base %stringsBase, %StackPointer %stringsStackPointer, %Sharer @sharePositive)
-
-    %newMemory.0 = call %Memory @copyMemory(%Memory %memory.0)
-    %newMemory.1 = call %Memory @copyMemory(%Memory %memory.1)
-    %newMemory.2 = call %Memory @copyMemory(%Memory %memory.2)
-
-    %region.0 = insertvalue %Region undef, %Memory %newMemory.0, 0
-    %region.1 = insertvalue %Region %region.0, %Memory %newMemory.1, 1
-    %region.2 = insertvalue %Region %region.1, %Memory %newMemory.2, 2
-
-    ret %Region %region.2
-}
 
 define private %Resumption @uniqueStack(%Resumption %resumption) alwaysinline {
 
@@ -672,34 +550,28 @@ loop:
     %newStack = phi %Stack [%newHead, %copy], [%nextNew, %next]
 
     %stackMemory = getelementptr %StackValue, %Stack %old, i64 0, i32 1
-    %stackRegion = getelementptr %StackValue, %Stack %old, i64 0, i32 2
-    %stackPrompt = getelementptr %StackValue, %Stack %old, i64 0, i32 3
-    %stackRest = getelementptr %StackValue, %Stack %old, i64 0, i32 5
+    %stackPrompt = getelementptr %StackValue, %Stack %old, i64 0, i32 2
+    %stackRest = getelementptr %StackValue, %Stack %old, i64 0, i32 4
 
     %memory = load %Memory, ptr %stackMemory
-    %region = load %Region, ptr %stackRegion
     %prompt = load %Prompt, ptr %stackPrompt
     %rest = load %Stack, ptr %stackRest
 
     %newStackReferenceCounter = getelementptr %StackValue, %Stack %newStack, i64 0, i32 0
     %newStackMemory = getelementptr %StackValue, %Stack %newStack, i64 0, i32 1
-    %newStackRegion = getelementptr %StackValue, %Stack %newStack, i64 0, i32 2
-    %newStackPrompt = getelementptr %StackValue, %Stack %newStack, i64 0, i32 3
-    %newStackDirtyBit = getelementptr %StackValue, %Stack %newStack, i64 0, i32 4
-    %newStackRest = getelementptr %StackValue, %Stack %newStack, i64 0, i32 5
+    %newStackPrompt = getelementptr %StackValue, %Stack %newStack, i64 0, i32 2
+    %newStackDirtyBit = getelementptr %StackValue, %Stack %newStack, i64 0, i32 3
+    %newStackRest = getelementptr %StackValue, %Stack %newStack, i64 0, i32 4
 
     %newMemory = call %Memory @copyMemory(%Memory %memory)
 
     %newStackPointer = extractvalue %Memory %newMemory, 0
     call void @shareFrames(%StackPointer %newStackPointer)
 
-    %newRegion = call %Region @copyRegion(%Region %region)
-
     call void @sharePrompt(%Prompt %prompt)
 
-    store i64 0, ptr %newStackReferenceCounter
+    store %ReferenceCount 0, ptr %newStackReferenceCounter
     store %Memory %newMemory, ptr %newStackMemory
-    store %Region %newRegion, ptr %newStackRegion
     store %Prompt %prompt, ptr %newStackPrompt
     store i1 1, ptr %newStackDirtyBit
 
@@ -744,20 +616,17 @@ define void @eraseResumption(%Resumption %resumption) alwaysinline {
 
 define void @eraseStack(%Stack %stack) alwaysinline {
     %stackPointer_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 1, i32 0
-    %region_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
-    %prompt_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
-    %dirtyBit_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
-    %rest_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 5
+    %prompt_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
+    %dirtyBit_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
+    %rest_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
 
     %stackPointer = load %StackPointer, ptr %stackPointer_pointer
-    %region = load %Region, ptr %region_pointer
     %prompt = load %Stack, ptr %prompt_pointer
     %dirtyBit = load i1, ptr %dirtyBit_pointer
     %rest = load %Stack, ptr %rest_pointer
 
     call void @free(%Stack %stack)
     call void @eraseFrames(%StackPointer %stackPointer)
-    call void @eraseRegion(%Region %region)
     call void @erasePrompt(%Prompt %prompt, i1 %dirtyBit)
 
     %isNull = icmp eq %Stack %rest, null

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -347,7 +347,7 @@ define private %Stack @reset(%Stack %oldStack) {
 }
 
 define private void @updatePrompts(%Stack %stack) {
-    %dirtyBit_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
+    %dirtyBit_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
     %dirtyBit = load i1, ptr %dirtyBit_pointer
     br i1 %dirtyBit, label %continue, label %done
 
@@ -355,7 +355,7 @@ done:
     ret void
 
 continue:
-    %prompt_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
+    %prompt_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
     %prompt = load %Prompt, ptr %prompt_pointer
     %stack_pointer = getelementptr %PromptValue, %Prompt %prompt, i64 0, i32 1
     %promptStack = load %Stack, ptr %stack_pointer
@@ -370,16 +370,16 @@ update:
     store %Stack %stack, ptr %stack_pointer
     store i1 0, ptr %dirtyBit_pointer
 
-    %next_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 5
+    %next_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
     %next = load %Stack, ptr %next_pointer
     tail call void @updatePrompts(%Stack %next)
     ret void
 }
 
 define void @displace(%Stack %stack) {
-    %prompt_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
-    %next_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 5
-    %dirtyBit_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
+    %prompt_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
+    %next_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
+    %dirtyBit_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
     %dirtyBit = load i1, ptr %dirtyBit_pointer
     br i1 %dirtyBit, label %done, label %continue
 
@@ -399,7 +399,7 @@ continue:
 
 define %Stack @resume(%Resumption %resumption, %Stack %oldStack) {
     %uniqueResumption = call %Resumption @uniqueStack(%Resumption %resumption)
-    %rest_pointer = getelementptr %StackValue, %Resumption %uniqueResumption, i64 0, i32 5
+    %rest_pointer = getelementptr %StackValue, %Resumption %uniqueResumption, i64 0, i32 4
     %start = load %Stack, ptr %rest_pointer
     call void @updatePrompts(%Stack %start)
 
@@ -411,7 +411,7 @@ define %Stack @resume(%Resumption %resumption, %Stack %oldStack) {
 define private {%Resumption, %Stack} @shift(%Stack %stack, %Prompt %prompt) {
     %resumpion_pointer = getelementptr %PromptValue, %Prompt %prompt, i64 0, i32 1
     %resumption = load %Stack, ptr %resumpion_pointer
-    %next_pointer = getelementptr %StackValue, %Stack %resumption, i64 0, i32 5
+    %next_pointer = getelementptr %StackValue, %Stack %resumption, i64 0, i32 4
     %next = load %Stack, ptr %next_pointer
 
     store %Stack %stack, ptr %next_pointer
@@ -476,9 +476,9 @@ define void @sharePrompt(%Prompt %prompt) alwaysinline {
 
 define private %Stack @underflowStack(%Stack %stack) {
     %stackMemory = getelementptr %StackValue, %Stack %stack, i64 0, i32 1
-    %stackPrompt = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
-    %stackDirtyBit = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
-    %stackRest = getelementptr %StackValue, %Stack %stack, i64 0, i32 5
+    %stackPrompt = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
+    %stackDirtyBit = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
+    %stackRest = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
 
     %memory = load %Memory, ptr %stackMemory
     %prompt = load %Prompt, ptr %stackPrompt
@@ -537,7 +537,7 @@ done:
 copy:
     %newOldReferenceCount = sub %ReferenceCount %referenceCount, 1
     store %ReferenceCount %newOldReferenceCount, ptr %referenceCount_pointer
-    %stack_pointer = getelementptr %StackValue, %Resumption %resumption, i64 0, i32 5
+    %stack_pointer = getelementptr %StackValue, %Resumption %resumption, i64 0, i32 4
     %stack = load %Stack, ptr %stack_pointer
 
     %size = ptrtoint ptr getelementptr (%StackValue, ptr null, i64 1) to i64
@@ -607,7 +607,7 @@ define void @eraseResumption(%Resumption %resumption) alwaysinline {
     ret void
 
     free:
-    %stack_pointer = getelementptr %StackValue, %Resumption %resumption, i64 0, i32 5
+    %stack_pointer = getelementptr %StackValue, %Resumption %resumption, i64 0, i32 4
     %stack = load %Stack, ptr %stack_pointer
     store %Stack null, ptr %stack_pointer
     call void @eraseStack(%Stack %stack)

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -591,6 +591,10 @@ define private %Stack @underflowStack(%Stack %stack) {
     ret %Stack %rest
 }
 
+define private void @nop(%Stack %stack) {
+    ret void
+}
+
 define private %Memory @copyMemory(%Memory %memory) alwaysinline {
     %stackPointer = extractvalue %Memory %memory, 0
     %base = extractvalue %Memory %memory, 1

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -677,7 +677,9 @@ define private void @topLevelEraser(%Environment %environment) {
 @global = private global { i64, %Stack } { i64 0, %Stack null }
 
 define private %Stack @withEmptyStack() {
-    %stack = call %Stack @reset(%Stack null)
+    %globals = call %Stack @reset(%Stack null)
+
+    %stack = call %Stack @reset(%Stack %globals)
 
     %globalStack = getelementptr %PromptValue, %Prompt @global, i64 0, i32 1
     store %Stack %stack, ptr %globalStack


### PR DESCRIPTION
@phischu I hate how this turned out.

When allocating into a region, we cannot know the answer type of that region. This makes it impossible to push a regular return address.

As a workaround, variables are allocated with a special return function, that removes the region from the stack. When underflowing a region, we first call this special function, and then return regularly.

Also, this breaks globals, as the first stack has no previous stack.