### PR TITLE
Cherry-pick inlining fix from #725

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/Inline.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Inline.scala
@@ -98,8 +98,7 @@ object Inline {
 
   def blockDefFor(id: Id)(using ctx: InlineContext): Option[Block] =
     ctx.defs.get(id) map {
-      // TODO rewriting here leads to a stack overflow in one test, why?
-      case Definition.Def(id, block) => block //rewrite(block)
+      case Definition.Def(id, block) => rewrite(block)
       case Definition.Let(id, _, binding) => INTERNAL_ERROR("Should not happen")
     }
 


### PR DESCRIPTION
As discussed in https://github.com/effekt-lang/effekt/pull/561#issuecomment-2513199799, there's a missing rewrite.
This fix is necessary for the `map` and `set` examples, as well as some of my AoC solutions using them, so I'd like to upstream it, if possible.