### PR TITLE
Fix #772 by parsing 'box <callExpr>' instead of 'box <ident>'

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -140,6 +140,9 @@ class RecursiveDescentTests extends munit.FunSuite {
     )
     parseExpr("box { (x: Int) => x }")
     parseExpr("box new Fresh { def fresh() = \"42\" }")
+    parseExpr("box foo()")
+    parseExpr("box bar(1)")
+    parseExpr("box baz(quux)")
 
     // { f } is parsed as a capture set and not backtracked.
     intercept[Throwable] { parseExpr("box { f }") }

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -672,7 +672,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
       val captures = `box` ~> backtrack(captureSet())
       val expr = if (peek(`{`)) functionArg()
         else if (peek(`new`)) newExpr()
-        else Var(idRef())
+        else callExpr()
       Box(captures, expr)
 
 

--- a/examples/neg/issue772.effekt
+++ b/examples/neg/issue772.effekt
@@ -1,0 +1,7 @@
+def main(): Unit = {
+  def sayHelloTo(name: String): Unit =
+    println("Hello, " ++ name ++ "!")
+
+  val _ = box sayHelloTo("Jolene") // ERROR Unbox requires a boxed type, but got Unit.
+  ()
+}


### PR DESCRIPTION
Resolves #772 (if it works)

The only downside now is that box-unbox inference could get some super weird and unexpected input. Oh well :)