### PR TITLE
Allow importing JS-specific Effekt libraries on jsWeb backend

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -190,6 +190,8 @@ object JSWebRunner extends Runner[String] {
 
   def standardLibraryPath(root: File): File = root / "libraries" / "common"
 
+  override def includes(path: File): List[File] = List(path / ".." / "js")
+
   override def prelude: List[String] = List("effekt", "option", "list", "result", "exception", "array", "string", "ref")
 
   def checkSetup(): Either[String, Unit] =


### PR DESCRIPTION
Currently, it's not possible to import, say, `mutable/map` when working on the `jsWeb` backend.
This PR should fix that.