### PR TITLE
Revert "Cherry-pick inlining fix from #725"

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/Inline.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Inline.scala
@@ -98,7 +98,8 @@ object Inline {
 
   def blockDefFor(id: Id)(using ctx: InlineContext): Option[Block] =
     ctx.defs.get(id) map {
-      case Definition.Def(id, block) => rewrite(block)
+      // TODO rewriting here leads to a stack overflow in one test, why?
+      case Definition.Def(id, block) => block //rewrite(block)
       case Definition.Let(id, _, binding) => INTERNAL_ERROR("Should not happen")
     }
 


### PR DESCRIPTION
Reverts effekt-lang/effekt#730 as it seems like an incorrect fix, judging both by the Effekt Working Group meeting, and the graphs after merging it:

![image](https://github.com/user-attachments/assets/67f28d10-ef57-4529-b47d-4df1d342bd63)
![image](https://github.com/user-attachments/assets/e6de9240-d9fd-4aeb-8f45-79a225307811)
