### PR TITLE
Require default for finite domains instead of giving up

### DIFF
--- a/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
@@ -253,19 +253,16 @@ object ExhaustivityChecker {
         }
       }
 
-      def requireDefault(): Unit =
-        defaults.toList match {
-          case Nil => E.missingDefault(tpe, scrutinee)
-          case head :: tail => matchClauses(head, tail)
-        }
-
       finite match {
         // we have a finite domain
         case Some(cases) =>
           cases.foreach { v =>
             matches.get(v) match {
               case Some(head :: tail) => matchClauses(head, tail)
-              case _ => requireDefault()
+              case _ => defaults.toList match {
+                case Nil => E.missingLiteral(v, tpe, scrutinee)
+                case head :: tail => matchClauses(head, tail)
+              }
             }
           }
 
@@ -274,7 +271,10 @@ object ExhaustivityChecker {
           matches.collect {
             case (_, head :: tail) => matchClauses(head, tail)
           }
-          requireDefault()
+          defaults.toList match {
+            case Nil => E.missingDefault(tpe, scrutinee)
+            case head :: tail => matchClauses(head, tail)
+          }
       }
     }
 

--- a/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
@@ -253,13 +253,19 @@ object ExhaustivityChecker {
         }
       }
 
+      def requireDefault(): Unit =
+        defaults.toList match {
+          case Nil => E.missingDefault(tpe, scrutinee)
+          case head :: tail => matchClauses(head, tail)
+        }
+
       finite match {
         // we have a finite domain
         case Some(cases) =>
           cases.foreach { v =>
             matches.get(v) match {
               case Some(head :: tail) => matchClauses(head, tail)
-              case _ => E.missingLiteral(v, tpe, scrutinee)
+              case _ => requireDefault()
             }
           }
 
@@ -268,10 +274,7 @@ object ExhaustivityChecker {
           matches.collect {
             case (_, head :: tail) => matchClauses(head, tail)
           }
-          defaults.toList match {
-            case Nil => E.missingDefault(tpe, scrutinee)
-            case head :: tail => matchClauses(head, tail)
-          }
+          requireDefault()
       }
     }
 

--- a/examples/pos/issue652.effek
+++ b/examples/pos/issue652.effek
@@ -1,0 +1,4 @@
+def foo(opt: Option[Bool]) = opt match {
+  case Some(false) => Some(false)
+  case opt => Some(true)
+}

--- a/examples/pos/issue652.effekt
+++ b/examples/pos/issue652.effekt
@@ -1,0 +1,6 @@
+def foo(opt: Option[Bool]) = opt match {
+  case Some(false) => Some(false)
+  case opt => Some(true)
+}
+
+def main() = ()


### PR DESCRIPTION
Should fix #652 