### PR TITLE
Static argument optimization

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/Optimizer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Optimizer.scala
@@ -24,8 +24,13 @@ object Optimizer extends Phase[CoreTransformed, CoreTransformed] {
 
     if !Context.config.optimize() then return tree;
 
-    // (2) inline unique block definitions
+    // (2) lift static arguments (worker/wrapper)
+    val lifted = Context.timed("static-argument-transformation", source.name) {
+      StaticArguments.transform(mainSymbol, tree)
+    }
+
+    // (3) inline unique block definitions
     Context.timed("inliner", source.name) {
-      Inline.full(Set(mainSymbol), tree, Context.config.maxInlineSize().toInt)
+      Inline.full(Set(mainSymbol), lifted, Context.config.maxInlineSize().toInt)
     }
 }

--- a/effekt/shared/src/main/scala/effekt/core/Recursive.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Recursive.scala
@@ -7,8 +7,9 @@ import scala.collection.mutable
  */
 case class RecursiveFunction(
   definition: BlockLit,
-  vargs: mutable.Set[List[Pure]],
-  bargs: mutable.Set[List[Block]]
+  targs: mutable.Set[List[ValueType]] = mutable.Set.empty,
+  vargs: mutable.Set[List[Pure]] = mutable.Set.empty,
+  bargs: mutable.Set[List[Block]] = mutable.Set.empty
 )
 
 class Recursive(
@@ -20,7 +21,7 @@ class Recursive(
       case Definition.Def(id, block) =>
         block match {
           case b @ BlockLit(tparams, cparams, vparams, bparams, body) =>
-            defs(id) = RecursiveFunction(b, mutable.Set.empty, mutable.Set.empty)
+            defs(id) = RecursiveFunction(b)
             val before = stack
             stack = id :: stack
             process(block)
@@ -58,6 +59,7 @@ class Recursive(
       callee match {
         case BlockVar(id, annotatedTpe, annotatedCapt) =>
           if (stack.contains(id)) // is recursive
+            defs(id).targs += targs
             defs(id).vargs += vargs
             defs(id).bargs += bargs
         case _ => ()

--- a/effekt/shared/src/main/scala/effekt/core/Recursive.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Recursive.scala
@@ -1,0 +1,120 @@
+package effekt.core
+
+import scala.collection.mutable
+
+// TODO: Is there a simpler way of iterating the functions and calls (like a fold)?
+//       Reachable etc. use similar recursions
+//       We could probably remove a lot of recursion here!
+
+/**
+ * Gather all functions, their arguments, and arguments of their recursive calls
+ */
+class Recursive(
+  var defs: mutable.Map[Id, (List[Id], mutable.Set[List[Pure]])],
+  var stack: List[Id]
+) {
+  def process(d: Definition): Unit =
+    d match {
+      case Definition.Def(id, block) =>
+        block match {
+          // TODO: also track block params
+          case BlockLit(tparams, cparams, vparams, bparams, body) =>
+            defs(id) = (vparams.map(_.id), mutable.Set())
+            val before = stack
+            stack = id :: stack
+            process(block)
+            stack = before
+          case _ => ()
+        }
+      case Definition.Let(id, _, binding) =>
+        process(binding)
+    }
+
+  // TODO: Necessary?
+  def process(id: Id): Unit =
+    ()
+
+  def process(b: Block): Unit =
+    b match {
+      case Block.BlockVar(id, annotatedTpe, annotatedCapt) => () // TODO?
+      case Block.BlockLit(tparams, cparams, vparams, bparams, body) => process(body)
+      case Block.Unbox(pure) => process(pure)
+      case Block.New(impl) => process(impl)
+    }
+
+  def process(s: Stmt): Unit = s match {
+    case Stmt.Scope(definitions, body) =>
+      definitions.foreach {
+        case d: Definition.Def =>
+          process(d)
+        case d: Definition.Let =>
+          process(d)
+      }
+      process(body)
+    case Stmt.Return(expr) => process(expr)
+    case Stmt.Val(id, tpe, binding, body) => process(binding); process(body)
+    case a @ Stmt.App(callee, targs, vargs, bargs) =>
+      process(callee)
+      vargs.foreach(process)
+      bargs.foreach(process)
+
+      callee match {
+        case BlockVar(id, annotatedTpe, annotatedCapt) => 
+          if (stack.contains(id)) // is recursive
+            defs(id)._2 += vargs
+        case _ => ()
+      }
+    case Stmt.Invoke(callee, method, methodTpe, targs, vargs, bargs) =>
+      process(callee)
+      process(method)
+      vargs.foreach(process)
+      bargs.foreach(process)
+    case Stmt.If(cond, thn, els) => process(cond); process(thn); process(els)
+    case Stmt.Match(scrutinee, clauses, default) =>
+      process(scrutinee)
+      clauses.foreach { case (id, value) => process(value) }
+      default.foreach(process)
+    case Stmt.Alloc(id, init, region, body) =>
+      process(init)
+      process(region)
+      process(body)
+    case Stmt.Var(id, init, capture, body) =>
+      process(init)
+      process(body)
+    case Stmt.Get(id, capt, tpe) => process(id)
+    case Stmt.Put(id, tpe, value) => process(id); process(value)
+    case Stmt.Reset(body) => process(body)
+    case Stmt.Shift(prompt, body) => process(prompt); process(body)
+    case Stmt.Resume(k, body) => process(k); process(body)
+    case Stmt.Region(body) => process(body)
+    case Stmt.Hole() => ()
+  }
+
+  def process(e: Expr): Unit = e match {
+    case DirectApp(b, targs, vargs, bargs) =>
+      process(b)
+      vargs.foreach(process)
+      bargs.foreach(process)
+    case Run(s) => process(s)
+    case Pure.ValueVar(id, annotatedType) => process(id)
+    case Pure.Literal(value, annotatedType) => ()
+    case Pure.PureApp(b, targs, vargs) => process(b); vargs.foreach(process)
+    case Pure.Make(data, tag, vargs) => process(tag); vargs.foreach(process)
+    case Pure.Select(target, field, annotatedType) => process(field); process(target)
+    case Pure.Box(b, annotatedCapture) => process(b)
+  }
+
+  def process(i: Implementation): Unit =
+    i.operations.foreach { op => process(op.body) }
+
+  def process(m: ModuleDecl): Unit =
+    m.definitions.map(process)
+}
+
+object Recursive {
+  def apply(m: ModuleDecl) = {
+    val analysis = new Recursive(mutable.Map.empty, List())
+    analysis.process(m)
+    analysis.defs
+  }
+}

--- a/effekt/shared/src/main/scala/effekt/core/Renamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Renamer.scala
@@ -60,7 +60,7 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
 
     case core.Val(id, tpe, binding, body) =>
       val resolvedBinding = rewrite(binding)
-      withBinding(id) { core.Val(rewrite(id), tpe, resolvedBinding, rewrite(body)) }
+      withBinding(id) { core.Val(rewrite(id), rewrite(tpe), resolvedBinding, rewrite(body)) }
 
     case core.Alloc(id, init, reg, body) =>
       val resolvedInit = rewrite(init)

--- a/effekt/shared/src/main/scala/effekt/core/StaticArguments.scala
+++ b/effekt/shared/src/main/scala/effekt/core/StaticArguments.scala
@@ -1,0 +1,218 @@
+package effekt
+package core
+
+import effekt.core.normal.*
+import scala.collection.mutable
+
+/**
+ * Static argument transformation
+ *
+ * 1. First gathers recursive calls (using [[Recursive.apply]])
+ * 2. Transforms them using a Worker/Wrapper strategy
+ */
+object StaticArguments {
+
+  case class StaticArgumentsContext(
+    staticArguments: Map[Id, List[Boolean]],
+    workers: mutable.Map[Id, Id],
+    var stack: List[Id]
+  )
+
+  def dropStatic[A](staticArguments: List[Boolean], list: List[A]) =
+    list.zip(staticArguments).filter((_, bool) => !bool).map(_._1)
+  
+  /**
+   * Wraps the definition in another function, abstracting arguments along the way.
+   * For example:
+   * 
+   *   def foo(a, b, c) =
+   *     if (a == b) println(c)
+   *     else foo(a - 2, b - 1, c)
+   *   foo(4, 2, 0)
+   *
+   * becomes:
+   *
+   *   def foo(a_fresh, b_fresh, c) =
+   *     def foo_worker(a, b) =
+   *       if (a == b) println(c)
+   *       else foo_worker(a - 2, b - 1)
+   *     foo_worker(a_fresh, b_fresh)
+   *   foo(4, 2, 0)
+   */
+  def wrapDefinition(definition: Definition.Def)(using ctx: StaticArgumentsContext): Definition.Def =
+    // This is guaranteed by Recursive()!
+    val blockLit = definition.block.asInstanceOf[BlockLit]
+
+    val staticArguments = ctx.staticArguments(definition.id)
+
+    val worker = Id(definition.id.name.name + "_worker")
+    ctx.workers(definition.id) = worker
+
+    val calleeType = BlockType.Function(
+      blockLit.tparams,
+      blockLit.cparams,
+      dropStatic(staticArguments, blockLit.vparams.map(_.tpe)),
+      blockLit.bparams.map(_.tpe),
+      blockLit.tpe match
+        case BlockType.Function(_, _, _, _, result) => result
+        case _ => ??? // impossible!
+    )
+
+    // push to the stack to detect recursion, since recursive calls will need to call the worker
+    def rewriteBody(body: Stmt) =
+      val before = ctx.stack
+      ctx.stack = definition.id :: ctx.stack
+      val newBody = rewrite(body)
+      ctx.stack = before
+      newBody
+    
+    // fresh params for the wrapper function and its invocation
+    val freshCparams = blockLit.cparams.map(c => Id(c.name.name))
+    val freshBparams: List[Param.BlockParam] = blockLit.bparams.map(b => BlockParam(Id(b.id.name.name), b.tpe, b.capt))
+    val freshVparams: List[Param.ValueParam] = // here: only freshen params if not static to prevent duplicates
+      blockLit.vparams.zip(staticArguments).map((v, bool) => ValueParam(if (bool) v.id else Id(v.id.name.name), v.tpe))
+
+    Definition.Def(definition.id, BlockLit(
+      blockLit.tparams, // TODO: Do we need to freshen these as well?
+      blockLit.cparams, // TODO: Do we need to freshen these as well?
+      freshVparams,
+      freshBparams,
+      Scope(List(Definition.Def(worker, BlockLit(
+        blockLit.tparams,
+        blockLit.cparams,
+        dropStatic(staticArguments, blockLit.vparams),
+        blockLit.bparams,
+        rewriteBody(blockLit.body)
+      ))), App(
+        // TODO: Where do we get the capture set?
+        BlockVar(worker, calleeType, Set()),
+        // TODO: These conversions to types are a bit hacky, are there better ways?
+        blockLit.tparams.map(t => ValueType.Var(t)),
+        dropStatic(staticArguments, freshVparams.map(v => ValueVar(v.id, v.tpe))),
+        freshBparams.map(b => BlockVar(b.id, b.tpe, b.capt))
+      ))
+    ))
+  
+  def rewrite(definitions: List[Definition])(using ctx: StaticArgumentsContext): List[Definition] =
+    val lifted = definitions.collect {
+      case d @ Definition.Def(id, block) if ctx.staticArguments.contains(id) => wrapDefinition(d)
+      case Definition.Def(id, block) => Definition.Def(id, rewrite(block))
+      case Definition.Let(id, tpe, binding) => Definition.Let(id, tpe, rewrite(binding))
+    }
+    lifted
+
+  def rewrite(d: Definition)(using StaticArgumentsContext): Definition = d match {
+    case Definition.Def(id, block) => Definition.Def(id, rewrite(block))
+    case Definition.Let(id, tpe, binding) => Definition.Let(id, tpe, rewrite(binding))
+  }
+
+  def rewrite(s: Stmt)(using C: StaticArgumentsContext): Stmt = s match {
+    case Stmt.Scope(definitions, body) =>
+      scope(rewrite(definitions), rewrite(body))
+
+    case Stmt.App(b, targs, vargs, bargs) =>
+      b match {
+        // if arguments are static && recursive call: call worker with reduced arguments
+        case BlockVar(id, annotatedTpe, annotatedCapt) if C.staticArguments.contains(id) && C.stack.contains(id) => 
+          app(BlockVar(C.workers(id), annotatedTpe, annotatedCapt),
+            targs, dropStatic(C.staticArguments(id), vargs.map(rewrite)), bargs.map(rewrite))
+        case _ => app(rewrite(b), targs, vargs.map(rewrite), bargs.map(rewrite))
+      }
+
+    case Stmt.Invoke(b, method, methodTpe, targs, vargs, bargs) =>
+      invoke(rewrite(b), method, methodTpe, targs, vargs.map(rewrite), bargs.map(rewrite))
+
+    case Stmt.Reset(body) =>
+      rewrite(body) match {
+        case b => Stmt.Reset(b)
+      }
+
+    // congruences
+    case Stmt.Return(expr) => Return(rewrite(expr))
+    case Stmt.Val(id, tpe, binding, body) => valDef(id, tpe, rewrite(binding), rewrite(body))
+    case Stmt.If(cond, thn, els) => If(rewrite(cond), rewrite(thn), rewrite(els))
+    case Stmt.Match(scrutinee, clauses, default) =>
+      patternMatch(rewrite(scrutinee), clauses.map { case (id, value) => id -> rewrite(value) }, default.map(rewrite))
+    case Stmt.Alloc(id, init, region, body) => Alloc(id, rewrite(init), region, rewrite(body))
+    case Stmt.Shift(prompt, body) => Shift(prompt, rewrite(body))
+    case Stmt.Resume(k, body) => Resume(k, rewrite(body))
+    case Stmt.Region(body) => Region(rewrite(body))
+    case Stmt.Var(id, init, capture, body) => Stmt.Var(id, rewrite(init), capture, rewrite(body))
+    case Stmt.Get(id, capt, tpe) => Stmt.Get(id, capt, tpe)
+    case Stmt.Put(id, capt, value) => Stmt.Put(id, capt, rewrite(value))
+    case Stmt.Hole() => s
+  }
+  def rewrite(b: BlockLit)(using StaticArgumentsContext): BlockLit =
+    b match {
+      case BlockLit(tparams, cparams, vparams, bparams, body) =>
+        BlockLit(tparams, cparams, vparams, bparams, rewrite(body))
+    }
+
+  def rewrite(b: Block)(using C: StaticArgumentsContext): Block = b match {
+    case b @ Block.BlockVar(id, _, _) => b
+
+    // congruences
+    case b @ Block.BlockLit(tparams, cparams, vparams, bparams, body) => rewrite(b)
+    case Block.Unbox(pure) => unbox(rewrite(pure))
+    case Block.New(impl) => New(rewrite(impl))
+  }
+
+  def rewrite(s: Implementation)(using StaticArgumentsContext): Implementation =
+    s match {
+      case Implementation(interface, operations) => Implementation(interface, operations.map { op =>
+        op.copy(body = rewrite(op.body))
+      })
+    }
+
+  def rewrite(p: Pure)(using StaticArgumentsContext): Pure = p match {
+    case Pure.PureApp(b, targs, vargs) => pureApp(rewrite(b), targs, vargs.map(rewrite))
+    case Pure.Make(data, tag, vargs) => make(data, tag, vargs.map(rewrite))
+    case x @ Pure.ValueVar(id, annotatedType) => x
+
+    // congruences
+    case Pure.Literal(value, annotatedType) => p
+    case Pure.Select(target, field, annotatedType) => select(rewrite(target), field, annotatedType)
+    case Pure.Box(b, annotatedCapture) => box(rewrite(b), annotatedCapture)
+  }
+
+  def rewrite(e: Expr)(using StaticArgumentsContext): Expr = e match {
+    case DirectApp(b, targs, vargs, bargs) => directApp(rewrite(b), targs, vargs.map(rewrite), bargs.map(rewrite))
+
+    // congruences
+    case Run(s) => run(rewrite(s))
+    case pure: Pure => rewrite(pure)
+  }
+
+  def analyzeParameters(vargs: List[Pure]) =
+    vargs.map(p => p match {
+      case ValueVar(id, annotatedType) => ArgumentType.Static(id.name.name)
+      case _ => ArgumentType.NonStatic
+    })
+  
+  def transform(entrypoint: Id, m: ModuleDecl): ModuleDecl =
+    val recursiveFunctions = Recursive(m)
+
+    // a map of function names to a list of booleans, indicating whether
+    //   the respective argument can be statically transformed
+    val staticArguments = recursiveFunctions.view.mapValues { (callee, set) =>
+      val calleeParams = callee.map(arg => ArgumentType.Static(arg.name.name))
+      set.map(analyzeParameters).map(_.zip(calleeParams).map((a, b) => a == b))
+        .toList.transpose.map(_.forall(identity)) // the column-wise AND of all lists
+    }.toMap
+
+    val staticArgumentsFiltered = staticArguments.filter(_._2.contains(true))
+
+    given ctx: StaticArgumentsContext = StaticArgumentsContext(
+      staticArgumentsFiltered,
+      mutable.Map(),
+      List()
+    )
+
+    val updatedDefs = rewrite(m.definitions)
+    m.copy(definitions = updatedDefs)
+}
+
+enum ArgumentType {
+  case Static(name: String)
+  case NonStatic
+}

--- a/effekt/shared/src/main/scala/effekt/core/StaticArguments.scala
+++ b/effekt/shared/src/main/scala/effekt/core/StaticArguments.scala
@@ -215,13 +215,13 @@ object StaticArguments {
       set.map(f).map(_.zip(static).map((a, b) => a == b))
         .toList.transpose.map(_.forall(identity)) // the column-wise AND of all lists
 
-    val staticC = recursiveFunctions.view.mapValues { case (cparams, _, _, (cset, _, _)) => fullyStatic(cparams, cset, analyzeBargs) }
+    val staticC = recursiveFunctions.view.mapValues { gathering => fullyStatic(gathering.cparams, gathering.cargs, analyzeBargs) }
       .toMap.filter(_._2.contains(true))
 
-    val staticV = recursiveFunctions.view.mapValues { case (_, vparams, _, (_, vset, _)) => fullyStatic(vparams, vset, analyzeVargs) }
+    val staticV = recursiveFunctions.view.mapValues { gathering => fullyStatic(gathering.vparams, gathering.vargs, analyzeVargs) }
       .toMap.filter(_._2.contains(true))
 
-    val staticB = recursiveFunctions.view.mapValues { case (_, _, bparams, (_, _, bset)) => fullyStatic(bparams, bset, analyzeBargs) }
+    val staticB = recursiveFunctions.view.mapValues { gathering => fullyStatic(gathering.bparams, gathering.bargs, analyzeBargs) }
       .toMap.filter(_._2.contains(true))
 
     given ctx: StaticArgumentsContext = StaticArgumentsContext(

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -100,6 +100,7 @@ object Id {
   def apply(n: String): Id = new symbols.Symbol {
     val name = symbols.Name.local(n)
   }
+  def apply(n: Id): Id = apply(n.name.name)
 }
 
 /**

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -1,9 +1,7 @@
 package effekt
 package core
 
-import effekt.symbols.TrackedParam.BlockParam
-import symbols.{ Symbol, TypeSymbol, builtins }
-import symbols.Name
+import symbols.{ Symbol, builtins }
 
 /**
  * In core, all names, including those in capture sets are just symbols.

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -174,7 +174,10 @@ object Type {
       val bparams = bps.map { p => p.tpe }
 
       BlockType.Function(tparams, cparams, vparams, bparams, body.tpe)
-    case Block.Unbox(pure) => pure.tpe.asInstanceOf[ValueType.Boxed].tpe
+    case Block.Unbox(pure) => pure.tpe match {
+      case ValueType.Boxed(tpe, capt) => tpe
+      case tpe => println(util.show(block)); sys.error(s"Got ${tpe}, which is not a boxed block type.")
+    }
     case Block.New(impl) => impl.tpe
   }
   def inferCapt(block: Block): Captures = block match {

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -127,11 +127,7 @@ object Type {
   def instantiate(f: BlockType.Function, targs: List[ValueType], cargs: List[Captures]): BlockType.Function = f match {
     case BlockType.Function(tparams, cparams, vparams, bparams, result) =>
       assert(targs.size == tparams.size, "Wrong number of type arguments")
-      // assert(cargs.size == cparams.size, "Wrong number of capture arguments")
-      if (cargs.size != cparams.size) {
-        println(cargs)
-        println(cparams)
-      }
+      assert(cargs.size == cparams.size, "Wrong number of capture arguments")
 
       val vsubst = (tparams zip targs).toMap
       val csubst = (cparams zip cargs).toMap

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -129,7 +129,11 @@ object Type {
   def instantiate(f: BlockType.Function, targs: List[ValueType], cargs: List[Captures]): BlockType.Function = f match {
     case BlockType.Function(tparams, cparams, vparams, bparams, result) =>
       assert(targs.size == tparams.size, "Wrong number of type arguments")
-      assert(cargs.size == cparams.size, "Wrong number of capture arguments")
+      // assert(cargs.size == cparams.size, "Wrong number of capture arguments")
+      if (cargs.size != cparams.size) {
+        println(cargs)
+        println(cparams)
+      }
 
       val vsubst = (tparams zip targs).toMap
       val csubst = (cparams zip cargs).toMap


### PR DESCRIPTION
In this PR I implement an optimization pass for static argument transformation.

Definitions with recursive calls that involve static arguments will now be wrapped in another function, abstracting arguments along the way.

For example, in pseudocode:

``` scala
def foo(a, b, c) =
  if (a == b) println(c)
  else foo(a - 2, b - 1, c)
foo(4, 2, 0)
```

becomes:

``` scala
def foo(a_fresh, b_fresh, c) =
  def foo_worker(a, b) =
    if (a == b) println(c)
    else foo_worker(a - 2, b - 1)
  foo_worker(a_fresh, b_fresh)
foo(4, 2, 0)
```

For now this works great for transforming static vargs, but has some bugs left for static capture/block arguments. Mutual recursion is also not supported for now.

We can see the optimization in the following example:

``` scala
def fold[A, B](list: List[A], end: B) { f: (B, A) => B }: B = {
  list match {
    case Nil() => end
    case Cons(elem, rest) => f(fold(rest, end) { f }, elem)
  }
}

def sum(list: List[Int]): Int =
  fold(list, 0) { (a, b) => a + b }

def main() = println(sum([1, 2, 3]))
```

Previously the resulting core was:

``` scala
def fold2239[A2234, B2235](list2236: List910[A2234], end2237: B2235){f2238} =
  def b_k_23733524() =
    end2237;
  def b_k_23803525(elem2243: A2234, rest2244: List910[A2234]) =
    val v_r_23773526: B2235 = fold2239[A2234, B2235](rest2244, end2237, f2238);
    f2238(v_r_23773526, elem2243)

  list2236 match {
    case Nil1114 { () =>
      b_k_23733524()
    }
    case Cons1115 { (v_y_23812384: A2234, v_y_23822383: List910[A2234]) =>
      b_k_23803525(v_y_23812384, v_y_23822383)
    }
  };
def sum2241(list2240: List910[BoxedInt296]) =
  val v_coe_39623971: BoxedInt296 = fold2239[BoxedInt296, BoxedInt296](list2240, boxInt298(0), { (v_coe_39633968: BoxedInt296, v_coe_39643969: BoxedInt296) =>
    def b_tmp_39663967(a2245: Int398, b2246: Int398) =
      infixAdd93(a2245, b2246)

    val v_coe_39653970: Int398 = b_tmp_39663967(unboxInt300(v_coe_39633968), unboxInt300(v_coe_39643969));
    boxInt298(v_coe_39653970)
  });
  unboxInt300(v_coe_39623971);
def main2242() =
  let v_r_23893523 = run {sum2241(make List910[BoxedInt296] Cons1115(boxInt298(1), make List910[BoxedInt296] Cons1115(boxInt298(2), make List910[BoxedInt296] Cons1115(boxInt298(3), make List910[BoxedInt296] Nil1114()))))}
```

Now:

``` scala
def fold2239[A2234, B2235](list3972: List910[A2234], end2237: B2235){f2238} =
  def fold_worker3973[A2234, B2235](list2236: List910[A2234]) =
    def b_k_23733524() =
      end2237;
    def b_k_23803525(elem2243: A2234, rest2244: List910[A2234]) =
      val v_r_23773526: B2235 = fold_worker3973[A2234, B2235](rest2244);
      f2238(v_r_23773526, elem2243)

    list2236 match {
      case Nil1114 { () =>
        b_k_23733524()
      }
      case Cons1115 { (v_y_23812384: A2234, v_y_23822383: List910[A2234]) =>
        b_k_23803525(v_y_23812384, v_y_23822383)
      }
    }

  fold_worker3973[A2234, B2235](list3972);
def sum2241(list2240: List910[BoxedInt296]) =
  val v_coe_39623971: BoxedInt296 = fold2239[BoxedInt296, BoxedInt296](list2240, boxInt298(0), { (v_coe_39633968: BoxedInt296, v_coe_39643969: BoxedInt296) =>
    def b_tmp_39663967(a2245: Int398, b2246: Int398) =
      infixAdd93(a2245, b2246)

    val v_coe_39653970: Int398 = b_tmp_39663967(unboxInt300(v_coe_39633968), unboxInt300(v_coe_39643969));
    boxInt298(v_coe_39653970)
  });
  unboxInt300(v_coe_39623971);
def main2242() =
  let v_r_23893523 = run {sum2241(make List910[BoxedInt296] Cons1115(boxInt298(1), make List910[BoxedInt296] Cons1115(boxInt298(2), make List910[BoxedInt296] Cons1115(boxInt298(3), make List910[BoxedInt296] Nil1114()))))}
```