### PR TITLE
Fix unknown compiler crash printing 'null'

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -115,6 +115,11 @@ trait Compiler[Executable] {
    * - Server / Driver to typecheck and report type errors in VSCode
    */
   def runFrontend(source: Source)(using C: Context): Option[Module] =
+    def getStackTrace(e: Throwable): String =
+      val stringWriter = new java.io.StringWriter()
+      e.printStackTrace(new java.io.PrintWriter(stringWriter))
+      stringWriter.toString
+
     try {
       val res = Frontend(source).map { res =>
         val mod = res.mod
@@ -128,15 +133,11 @@ trait Compiler[Executable] {
         None
       case e @ CompilerPanic(msg) =>
         C.report(msg)
-        e.getStackTrace.foreach { line =>
-          C.info("  at " + line)
-        }
+        C.info(getStackTrace(e))
         None
       case e =>
         C.info("Effekt Compiler Crash: " + e.toString)
-        e.getStackTrace.foreach { line =>
-          C.info("  at " + line)
-        }
+        C.info(getStackTrace(e))
         None
     }
 

--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -133,7 +133,7 @@ trait Compiler[Executable] {
         }
         None
       case e =>
-        C.info("Effekt Compiler Crash: " + e.getMessage)
+        C.info("Effekt Compiler Crash: " + e.toString)
         e.getStackTrace.foreach { line =>
           C.info("  at " + line)
         }


### PR DESCRIPTION
Resolves the `Effect Compiler Crash: null` part of #760.
The actual problem there was that `e.getMessage` can return `null` and it does for... _StackOverflowException_ 🥳.
Looking at the docs, it's recommended to use `e.toString`.

While I was at it, I modified stack trace printing, now we do it properly by using `.printStackTrace`.

This is very related to #731, I just want to get this out quickly to unblock other problems.