### PR TITLE
Direct Style Shift

### DIFF
--- a/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
@@ -147,8 +147,9 @@ object Transformer {
     case core.Stmt.Resume(cont, body) =>
       val ks2 = Id("ks")
       val k2 = Id("k")
-      val thunk: BlockLit = Block.BlockLit(Nil, Nil, ks2, k2, transform(body, ks2, Continuation.Dynamic(k2)))
-      App(Block.BlockVar(cont.id), Nil, List(thunk), MetaCont(ks), k.reify)
+
+      Resume(cont.id, Block.BlockLit(Nil, Nil, ks2, k2, transform(body, ks2, Continuation.Dynamic(k2))),
+        MetaCont(ks), k.reify)
 
     case core.Stmt.Hole() => Hole()
 

--- a/effekt/shared/src/main/scala/effekt/cps/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Tree.scala
@@ -139,6 +139,9 @@ enum Stmt extends Tree {
   // shift(p, { (resume, ks, k) => STMT }, ks, k)
   case Shift(prompt: Id, body: BlockLit, ks: MetaCont, k: Cont)
 
+  // resume(k, (ks, k) => STMT, ks, k)
+  case Resume(resumption: Id, body: BlockLit, ks: MetaCont, k: Cont)
+
   // Others
   case Hole()
 }
@@ -217,8 +220,11 @@ object Variables {
     case Stmt.Get(ref, id, body) => block(ref) ++ (free(body) -- value(id))
     case Stmt.Put(ref, value, body) => block(ref) ++ free(value) ++ free(body)
 
+
     case Stmt.Reset(prog, ks, k) => free(prog) ++ free(ks) ++ free(k)
     case Stmt.Shift(prompt, body, ks, k) => block(prompt) ++ free(body) ++ free(ks) ++ free(k)
+    case Stmt.Resume(r, body, ks, k) => block(r) ++ free(body) ++ free(ks) ++ free(k)
+
     case Stmt.Hole() => empty
   }
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -14,6 +14,7 @@ object TransformerCps extends Transformer {
   val RUN_TOPLEVEL = Variable(JSName("RUN_TOPLEVEL"))
   val RESET = Variable(JSName("RESET"))
   val SHIFT = Variable(JSName("SHIFT"))
+  val RESUME = Variable(JSName("RESUME"))
   val THUNK = Variable(JSName("THUNK"))
   val DEALLOC = Variable(JSName("DEALLOC"))
   val TRAMPOLINE = Variable(JSName("TRAMPOLINE"))
@@ -257,7 +258,9 @@ object TransformerCps extends Transformer {
           Call(RESET, toJS(ks2), toJS(k2))) ::
           toJS(body).run(k)
       }
-    case cps.Stmt.Reset(body, ks, k) => ???
+
+    case cps.Stmt.Reset(prog, ks, k) =>
+      pure(js.Return(Call(RESET, toJS(prog), toJS(ks), toJS(k))))
 
     case cps.Stmt.Shift(prompt, BlockLit(vparams, List(resume), ks3, k3, body), ks2, k2) =>
       Binding { k =>
@@ -266,6 +269,13 @@ object TransformerCps extends Transformer {
           toJS(body).run(k)
       }
     case cps.Stmt.Shift(prompt, body, ks, k) => ???
+
+    case cps.Stmt.Resume(r, BlockLit(vparams, bparams, ks3, k3, body), ks2, k2) =>
+      Binding { k =>
+        js.Const(js.Pattern.Array(List(js.Pattern.Variable(nameDef(ks3)), js.Pattern.Variable(nameDef(k3)))),
+          Call(RESUME, nameRef(r), toJS(ks2), toJS(k2))) ::
+          toJS(body).run(k)
+      }
 
     case cps.Stmt.Hole() =>
       pure(js.Return($effekt.call("hole")))

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -251,11 +251,21 @@ object TransformerCps extends Transformer {
         toJS(body).run(k)
     }
 
-    case cps.Stmt.Reset(prog, ks, k) =>
-      pure(js.Return(Call(RESET, toJS(prog), toJS(ks), toJS(k))))
+    case cps.Stmt.Reset(BlockLit(vparams, List(prompt), ks3, k3, body), ks2, k2) =>
+      Binding { k =>
+        js.Const(js.Pattern.Array(List(js.Pattern.Variable(nameDef(prompt)), js.Pattern.Variable(nameDef(ks3)), js.Pattern.Variable(nameDef(k3)))),
+          Call(RESET, toJS(ks2), toJS(k2))) ::
+          toJS(body).run(k)
+      }
+    case cps.Stmt.Reset(body, ks, k) => ???
 
-    case cps.Stmt.Shift(prompt, body, ks, k) =>
-      pure(js.Return(Call(SHIFT, nameRef(prompt), noThunking { toJS(body) }, toJS(ks), toJS(k))))
+    case cps.Stmt.Shift(prompt, BlockLit(vparams, List(resume), ks3, k3, body), ks2, k2) =>
+      Binding { k =>
+        js.Const(js.Pattern.Array(List(js.Pattern.Variable(nameDef(resume)), js.Pattern.Variable(nameDef(ks3)), js.Pattern.Variable(nameDef(k3)))),
+          Call(SHIFT, nameRef(prompt), toJS(ks2), toJS(k2))) ::
+          toJS(body).run(k)
+      }
+    case cps.Stmt.Shift(prompt, body, ks, k) => ???
 
     case cps.Stmt.Hole() =>
       pure(js.Return($effekt.call("hole")))

--- a/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
@@ -129,7 +129,6 @@ implicit class JavaScriptInterpolator(private val sc: StringContext) extends Any
   def js(args: Expr*): Expr = RawExpr(sc.parts.toList, args.toList)
 }
 
-
 enum Pattern {
   case Variable(name: JSName)
   case Array(ps: List[Pattern])

--- a/libraries/js/effekt_runtime.js
+++ b/libraries/js/effekt_runtime.js
@@ -85,10 +85,10 @@ const RETURN = (x, ks) => ks.rest.stack(x, ks.rest)
 // const x = r.alloc(init); body
 
 // HANDLE(ks, ks, (p, ks, k) => { STMT })
-function RESET(prog, ks, k) {
+function RESET(ks, k) {
   const prompt = _prompt++;
   const rest = { stack: k, prompt: ks.prompt, arena: ks.arena, rest: ks.rest }
-  return prog(prompt, { prompt, arena: Arena([]), rest }, RETURN)
+  return [prompt, { prompt, arena: Arena([]), rest }, RETURN]
 }
 
 function DEALLOC(ks) {
@@ -98,7 +98,7 @@ function DEALLOC(ks) {
   }
 }
 
-function SHIFT(p, body, ks, k) {
+function SHIFT(p, ks, k) {
 
   // TODO avoid constructing this object
   let meta = { stack: k, prompt: ks.prompt, arena: ks.arena, rest: ks.rest }
@@ -129,7 +129,7 @@ function SHIFT(p, body, ks, k) {
 
   let k1 = meta.stack
   meta.stack = null
-  return body(resumeComp, meta, k1)
+  return [resumeComp, meta, k1]
 }
 
 function RUN_TOPLEVEL(comp) {


### PR DESCRIPTION
This is WIP PR where we translate shift, reset, and resume to direct style in JS...

Overall, the performance stays the same; only `tree explore` looks faster. Strangely, `resume non-tail` get's MUCH slower (factor 2-3). Maybe the higher-order functions weren't that bad before for inlining by the JIT.

<img width="2006" alt="image" src="https://github.com/user-attachments/assets/8711b5a0-975a-41b0-b9ab-25930e65e9ba">
