### PR TITLE
Experiment: calculate test coverage and send it to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,10 @@ jobs:
     - name: Run tests with coverage
       run: EFFEKT_VALGRIND=1 EFFEKT_DEBUG=1 sbt clean coverage test coverageReport
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+    - name: Upload test coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Assemble fully optimized js file
       run: sbt effektJS/fullOptJS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,11 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
 
-    - name: Run tests
-      run: EFFEKT_VALGRIND=1 EFFEKT_DEBUG=1 sbt clean test
+    - name: Run tests with coverage
+      run: EFFEKT_VALGRIND=1 EFFEKT_DEBUG=1 sbt clean coverage test coverageReport
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
 
     - name: Assemble fully optimized js file
       run: sbt effektJS/fullOptJS

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")


### PR DESCRIPTION
I tried setting up Codecov (free for public repos) so that we have some access to test coverage metrics.
Not sure if it even works or if we want this, hence the experiment label. :)

For each new PR after merging this, it should generate a report of how the coverage changed with the incoming patch, thus giving us (ignorable) signal as to what changes are not tested.
See the [PRs in Polarity](https://github.com/polarity-lang/polarity/pulls) for an idea of how this looks like there:
<img width="777" alt="Screenshot 2025-01-08 at 18 12 47" src="https://github.com/user-attachments/assets/48c614b6-27d7-43a4-a0e4-70bce900da79" />
