### PR TITLE
Insert explicit boxing and unboxing 

### DIFF
--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -182,7 +182,12 @@ object Transformer {
               }
 
             case Block.Unbox(pure) =>
-              transform(pure).run { callee => Invoke(callee, builtins.Apply, values ++ blocks) }
+              transform(pure).run { boxedCallee =>
+                val callee = Variable(freshName(boxedCallee.name), Type.Negative())
+
+                ForeignCall(callee, "unbox", List(boxedCallee),
+                  Invoke(callee, builtins.Apply, values ++ blocks))
+              }
 
             case Block.New(impl) =>
               ErrorReporter.panic("Applying an object")
@@ -202,7 +207,12 @@ object Transformer {
               Invoke(Variable(transform(id), transform(tpe)), opTag, values ++ blocks)
 
             case Block.Unbox(pure) =>
-              transform(pure).run { callee => Invoke(callee, opTag, values ++ blocks) }
+              transform(pure).run { boxedCallee =>
+                val callee = Variable(freshName(boxedCallee.name), Type.Negative())
+
+                ForeignCall(callee, "unbox", List(boxedCallee),
+                  Invoke(callee, opTag, values ++ blocks))
+              }
 
             case Block.New(impl) =>
               ErrorReporter.panic("Method call to known object should have been reduced")
@@ -451,7 +461,12 @@ object Transformer {
       }
 
     case core.Box(block, annot) =>
-      transformBlockArg(block)
+      transformBlockArg(block).flatMap { unboxed =>
+        Binding { k =>
+          val boxed = Variable(freshName(unboxed.name), Type.Positive())
+          ForeignCall(boxed, "box", List(unboxed), k(boxed))
+        }
+      }
 
     case _ =>
       ErrorReporter.abort(s"Unsupported expression: $expr")
@@ -485,7 +500,7 @@ object Transformer {
 
   def transform(tpe: core.ValueType)(using ErrorReporter): Type = tpe match {
     case core.ValueType.Var(name) => Positive() // assume all value parameters are data
-    case core.ValueType.Boxed(tpe, capt) => Negative()
+    case core.ValueType.Boxed(tpe, capt) => Positive()
     case core.Type.TUnit => builtins.UnitType
     case core.Type.TInt => Type.Int()
     case core.Type.TChar => Type.Int()

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -114,6 +114,26 @@ declare void @exit(i64)
 declare void @llvm.assume(i1)
 
 
+; Boxing (externs functions, hence ccc)
+define ccc %Pos @box(%Neg %input) {
+    %vtable = extractvalue %Neg %input, 0
+    %heap_obj = extractvalue %Neg %input, 1
+    %vtable_as_int = ptrtoint ptr %vtable to i64
+    %pos_result = insertvalue %Pos undef, i64 %vtable_as_int, 0
+    %pos_result_with_heap = insertvalue %Pos %pos_result, ptr %heap_obj, 1
+    ret %Pos %pos_result_with_heap
+}
+
+define ccc %Neg @unbox(%Pos %input) {
+    %tag = extractvalue %Pos %input, 0
+    %heap_obj = extractvalue %Pos %input, 1
+    %vtable = inttoptr i64 %tag to ptr
+    %neg_result = insertvalue %Neg undef, ptr %vtable, 0
+    %neg_result_with_heap = insertvalue %Neg %neg_result, ptr %heap_obj, 1
+    ret %Neg %neg_result_with_heap
+}
+
+
 ; Prompts
 
 define private %Prompt @currentPrompt(%Stack %stack) {


### PR DESCRIPTION
This PR tries to unblock #695 by treating boxing and unboxing correctly in machine. 
There are two decisions here, neither of them is final:

1. I represent `box` and `unbox` as `ForeignCall` rather than adding two additional constructs to the machine IR.
2. I reconstruct the Pos and Neg values in LLVM IR manually since simple bit casting did not work.

@phischu can you please look at this? Maybe also perform some benchmarking / inspect the output of running `opt` to see whether LLVM can reason about box / unbox removal?