### PR TITLE
Add UTF-8 console encoding support for Windows

### DIFF
--- a/libraries/common/io/console.effekt
+++ b/libraries/common/io/console.effekt
@@ -46,7 +46,7 @@ namespace js {
   extern async def readLine(console: JSConsole): String =
     jsNode "$effekt.capture(k => ${console}.once('line', k))"
   extern io def writeLine(console: JSConsole, message: String): Unit =
-    jsNode """${console}.write(${message} + '\\n', 'utf8')"""
+    jsNode "${console}.output.write(${message} + '\\n')"
 }
 
 namespace examples {

--- a/libraries/common/io/console.effekt
+++ b/libraries/common/io/console.effekt
@@ -24,6 +24,11 @@ namespace js {
 
   extern jsNode """
     const readline = require('node:readline');
+    if (process.platform === 'win32') {
+      // Set UTF-8 codepage
+      require('child_process').execSync('chcp 65001');
+      process.stdout.setDefaultEncoding('utf8');
+    }
   """
 
   extern type JSConsole
@@ -32,6 +37,7 @@ namespace js {
     jsNode """readline.createInterface({
         input: process.stdin,
         output: process.stdout,
+        encoding: 'utf8',
       })"""
 
   extern io def close(console: JSConsole): Unit =
@@ -40,7 +46,7 @@ namespace js {
   extern async def readLine(console: JSConsole): String =
     jsNode "$effekt.capture(k => ${console}.once('line', k))"
   extern io def writeLine(console: JSConsole, message: String): Unit =
-    jsNode "${console}.output.write(${message} + '\\n')"
+    jsNode """${console}.write(${message} + '\\n', 'utf8')"""
 }
 
 namespace examples {


### PR DESCRIPTION
Fixes #726 

### Problem
When displaying Unicode characters (like chess pieces ♔) on Windows systems, the console shows '?' instead of the actual characters. This works correctly on Linux systems.
I saw the post in the effective programming with effekt course. I had the same problem because I want to create chess with effekt.

### Solution
Added Windows-specific console configuration:
- Set console codepage to 65001 (UTF-8) using `chcp` command
- Configure stdout to use UTF-8 encoding

### Notes
This change only affects Windows systems and has no impact on other platforms.
