### PR TITLE
Fix byte-related LLVM segfaults

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -22,6 +22,11 @@ class LLVMTests extends EffektTests {
   lazy val bugs: List[File] = List(
     // names not sanitized (even?)
     examplesDir / "pos" / "special_names.effekt",
+    // Jump to the invalid address stated on the next line
+    examplesDir / "benchmarks" / "input_output" / "dyck_one.effekt",
+    examplesDir / "benchmarks" / "input_output" / "number_matrix.effekt",
+    examplesDir / "benchmarks" / "input_output" / "word_count_ascii.effekt",
+    examplesDir / "benchmarks" / "input_output" / "word_count_utf8.effekt",
   )
 
   /**

--- a/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LLVMTests.scala
@@ -22,11 +22,6 @@ class LLVMTests extends EffektTests {
   lazy val bugs: List[File] = List(
     // names not sanitized (even?)
     examplesDir / "pos" / "special_names.effekt",
-    // Jump to the invalid address stated on the next line
-    examplesDir / "benchmarks" / "input_output" / "dyck_one.effekt",
-    examplesDir / "benchmarks" / "input_output" / "number_matrix.effekt",
-    examplesDir / "benchmarks" / "input_output" / "word_count_ascii.effekt",
-    examplesDir / "benchmarks" / "input_output" / "word_count_utf8.effekt",
   )
 
   /**

--- a/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
@@ -40,15 +40,5 @@ class StdlibLLVMTests extends StdlibTests {
   override def valgrind = sys.env.get("EFFEKT_VALGRIND").nonEmpty
   override def debug = sys.env.get("EFFEKT_DEBUG").nonEmpty
 
-  override def ignored: List[File] = List(
-    // segfaults
-    examplesDir / "stdlib" / "stream" / "fuse_newlines.effekt",
-
-    // Syscall param write(buf) points to uninitialised byte(s)
-    examplesDir / "stdlib" / "io" / "filesystem" / "files.effekt",
-    examplesDir / "stdlib" / "io" / "filesystem" / "async_file_io.effekt",
-
-    // Conditional jump or move depends on uninitialised value(s)
-    examplesDir / "stdlib" / "io" / "filesystem" / "wordcount.effekt",
-  )
+  override def ignored: List[File] = List()
 }

--- a/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/StdlibTests.scala
@@ -40,5 +40,12 @@ class StdlibLLVMTests extends StdlibTests {
   override def valgrind = sys.env.get("EFFEKT_VALGRIND").nonEmpty
   override def debug = sys.env.get("EFFEKT_DEBUG").nonEmpty
 
-  override def ignored: List[File] = List()
+  override def ignored: List[File] = List(
+    // Syscall param write(buf) points to uninitialised byte(s)
+    examplesDir / "stdlib" / "io" / "filesystem" / "files.effekt",
+    examplesDir / "stdlib" / "io" / "filesystem" / "async_file_io.effekt",
+
+    // Conditional jump or move depends on uninitialised value(s)
+    examplesDir / "stdlib" / "io" / "filesystem" / "wordcount.effekt",
+  )
 }

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -415,7 +415,6 @@ object Transformer {
     case machine.Type.Int()          => IntegerType64()
     case machine.Type.Byte()         => IntegerType8()
     case machine.Type.Double()       => DoubleType()
-    case machine.Type.String()       => positiveType
     case machine.Type.Reference(tpe) => referenceType
   }
 
@@ -431,7 +430,6 @@ object Transformer {
       case machine.Type.Int()        => 8 // TODO Make fat?
       case machine.Type.Byte()       => 8
       case machine.Type.Double()     => 8 // TODO Make fat?
-      case machine.Type.String()     => 16
       case machine.Type.Reference(_) => 16
     }
 
@@ -666,7 +664,6 @@ object Transformer {
       case machine.Positive()    => Call("_", Ccc(), VoidType(), sharePositive, List(transform(value)))
       case machine.Negative()    => Call("_", Ccc(), VoidType(), shareNegative, List(transform(value)))
       case machine.Type.Stack()  => Call("_", Ccc(), VoidType(), shareResumption, List(transform(value)))
-      case machine.Type.String() => Call("_", Ccc(), VoidType(), shareString, List(transform(value)))
     }.map(emit)
   }
 
@@ -675,7 +672,6 @@ object Transformer {
       case machine.Positive()    => Call("_", Ccc(), VoidType(), erasePositive, List(transform(value)))
       case machine.Negative()    => Call("_", Ccc(), VoidType(), eraseNegative, List(transform(value)))
       case machine.Type.Stack()  => Call("_", Ccc(), VoidType(), eraseResumption, List(transform(value)))
-      case machine.Type.String() => Call("_", Ccc(), VoidType(), eraseString, List(transform(value)))
     }.map(emit)
   }
 
@@ -703,14 +699,12 @@ object Transformer {
   val shareNegative = ConstantGlobal("shareNegative");
   val shareResumption = ConstantGlobal("shareResumption");
   val shareFrames = ConstantGlobal("shareFrames");
-  val shareString = ConstantGlobal("sharePositive");
 
   val eraseObject = ConstantGlobal("eraseObject");
   val erasePositive = ConstantGlobal("erasePositive");
   val eraseNegative = ConstantGlobal("eraseNegative");
   val eraseResumption = ConstantGlobal("eraseResumption");
   val eraseFrames = ConstantGlobal("eraseFrames");
-  val eraseString = ConstantGlobal("erasePositive");
 
   val alloc = ConstantGlobal("alloc")
   val getPointer = ConstantGlobal("getPointer")

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -429,7 +429,7 @@ object Transformer {
       case machine.Type.Prompt()     => 8 // TODO Make fat?
       case machine.Type.Stack()      => 8 // TODO Make fat?
       case machine.Type.Int()        => 8 // TODO Make fat?
-      case machine.Type.Byte()       => 1
+      case machine.Type.Byte()       => 8
       case machine.Type.Double()     => 8 // TODO Make fat?
       case machine.Type.String()     => 16
       case machine.Type.Reference(_) => 16

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -32,7 +32,6 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Type.Int()          => "Int"
     case Type.Byte()         => "Byte"
     case Type.Double()       => "Double"
-    case Type.String()       => "String"
     case Type.Reference(tpe) => toDoc(tpe) <> "*"
   }
 

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -390,7 +390,7 @@ object Transformer {
       }
 
     case core.Literal(javastring: String, _) =>
-      val literal_binding = Variable(freshName("utf8StringLiteral"), Type.String());
+      val literal_binding = Variable(freshName("utf8StringLiteral"), builtins.StringType);
       Binding { k =>
         LiteralUTF8String(literal_binding, javastring.getBytes("utf-8"), k(literal_binding))
       }
@@ -472,7 +472,7 @@ object Transformer {
     case core.Type.TByte => Type.Byte()
     case core.Type.TBoolean => builtins.BooleanType
     case core.Type.TDouble => Type.Double()
-    case core.Type.TString => Type.String()
+    case core.Type.TString => Positive()
     case core.ValueType.Data(symbol, targs) => Positive()
   }
 

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -222,7 +222,6 @@ enum Type {
   case Int()
   case Byte()
   case Double()
-  case String()
   case Reference(tpe: Type)
 }
 export Type.{ Positive, Negative }
@@ -240,6 +239,8 @@ object builtins {
   val True: Tag = 1
   val False: Tag = 0
   val BooleanType = Positive()
+
+  val StringType = Positive()
 
   val SingletonRecord: Tag = 0
 }

--- a/libraries/llvm/main.c
+++ b/libraries/llvm/main.c
@@ -40,4 +40,5 @@ int main(int argc, char *argv[]) {
     uv_loop_t *loop = uv_default_loop();
     uv_run(loop, UV_RUN_DEFAULT);
     uv_loop_close(loop);
+    return 0;
 }


### PR DESCRIPTION
Closes #783. And closes #778.

I believe the way we currently handle size calculations for stack pushes/pops of non-structural types has some flaws for non-pointer values. Some changes in how we use the GEP instruction will probably fix this, but I find its syntax really confusing. I have a proof-of-concept alternate fix at the end.

To bypass the calculation issues, we can also just change the size of a byte to 8 byte instead. This *hotfix* fixes the segfault in the original issue as well as all of my minified versions.

Some additional explanations of the issue using an example program:

```scala
def foo { action: Byte => Unit }: Unit =
  action(42.toByte)

def main() = {
  foo { b =>
    // does not segfault when printlns are swapped
    println(42)
    println(b)
  }
}
```

<details>

<summary>Pseudo-flow with relevant (for the segfault) lines marked</summary>

```
main(stack)

main(stack):
alloc(3 * 8 = 24)
push returnAddress_1
push sharer_5
push eraser_7
blockLit = vtable[blockLit_3289_clause_13]
foo(blockLit, stack)

foo(blockLit, stack):
alloc(3 * 8 = 24)
push returnAddress_40
push sharer_5
push eraser_7
literal = 42
byte = toByte(literal)
vtable = blockLit[0]
closure = blockLit[1]
fp = *vtable // = blockLit_3289_clause_13
fp(closure, byte, stack)

blockLit_3289_clause_13(closure, byte, stack):
alloc(3 * 8 + 1 = 25) // <---------------------------
push byte
push returnAddress_14
push sharer_26
push eraser_30
literal = 42
printlnInt(literal, stack)

printlnInt(value, stack): // _4
str = show(value)
unit = println(str)
dealloc(3 * 8 = 24)
pop _
pop _
pop returnAddress // _14
returnAddress(unit, stack) // <---------------------------

returnAddress_14(ret, stack):
dealloc(1)
pop byte
erase(ret)
alloc(3 * 8 = 24)
push returnAddress_17
push sharer_5
push eraser_7
printlnByte(byte, stack)

printlnByte(byte, stack):
str = show(byte)
unit = println(str)
dealloc(24)
pop _
pop _
pop returnAddress // _17
returnAddress(unit, stack)

returnAddress_17(unit, stack):
dealloc(24)
pop _
pop _
pop returnAddress // _40
returnAddress(unit, stack)

returnAddress_40(unit, stack)
dealloc(24)
pop _
pop _
pop returnAddress // _1
returnAddress(unit, stack)

returnAddress_1(unit, stack):
dealloc(24)
pop _
pop _
pop returnAddress
returnAddress(unit, stack)
```

</details>

The corresponding LLVM code of the relevant sections:

```llvm
define tailcc void @blockLit_3289_clause_13(%Object %closure, i8 %b_2365, %Stack %stack) {
        
    entry:
        
        ; new blockLit_3289_clause_13, 1 parameters
        %stackPointer_33 = call ccc %StackPointer @stackAllocate(%Stack %stack, i64 25) ; <---------------
        %b_2365_pointer_34 = getelementptr {i8}, %StackPointer %stackPointer_33, i64 0, i32 0
        store i8 %b_2365, ptr %b_2365_pointer_34, !noalias !2
        %returnAddress_pointer_35 = getelementptr {{i8}, %FrameHeader}, %StackPointer %stackPointer_33, i64 0, i32 1, i32 0
        %sharer_pointer_36 = getelementptr {{i8}, %FrameHeader}, %StackPointer %stackPointer_33, i64 0, i32 1, i32 1
        %eraser_pointer_37 = getelementptr {{i8}, %FrameHeader}, %StackPointer %stackPointer_33, i64 0, i32 1, i32 2
        store ptr @returnAddress_14, ptr %returnAddress_pointer_35, !noalias !2
        store ptr @sharer_26, ptr %sharer_pointer_36, !noalias !2
        store ptr @eraser_30, ptr %eraser_pointer_37, !noalias !2
        
        ; literalInt longLiteral_3291, n=42
        %longLiteral_3291 = add i64 42, 0
        
        ; substitution
        
        ; substitution [value_3 !-> longLiteral_3291]
        
        ; jump println_4
        musttail call tailcc void @println_4(i64 %longLiteral_3291, %Stack %stack)
        ret void
}

...

define tailcc void @println_4(i64 %value_3, %Stack %stack) {
        
    entry:
        
        ; definition println_4, environment length 1
        
        ; foreignCall pureApp_3284 : String(), foreign show_14, 1 values
        %pureApp_3284 = call ccc %Pos @show_14(i64 %value_3)
        
        ; foreignCall pureApp_3283 : Positive(), foreign println_1, 1 values
        %pureApp_3283 = call ccc %Pos @println_1(%Pos %pureApp_3284)
        
        ; substitution
        
        ; substitution [v_r_3164_3278 !-> pureApp_3283]
        
        ; return, 1 values
        %stackPointer_56 = call ccc %StackPointer @stackDeallocate(%Stack %stack, i64 24)
        %returnAddress_pointer_57 = getelementptr %FrameHeader, %StackPointer %stackPointer_56, i64 0, i32 0
        %returnAddress_55 = load %ReturnAddress, ptr %returnAddress_pointer_57, !noalias !2
        musttail call tailcc void %returnAddress_55(%Pos %pureApp_3283, %Stack %stack) ; <-------------------------
        ; here is the segfault, since returnAddress_55 is missing one byte!
        ret void
}
```

---

A fix I came up with that does not involve making the size of a byte large:

``` llvm
define tailcc void @blockLit_3289_clause_13(%Object %closure, %Byte %b_2365, %Stack %stack) {
        
    entry:
        ; new blockLit_3289_clause_13, 1 parameters
        ; SPLIT the allocation into two segments <-----------------------
        %stackPointar_33 = call ccc %StackPointer @stackAllocate(%Stack %stack, i64 1)
        %b_2365_pointer_34 = getelementptr %Byte, %StackPointer %stackPointar_33, i64 0
        store %Byte %b_2365, ptr %b_2365_pointer_34, !noalias !2
        
        %stackPointer_33 = call ccc %StackPointer @stackAllocate(%Stack %stack, i64 24)

        %returnAddress_pointer_35 = getelementptr %FrameHeader, %StackPointer %stackPointer_33, i64 0, i32 0
        %sharer_pointer_36 = getelementptr %FrameHeader, %StackPointer %stackPointer_33, i64 0, i32 1
        %eraser_pointer_37 = getelementptr %FrameHeader, %StackPointer %stackPointer_33, i64 0, i32 2
        store ptr @returnAddress_14, ptr %returnAddress_pointer_35, !noalias !2
        store ptr @sharer_26, ptr %sharer_pointer_36, !noalias !2
        store ptr @eraser_30, ptr %eraser_pointer_37, !noalias !2

        ; literalInt longLiteral_3291, n=42
        %longLiteral_3291 = add i64 42, 0
        
        ; substitution
        
        ; substitution [value_3 !-> longLiteral_3291]
        
        ; jump println_4
        musttail call tailcc void @println_4(i64 %longLiteral_3291, %Stack %stack)
        ret void
}

...
```