### PR TITLE
Add 'show' for 'Byte' on JavaScript

### DIFF
--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -85,6 +85,7 @@ extern pure def show(value: Char): String =
   """
 
 extern pure def show(value: Byte): String =
+  js "'' + ${value}"
   llvm """
     %z = call %Pos @c_bytearray_show_Byte(i8 ${value})
     ret %Pos %z


### PR DESCRIPTION
Fixes #749 