### PR TITLE
Custom compiler crash/panic handler

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -110,6 +110,11 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     import java.nio.charset.StandardCharsets
 
     // Capture general information
+    val errorMessage = msg match {
+      case PlainTextError(content, _, _) => content
+      case _ => msg
+    }
+
 
     val effektVersion = effekt.util.Version.effektVersion
     val osInfoName = System.getProperty("os.name")
@@ -137,7 +142,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     val reportContent =
       s"""|# Effekt Compiler Crash Report
           |
-          |**ERROR** : $msg
+          |**ERROR** : $errorMessage
           |
           |$errorReport
           |[Submit an issue]($issueLink)
@@ -178,6 +183,8 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     val report =
       s"""|=== Effekt Compiler Crash Report ===
           |
+          |[Error] $errorMessage
+          |
           |The compiler unexpectedly panicked. This is a compiler bug.
           |Please report it: $issueLink
           |
@@ -197,8 +204,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
           |Arguments passed to the compiler:
           |$argsMarkdown
           |""".stripMargin
-
-    context.report(msg)
+    
     // Print the report to console
     context.info(report)
   }

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -88,7 +88,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     }
   } catch {
     case FatalPhaseError(msg) => context.report(msg)
-    case e @ CompilerPanic(msg) => generateCrashReport(e, context, config,msg)
+    case e @ CompilerPanic(msg) => generateCrashReport(e, context, config, msg)
 
     // when in server-mode, do not crash but report the error to avoid
     // restarting the server.
@@ -118,7 +118,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
 
     val javaInfoVersion = System.getProperty("java.version")
     val javaInfoVendor = System.getProperty("java.vendor")
-    val javaInfoHome = System.getProperty("java.home")
+    val javaInfoRuntime = System.getProperty("java.runtime.name")
 
     val errorReport = "The compiler unexpectedly panicked. This is a compiler bug.\nPlease report it:"
     val issueLink = "https://github.com/effekt-lang/effekt/issues/new?labels=bug"
@@ -149,7 +149,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
           |### System Information
           |Operating System: $osInfoName \n Arch: $osInfoArch \n Version: $osInfoVersion
           |
-          |JVM Version: $javaInfoVersion ($javaInfoVendor, $javaInfoHome)
+          |JVM Version: $javaInfoVersion ($javaInfoVendor, $javaInfoRuntime)
           |
           |### Full Stack Trace
           |```

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -88,7 +88,9 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     }
   } catch {
     case FatalPhaseError(msg) => context.report(msg)
-    case e @ CompilerPanic(msg) => generateCrashReport(e, context, config, msg)
+    case e @ CompilerPanic(msg) => 
+      context.report(msg)
+      generateCrashReport(e, context, config, msg)
 
     // when in server-mode, do not crash but report the error to avoid
     // restarting the server.

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -143,9 +143,9 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
           |
           |Where to report: https://github.com/effekt-lang/effekt/issues
           |
-          |$effektVersion
           |
           |Effekt Compiler Version: $effektVersion
+          |
           |Backend-specific info:
           |  - Name: $backendInfoName
           |  - Compiler: $backendInfoCompiler

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -114,7 +114,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     import java.util.Properties
 
     // Capture general information
-    val effektVersion = "Effekt Compiler Version " + System.getProperty("effekt.version")
+    val effektVersion = "Effekt Compiler Version: " // Null:  + System.getProperty("effekt.version")
     val osInfo = "Operating System: " + System.getProperty("os.name") +
       " (" + System.getProperty("os.arch") + ") " +
       System.getProperty("os.version")
@@ -134,9 +134,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
           |
           |Where to report: https://github.com/effekt-lang/effekt/issues
           |
-          |effektVersion :
-          |
-          |
+          |$effektVersion
           |
           |$backendInfo
           |

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -116,8 +116,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
       case PlainTextError(content, _, _) => content
       case _ => msg
     }
-
-
+    
     val effektVersion = effekt.util.Version.effektVersion
     val osInfoName = System.getProperty("os.name")
     val osInfoArch = System.getProperty("os.arch")
@@ -129,6 +128,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
 
     val errorReport = "The compiler unexpectedly panicked. This is a compiler bug.\nPlease report it:"
     val issueLink = "https://github.com/effekt-lang/effekt/issues/new?labels=bug"
+    
     val stringWriter = new java.io.StringWriter()
     e.printStackTrace(new java.io.PrintWriter(stringWriter))
     val stackTrace = stringWriter.toString
@@ -176,8 +176,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     val outputFile = outputPath.resolve("crash-report.md")
     try {
       Files.createDirectories(outputPath.getParent)
-      Files.write(outputFile, reportContent.getBytes(StandardCharsets.UTF_8))
-      //context.info(s"Crash report saved to: $outputPath")
+      Files.write(outputFile, reportContent.getBytes(StandardCharsets.UTF_8))     
     } catch {
       case ex: Exception =>
         context.info("Failed to save crash report to file: " + ex.getMessage)

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -9,7 +9,7 @@ import effekt.context.{ Context, IOModuleDB }
 import kiama.output.PrettyPrinterTypes.Document
 import kiama.parsing.ParseResult
 import kiama.util.{ IO, Source }
-import effekt.util.messages.{ BufferedMessaging, CompilerPanic, EffektError, EffektMessaging, FatalPhaseError }
+import effekt.util.messages.{ BufferedMessaging, CompilerPanic, EffektError, EffektMessaging, FatalPhaseError, PlainTextError }
 import effekt.util.paths.file
 import effekt.util.{ AnsiColoredMessaging, MarkdownSource, getOrElseAborting }
 
@@ -204,7 +204,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
           |Arguments passed to the compiler:
           |$argsMarkdown
           |""".stripMargin
-    
+
     // Print the report to console
     context.info(report)
   }

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -163,10 +163,11 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
           |""".stripMargin
 
     // Write the report to a Markdown file
-    val outputPath = Paths.get("./out/crash-report.md")
+    val outputPath = Paths.get(config.outputPath().getAbsolutePath)
+    val outputFile = outputPath.resolve("crash-report.md")
     try {
       Files.createDirectories(outputPath.getParent)
-      Files.write(outputPath, reportContent.getBytes(StandardCharsets.UTF_8))
+      Files.write(outputFile, reportContent.getBytes(StandardCharsets.UTF_8))
       //context.info(s"Crash report saved to: $outputPath")
     } catch {
       case ex: Exception =>

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -147,13 +147,13 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
           |
           |Effekt Compiler Version: $effektVersion
           |Backend-specific info:
-          |  - $backendInfoName
-          |  - $backendInfoCompiler
-          |  - $backendInfoRunner
+          |  - Name: $backendInfoName
+          |  - Compiler: $backendInfoCompiler
+          |  - Runner: $backendInfoRunner
           |
-          |$osInfo
+          |Operating System: $osInfo
           |
-          |$jvmInfo
+          |JVM Version: $jvmInfo
           |
           |Full Stack Trace:
           |$stackTrace
@@ -169,15 +169,14 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
           |
           |- **Effekt Compiler Version**: $effektVersion
           |- **Backend-specific info**:
-          |  - $backendInfoName
-          |  - $backendInfoCompiler
-          |  - $backendInfoRunner
+          |  - **Name**: $backendInfoName
+          |  - **Compiler**: $backendInfoCompiler
+          |  - **Runner**: $backendInfoRunner
           |
           |- **Operating System**: $osInfo
           |
           |- **JVM Version**: $jvmInfo
           |
-          |$jvmInfo
           |
           |# Full Stack Trace:
           |```

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -127,7 +127,9 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
 
     val errorReport = "The compiler unexpectedly panicked. This is a compiler bug.\nPlease report it:"
     val issueLink = "https://github.com/effekt-lang/effekt/issues/new?labels=bug"
-    val stackTrace = e.getStackTrace.map(line => "  at " + line.toString).mkString("\n")
+    val stringWriter = new java.io.StringWriter()
+    e.printStackTrace(new java.io.PrintWriter(stringWriter))
+    val stackTrace = stringWriter.toString
 
     // Collect backend details (if applicable)
     val backendInfoName = config.backend() match {

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -89,7 +89,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
   } catch {
     case FatalPhaseError(msg) => context.report(msg)
     case e @ CompilerPanic(msg) => generateCrashReport(e, context, config,msg)
-      }
+
     // when in server-mode, do not crash but report the error to avoid
     // restarting the server.
     case e if config.server() =>

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -148,8 +148,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
           |
           |**ERROR** : $errorMessage
           |
-          |$errorReport
-          |[Submit an issue]($issueLink)
+          |$errorReport [Submit an issue]($issueLink)
           |
           |### Compiler Information
           |Effekt Version: $effektVersion \n

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -88,7 +88,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     }
   } catch {
     case FatalPhaseError(msg) => context.report(msg)
-    case e @ CompilerPanic(msg) => 
+    case e @ CompilerPanic(msg) =>
       context.report(msg)
       generateCrashReport(e, context, config, msg)
 
@@ -128,7 +128,8 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
 
     val errorReport = "The compiler unexpectedly panicked. This is a compiler bug.\nPlease report it:"
     val issueLink = "https://github.com/effekt-lang/effekt/issues/new?labels=bug"
-    
+
+    // Write stacktrace
     val stringWriter = new java.io.StringWriter()
     e.printStackTrace(new java.io.PrintWriter(stringWriter))
     val stackTrace = stringWriter.toString
@@ -139,7 +140,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
       case null => "Backend-specific info Name not retrievable"
     }
 
-    // Arguments passed to the compiler
+    // Collect arguments passed to the compiler
     val argsMarkdown = config.args.mkString("\n", "\n", "\n")
 
     // Construct the report content
@@ -181,7 +182,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
         context.info("Failed to save crash report to file: " + ex.getMessage)
     }
 
-    // Provide the report link in the user-visible output
+    // Terimnal output with reference to .md report
     val report =
       s"""|=== Effekt Compiler Crash Report ===
           |

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -114,7 +114,7 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
     import java.util.Properties
 
     // Capture general information
-    val effektVersion = "Effekt Compiler Version: " // Null:  + System.getProperty("effekt.version")
+    val effektVersion = "Effekt Compiler Version:  " + effekt.util.Version.effektVersion
     val osInfo = "Operating System: " + System.getProperty("os.name") +
       " (" + System.getProperty("os.arch") + ") " +
       System.getProperty("os.version")


### PR DESCRIPTION
## Motivation
Print and log a more verbose compiler crash/panic message with information about the specific user setup
Resolves #576.

## Changes
Implemented the `generateCrashReport` function, which creates a more verbose output if the compiler crashes/panics. 
This Report retrieves **general** and **backend-specific** information to make crashes more reproducable or traceable

### It holds information about :
- Effekt Version
-  Backend 
- OS
-  JVM
- and a full stacktrace. 

Additionally, the report is **written** to a `.md`-file in the .out/ directory

## Examples:
### Terminal Report
```
[info] === Effekt Compiler Crash Report ===

[Error] Internal compiler error: Error Text here bla bla

The compiler unexpectedly panicked. This is a compiler bug.
Please report it: https://github.com/effekt-lang/effekt/issues/new?labels=bug

Effekt Version: 0.13.0

Backend used: js

A detailed crash report has been written to:
/home/jakub/Effekt/repo/effekt/bin/./out

Operating System: Linux

JVM Version: 21.0.5

Full Stack Trace:
PlainTextError(Internal compiler error: Error Text here bla bla,None,Error)
        at effekt.util.messages$CompilerPanic$.apply(Messages.scala:37)
        at effekt.util.messages$.INTERNAL_ERROR(Messages.scala:53)
        at effekt.Driver.compileSource(Driver.scala:54)
        at effekt.Driver.compileSource$(Driver.scala:21)
        at effekt.Server$.compileSource(Server.scala:261)
        at effekt.Server$.compileSource(Server.scala:261)
        at kiama.util.Compiler.compileFile(Compiler.scala:102)
        at kiama.util.Compiler.compileFile$(Compiler.scala:22)
        at effekt.Server$.compileFile(Server.scala:261)
        at effekt.Driver.run$$anonfun$1(Driver.scala:41)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
        at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
        at scala.collection.immutable.List.foreach(List.scala:333)
        at effekt.Driver.run(Driver.scala:42)
        at effekt.Driver.run$(Driver.scala:21)
        at effekt.Server$.run(Server.scala:261)
        at effekt.Server$.run(Server.scala:261)
        at kiama.util.Compiler.driver(Compiler.scala:86)
        at kiama.util.Compiler.driver$(Compiler.scala:22)
        at effekt.Server$.driver(Server.scala:261)
        at kiama.util.Compiler.main(Compiler.scala:50)
        at kiama.util.Compiler.main$(Compiler.scala:22)
        at effekt.Server$.main(Server.scala:261)
        at effekt.Server.main(Server.scala)


Arguments passed to the compiler:

compilercrash.effekt

```
### Markdown Report
# Effekt Compiler Crash Report

**ERROR** : Internal compiler error: Error Text here bla bla

The compiler unexpectedly panicked. This is a compiler bug.
Please report it: [Submit an issue](https://github.com/effekt-lang/effekt/issues/new?labels=bug)

### Compiler Information
Effekt Version: 0.13.0 

Backend: js

### System Information
Operating System: Linux 
 Arch: amd64 
 Version: 5.15.167.4-microsoft-standard-WSL2

JVM Version: 21.0.5 (Ubuntu, OpenJDK Runtime Environment)

### Full Stack Trace
```
PlainTextError(Internal compiler error: Error Text here bla bla,None,Error)
	at effekt.util.messages$CompilerPanic$.apply(Messages.scala:37)
	at effekt.util.messages$.INTERNAL_ERROR(Messages.scala:53)
	at effekt.Driver.compileSource(Driver.scala:54)
	at effekt.Driver.compileSource$(Driver.scala:21)
	at effekt.Server$.compileSource(Server.scala:261)
	at effekt.Server$.compileSource(Server.scala:261)
	at kiama.util.Compiler.compileFile(Compiler.scala:102)
	at kiama.util.Compiler.compileFile$(Compiler.scala:22)
	at effekt.Server$.compileFile(Server.scala:261)
	at effekt.Driver.run$$anonfun$1(Driver.scala:41)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
	at scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
	at scala.collection.immutable.List.foreach(List.scala:333)
	at effekt.Driver.run(Driver.scala:42)
	at effekt.Driver.run$(Driver.scala:21)
	at effekt.Server$.run(Server.scala:261)
	at effekt.Server$.run(Server.scala:261)
	at kiama.util.Compiler.driver(Compiler.scala:86)
	at kiama.util.Compiler.driver$(Compiler.scala:22)
	at effekt.Server$.driver(Server.scala:261)
	at kiama.util.Compiler.main(Compiler.scala:50)
	at kiama.util.Compiler.main$(Compiler.scala:22)
	at effekt.Server$.main(Server.scala:261)
	at effekt.Server.main(Server.scala)

```

### Arguments Passed to the Compiler
```

compilercrash.effekt

```

