### PR TITLE
Do not abort after successful compilation on js-web

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -216,11 +216,16 @@ object JSWebRunner extends Runner[String] {
          |    <script type="text/javascript">
          |      window.onload=${mainName};
          |    </script>
+         |    <div id="app"></div>
          |  </body>
          |</html>
          |""".stripMargin
     IO.createFile(htmlFilePath, htmlContent, false)
-    C.abort(s"Open file://${htmlFilePath} in your browser or include ${jsFilePath}.")
+
+    // TODO: In ErrorReporter, add a way to terminate the program with a message, but not report a exit failure.
+    // Workaround: print and then 'exit(0)'
+    println(s"Open file://${htmlFilePath} in your browser or include ${jsFilePath}.")
+    scala.sys.exit(0)
 }
 
 trait ChezRunner extends Runner[String] {


### PR DESCRIPTION
Resolves #717

I am fully aware that this is not the best way to do things, a larger refactor would be needed (see the TODO in code). However, it's a somewhat pressing issue as we have users trying to work with `js-web` blocked on this...

As a bonus, I added a `id=app` div to the generated HTML.