### PR TITLE
Add more GCC flags to CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Run tests
-      run: EFFEKT_VALGRIND=1 sbt clean test
+      run: EFFEKT_VALGRIND=1 EFFEKT_DEBUG=1 sbt clean test
 
     - name: Assemble fully optimized js file
       run: sbt effektJS/fullOptJS

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -332,8 +332,9 @@ object LLVMRunner extends Runner[String] {
     val executableFile = basePath
     var gccArgs = Seq(gcc, gccMainFile, "-o", executableFile, objPath) ++ linkedLibraries
 
-    if (C.config.debug()) gccArgs ++= Seq("-fsanitize=address,undefined", "-fstack-protector-all", "-Og", "-g", "-Wall", "-Wextra")
+    if (C.config.debug()) gccArgs ++= Seq("-g", "-Wall", "-Wextra")
     if (C.config.valgrind()) gccArgs ++= Seq("-O0", "-g")
+    else if (C.config.debug()) gccArgs ++= Seq("-fsanitize=address,undefined", "-fstack-protector-all")
 
     exec(gccArgs: _*)
 

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -332,7 +332,7 @@ object LLVMRunner extends Runner[String] {
     val executableFile = basePath
     var gccArgs = Seq(gcc, gccMainFile, "-o", executableFile, objPath) ++ linkedLibraries
 
-    if (C.config.debug()) gccArgs ++= Seq("-g", "-Wall", "-Wextra")
+    if (C.config.debug()) gccArgs ++= Seq("-g", "-Wall", "-Wextra", "-Werror")
     if (C.config.valgrind()) gccArgs ++= Seq("-O0", "-g")
     else if (C.config.debug()) gccArgs ++= Seq("-fsanitize=address,undefined", "-fstack-protector-all")
 

--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -20,6 +20,9 @@ trait EffektTests extends munit.FunSuite {
   // Whether to execute using valgrind
   def valgrind = false
 
+  // Whether to execute using debug mode
+  def debug = false
+
   def output: File = new File(".") / "out" / "tests" / getClass.getName.toLowerCase
 
   // The sources of all testfiles are stored here:
@@ -62,9 +65,9 @@ trait EffektTests extends munit.FunSuite {
       "--Koutput", "string",
       "--backend", backendName,
       "--out", output.getPath,
-      "--debug",
     )
     if (valgrind) options = options :+ "--valgrind"
+    if (debug) options = options :+ "--debug"
     val configs = compiler.createConfig(options)
     configs.verify()
 

--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -62,6 +62,7 @@ trait EffektTests extends munit.FunSuite {
       "--Koutput", "string",
       "--backend", backendName,
       "--out", output.getPath,
+      "--debug",
     )
     if (valgrind) options = options :+ "--valgrind"
     val configs = compiler.createConfig(options)

--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -11,6 +11,7 @@ class LLVMTests extends EffektTests {
   def backendName = "llvm"
 
   override def valgrind = sys.env.get("EFFEKT_VALGRIND").nonEmpty
+  override def debug = sys.env.get("EFFEKT_DEBUG").nonEmpty
 
   override lazy val positives: List[File] = List(
     examplesDir / "llvm",

--- a/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
@@ -36,6 +36,7 @@ class StdlibLLVMTests extends StdlibTests {
   def backendName: String = "llvm"
 
   override def valgrind = sys.env.get("EFFEKT_VALGRIND").nonEmpty
+  override def debug = sys.env.get("EFFEKT_DEBUG").nonEmpty
 
   override def ignored: List[File] = List(
     // Toplevel let-bindings (for ANSI-color-codes in output) not supported


### PR DESCRIPTION
Within the last few weeks we've repeatedly had compilation warnings in the LLVM backend compiled with the master branch. The warnings could have been caught earlier by running Effekt with the `--debug` flag.

To enforce this, the CI now runs with `--debug` by default (in addition to `--valgrind`) and `--debug` adds the additional `-Werror` flag -- thus failing the CI if the compilation produces warnings.