### PR TITLE
Optimize tailresumptive handlers

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/Inline.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Inline.scala
@@ -4,11 +4,9 @@ package core
 import effekt.core.Block.BlockLit
 import effekt.core.Pure.ValueVar
 import effekt.core.normal.*
-
 import effekt.util.messages.INTERNAL_ERROR
 
 import scala.collection.mutable
-
 import kiama.util.Counter
 
 /**
@@ -122,7 +120,7 @@ object Inline {
     case Definition.Let(id, tpe, binding) => Definition.Let(id, tpe, rewrite(binding))
   }
 
-  def rewrite(s: Stmt)(using InlineContext): Stmt = s match {
+  def rewrite(s: Stmt)(using C: InlineContext): Stmt = s match {
     case Stmt.Scope(definitions, body) =>
       val (defs, ctx) = rewrite(definitions)
       scope(defs, rewrite(body)(using ctx))
@@ -130,9 +128,11 @@ object Inline {
     case Stmt.App(b, targs, vargs, bargs) =>
       app(rewrite(b), targs, vargs.map(rewrite), bargs.map(rewrite))
 
-    case Stmt.Reset(BlockLit(tparams, cparams, vparams, List(prompt), body)) if !used(prompt.id) => rewrite(body)
-
-    case Stmt.Reset(body) => Stmt.Reset(rewrite(body))
+    case Stmt.Reset(body) =>
+      rewrite(body) match {
+        case BlockLit(tparams, cparams, vparams, List(prompt), body) if !used(prompt.id) => body
+        case b => Stmt.Reset(b)
+      }
 
     // congruences
     case Stmt.Return(expr) => Return(rewrite(expr))
@@ -141,7 +141,13 @@ object Inline {
     case Stmt.Match(scrutinee, clauses, default) =>
       patternMatch(rewrite(scrutinee), clauses.map { case (id, value) => id -> rewrite(value) }, default.map(rewrite))
     case Stmt.Alloc(id, init, region, body) => Alloc(id, rewrite(init), region, rewrite(body))
+    case Stmt.Shift(prompt, b @ BlockLit(tparams, cparams, vparams, List(k), body)) if tailResumptive(k.id, body) =>
+      C.inlineCount.next()
+      rewrite(removeTailResumption(k.id, body))
+
     case Stmt.Shift(prompt, body) => Shift(prompt, rewrite(body))
+
+
     case Stmt.Resume(k, body) => Resume(k, rewrite(body))
     case Stmt.Region(body) => Region(rewrite(body))
     case Stmt.Var(id, init, capture, body) => Stmt.Var(id, rewrite(init), capture, rewrite(body))
@@ -206,4 +212,61 @@ object Inline {
   }
 
   def pure[A](a: A): Binding[A] = Binding(k => k(a))
+
+  // A simple syntactic check whether this stmt is tailresumptive in k
+  def tailResumptive(k: Id, stmt: Stmt): Boolean =
+    def freeInStmt(stmt: Stmt): Boolean = Variables.free(stmt).containsBlock(k)
+    def freeInExpr(expr: Expr): Boolean = Variables.free(expr).containsBlock(k)
+    def freeInDef(definition: Definition): Boolean = Variables.free(definition).containsBlock(k)
+
+    stmt match {
+      case Stmt.Scope(definitions, body) => definitions.forall { d => !freeInDef(d) } && tailResumptive(k, body)
+      case Stmt.Return(expr) => false
+      case Stmt.Val(id, annotatedTpe, binding, body) => tailResumptive(k, body) && !freeInStmt(binding)
+      case Stmt.App(callee, targs, vargs, bargs) => false
+      case Stmt.If(cond, thn, els) => !freeInExpr(cond) && tailResumptive(k, thn) && tailResumptive(k, els)
+      // Interestingly, we introduce a join point making this more difficult to implement properly
+      case Stmt.Match(scrutinee, clauses, default) => !freeInExpr(scrutinee) && clauses.forall {
+        case (_, BlockLit(tparams, cparams, vparams, bparams, body)) => tailResumptive(k, body)
+      } && default.forall { stmt => tailResumptive(k, stmt) }
+      case Stmt.Region(BlockLit(tparams, cparams, vparams, bparams, body)) => tailResumptive(k, body)
+      case Stmt.Region(_) => ???
+      case Stmt.Alloc(id, init, region, body) => tailResumptive(k, body) && !freeInExpr(init)
+      case Stmt.Var(id, init, capture, body) => tailResumptive(k, body) && !freeInExpr(init)
+      case Stmt.Get(id, annotatedCapt, annotatedTpe) => false
+      case Stmt.Put(id, annotatedCapt, value) => false
+      case Stmt.Reset(BlockLit(tparams, cparams, vparams, bparams, body)) => tailResumptive(k, body) // is this correct?
+      case Stmt.Shift(prompt, body) => false
+      case Stmt.Resume(k2, body) => k2.id == k // what if k is free in body?
+      case Stmt.Hole() => true
+    }
+
+  def removeTailResumption(k: Id, stmt: Stmt): Stmt = stmt match {
+    case Stmt.Scope(definitions, body) => Stmt.Scope(definitions, removeTailResumption(k, body))
+    case Stmt.Val(id, annotatedTpe, binding, body) => Stmt.Val(id, annotatedTpe, binding, removeTailResumption(k, body))
+    case Stmt.If(cond, thn, els) => Stmt.If(cond, removeTailResumption(k, thn), removeTailResumption(k, els))
+    case Stmt.Match(scrutinee, clauses, default) => Stmt.Match(scrutinee, clauses.map {
+      case (tag, block) => tag -> removeTailResumption(k, block)
+    }, default.map(removeTailResumption(k, _)))
+    case Stmt.Region(body : BlockLit) =>
+      Stmt.Region(removeTailResumption(k, body))
+    case Stmt.Region(_) => ???
+    case Stmt.Alloc(id, init, region, body) => Stmt.Alloc(id, init, region, body)
+    case Stmt.Var(id, init, capture, body) => Stmt.Var(id, init, capture, body)
+    case Stmt.Reset(body) => Stmt.Reset(removeTailResumption(k, body))
+    case Stmt.Resume(k2, body) if k2.id == k => body
+
+    case Stmt.Resume(k, body) => stmt
+    case Stmt.Shift(prompt, body) => stmt
+    case Stmt.Hole() => stmt
+    case Stmt.Return(expr) => stmt
+    case Stmt.App(callee, targs, vargs, bargs) => stmt
+    case Stmt.Get(id, annotatedCapt, annotatedTpe) => stmt
+    case Stmt.Put(id, annotatedCapt, value) => stmt
+  }
+
+  def removeTailResumption(k: Id, block: BlockLit): BlockLit = block match {
+    case BlockLit(tparams, cparams, vparams, bparams, body) =>
+      BlockLit(tparams, cparams, vparams, bparams, removeTailResumption(k, body))
+  }
 }

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -628,6 +628,9 @@ case class Variables(vars: Set[Variable]) {
   def flatMap(f: Variable => Variables): Variables = Variables(vars.flatMap(x => f(x).vars))
   def map(f: Variable => Variable): Variables = Variables(vars.map(f))
   def toList: List[Variable] = vars.toList
+
+  def containsValue(id: Id): Boolean = vars.collect { case v @ Variable.Value(other, tpe) if other == id => v }.nonEmpty
+  def containsBlock(id: Id): Boolean = vars.collect { case v @ Variable.Block(other, tpe, capt) if other == id => v }.nonEmpty
 }
 
 object Variables {

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -17,7 +17,8 @@ class JavaScript(additionalFeatureFlags: List[String] = Nil) extends Compiler[St
 
   override def supportedFeatureFlags: List[String] = additionalFeatureFlags ++ TransformerCps.jsFeatureFlags
 
-  override def prettyIR(source: Source, stage: Stage)(using Context): Option[Document] = stage match {
+  override def prettyIR(source: Source, stage: Stage)(using C: Context): Option[Document] = stage match {
+    case Stage.Core if C.config.optimize() => Optimized(source).map { (_, _, res) => core.PrettyPrinter.format(res) }
     case Stage.Core => Core(source).map { res => core.PrettyPrinter.format(res.core) }
     case Stage.Machine => None
     case Stage.Target => CompileLSP(source).map { pretty }


### PR DESCRIPTION
Enabled by #669 we can finally very easily optimize tail-resumptive handlers.