### PR TITLE
More sharing of erasers and sharers

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -714,31 +714,21 @@ object Transformer {
     }
 
   def shareValue(value: machine.Variable)(using FunctionContext, BlockContext): Unit = {
-    value.tpe match {
-      case machine.Positive()        => emit(Call("_", Ccc(), VoidType(), sharePositive, List(transform(value))))
-      case machine.Negative()        => emit(Call("_", Ccc(), VoidType(), shareNegative, List(transform(value))))
-      case machine.Type.Prompt()     => ()
-      case machine.Type.Stack()      => emit(Call("_", Ccc(), VoidType(), shareResumption, List(transform(value))))
-      case machine.Type.Int()        => ()
-      case machine.Type.Byte()       => ()
-      case machine.Type.Double()     => ()
-      case machine.Type.String()     => emit(Call("_", Ccc(), VoidType(), shareString, List(transform(value))))
-      case machine.Type.Reference(_) => ()
-    }
+    Option(value.tpe).collect {
+      case machine.Positive()    => Call("_", Ccc(), VoidType(), sharePositive, List(transform(value)))
+      case machine.Negative()    => Call("_", Ccc(), VoidType(), shareNegative, List(transform(value)))
+      case machine.Type.Stack()  => Call("_", Ccc(), VoidType(), shareResumption, List(transform(value)))
+      case machine.Type.String() => Call("_", Ccc(), VoidType(), shareString, List(transform(value)))
+    }.map(emit)
   }
 
   def eraseValue(value: machine.Variable)(using FunctionContext, BlockContext): Unit = {
-    value.tpe match {
-      case machine.Positive()        => emit(Call("_", Ccc(), VoidType(), erasePositive, List(transform(value))))
-      case machine.Negative()        => emit(Call("_", Ccc(), VoidType(), eraseNegative, List(transform(value))))
-      case machine.Type.Prompt()     => ()
-      case machine.Type.Stack()      => emit(Call("_", Ccc(), VoidType(), eraseResumption, List(transform(value))))
-      case machine.Type.Int()        => ()
-      case machine.Type.Byte()       => ()
-      case machine.Type.Double()     => ()
-      case machine.Type.String()     => emit(Call("_", Ccc(), VoidType(), eraseString, List(transform(value))))
-      case machine.Type.Reference(_) => ()
-    }
+    Option(value.tpe).collect {
+      case machine.Positive()    => Call("_", Ccc(), VoidType(), erasePositive, List(transform(value)))
+      case machine.Negative()    => Call("_", Ccc(), VoidType(), eraseNegative, List(transform(value)))
+      case machine.Type.Stack()  => Call("_", Ccc(), VoidType(), eraseResumption, List(transform(value)))
+      case machine.Type.String() => Call("_", Ccc(), VoidType(), eraseString, List(transform(value)))
+    }.map(emit)
   }
 
   def pushReturnAddressOnto(stack: Operand, returnAddressName: String, sharer: Operand, eraser: Operand)(using ModuleContext, FunctionContext, BlockContext): Unit = {

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -556,12 +556,13 @@ object Transformer {
       case machine.Variable(name, tpe) => machine.Variable(freshName(name), tpe)
     };
 
-    // TODO: re-add comments based on eraser kind
     C.erasers.getOrElseUpdate((types, kind), {
       kind match {
         case ObjectEraser =>
           val eraser = ConstantGlobal(freshName("eraser"));
           defineFunction(eraser.name, List(Parameter(environmentType, "environment"))) {
+            emit(Comment(s"${kind} eraser, ${freshEnvironment.length} free variables"))
+
             // TODO avoid unnecessary loads
             loadEnvironmentAt(LocalReference(environmentType, "environment"), freshEnvironment);
             eraseValues(freshEnvironment, Set());
@@ -571,6 +572,8 @@ object Transformer {
         case StackEraser | StackFrameEraser =>
           val eraser = ConstantGlobal(freshName("eraser"));
           defineFunction(eraser.name, List(Parameter(stackPointerType, "stackPointer"))) {
+            emit(Comment(s"${kind} eraser, ${freshEnvironment.length} free variables"))
+
             val nextStackPointer = LocalReference(stackPointerType, freshName("stackPointer"));
             emit(GetElementPtr(nextStackPointer.name, environmentType(freshEnvironment), LocalReference(stackPointerType, "stackPointer"), List(-1)));
             loadEnvironmentAt(nextStackPointer, freshEnvironment);
@@ -591,10 +594,11 @@ object Transformer {
       case machine.Variable(name, tpe) => machine.Variable(freshName(name), tpe)
     };
 
-    // TODO: re-add comments based on sharer kind
     C.sharers.getOrElseUpdate((types, kind), {
       val sharer = ConstantGlobal(freshName("sharer"));
       defineFunction(sharer.name, List(Parameter(stackPointerType, "stackPointer"))) {
+        emit(Comment(s"${kind} sharer, ${freshEnvironment.length} free variables"))
+
         val nextStackPointer = LocalReference(stackPointerType, freshName("stackPointer"));
         emit(GetElementPtr(nextStackPointer.name, environmentType(freshEnvironment), LocalReference(stackPointerType, "stackPointer"), List(-1)));
         loadEnvironmentAt(nextStackPointer, freshEnvironment);

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
@@ -70,6 +70,12 @@ enum EraserKind {
 }
 export EraserKind.*
 
+enum SharerKind {
+  case StackSharer
+  case StackFrameSharer
+}
+export SharerKind.*
+
 /**
  *  see: https://hackage.haskell.org/package/llvm-hs-pure-9.0.0/docs/LLVM-AST.html#t:Type
  */

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
@@ -63,6 +63,13 @@ object Operand {
 }
 export Operand.*
 
+enum EraserKind {
+  case ObjectEraser
+  case StackEraser
+  case StackFrameEraser
+}
+export EraserKind.*
+
 /**
  *  see: https://hackage.haskell.org/package/llvm-hs-pure-9.0.0/docs/LLVM-AST.html#t:Type
  */


### PR DESCRIPTION
Currently we generate a lot of erasers and sharers repeatedly even if they erase or share the same objects. This PR reduces the redundancy, although it has a smaller effect than (I) expected.

CLOC of `effekt.llvmtests` before:

```
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
LLVM IR                        188          98411          15714         225451
```

CLOC of `effekt.llvmtests` after (~20kLOC reduction):

```
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
LLVM IR                        188          86310          15714         207307
-------------------------------------------------------------------------------
```

This is a first step towards making erasing and sharing in the LLVM backend more elegant. There are many more (more complex) improvements that I/we would like to make, but I suggest we do this in a separate PR.