### PR TITLE
Fix nitpicks in core pretty-printing

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -108,13 +108,15 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def argsToDoc(targs: List[core.ValueType], vargs: List[core.Pure], bargs: List[core.Block]): Doc =
     val targsDoc = if targs.isEmpty then emptyDoc else brackets(targs.map(toDoc))
     //val cargsDoc = if cargs.isEmpty then emptyDoc else brackets(cargs.map(toDoc))
-    val vargsDoc = if vargs.isEmpty && !bargs.isEmpty then emptyDoc else vargs.map(toDoc)
-    val bargsDoc = bargs.map(toDoc)
-    targsDoc <> parens(vargsDoc) <> braces(bargsDoc)
+    val vargsDoc = if vargs.isEmpty && !bargs.isEmpty then emptyDoc else parens(vargs.map(toDoc))
+    val bargsDoc = if bargs.isEmpty then emptyDoc else braces(bargs.map(toDoc))
+    targsDoc <> vargsDoc <> bargsDoc
 
   def paramsToDoc(tps: List[symbols.Symbol], vps: List[ValueParam], bps: List[BlockParam]): Doc = {
-    val tpsDoc = if (tps.isEmpty) emptyDoc else brackets(tps.map(toDoc))
-    tpsDoc <> parens(hsep(vps map toDoc, comma)) <> hcat(bps map toDoc)
+    val tpsDoc = if tps.isEmpty then emptyDoc else brackets(tps.map(toDoc))
+    val vpsDoc = if vps.isEmpty && !bps.isEmpty then emptyDoc else parens(vps.map(toDoc))
+    val bpsDoc = if bps.isEmpty then emptyDoc else hcat(bps.map(toDoc)) // already are in braces!
+    tpsDoc <> vpsDoc <> bpsDoc
   }
 
   def toDoc(instance: Implementation): Doc = {

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -108,9 +108,9 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def argsToDoc(targs: List[core.ValueType], vargs: List[core.Pure], bargs: List[core.Block]): Doc =
     val targsDoc = if targs.isEmpty then emptyDoc else brackets(targs.map(toDoc))
     //val cargsDoc = if cargs.isEmpty then emptyDoc else brackets(cargs.map(toDoc))
-    val vargsDoc = vargs.map(toDoc)
+    val vargsDoc = if vargs.isEmpty && !bargs.isEmpty then emptyDoc else vargs.map(toDoc)
     val bargsDoc = bargs.map(toDoc)
-    targsDoc <> parens(vargsDoc ++ bargsDoc)
+    targsDoc <> parens(vargsDoc) <> braces(bargsDoc)
 
   def paramsToDoc(tps: List[symbols.Symbol], vps: List[ValueParam], bps: List[BlockParam]): Doc = {
     val tpsDoc = if (tps.isEmpty) emptyDoc else brackets(tps.map(toDoc))

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -155,7 +155,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Toplevel.Def(id, block) =>
       "def" <+> toDoc(id) <+> "=" <+> toDoc(block)
     case Toplevel.Val(id, _, binding) =>
-      "vet" <+> toDoc(id) <+> "=" <+> toDoc(binding)
+      "let" <+> toDoc(id) <+> "=" <+> toDoc(binding)
   }
 
   def toDoc(s: Stmt): Doc = s match {


### PR DESCRIPTION
Resolves #767 + renames `vet` to `let` for top-level value bindings.
Furthermore, I tried aligning the printing of params and args + added a rule that `()` won't be printed if there's a block arg afterwards (much like the current style in the frontend)

Here's a screenshot of a pretty diff:
<img width="1252" alt="Screenshot 2025-01-22 at 12 33 33" src="https://github.com/user-attachments/assets/4148a1d9-604e-4b22-9d48-aa63816fd8f0" />

And here's a machine-readable diff:
```diff
-vet oneIncrement2362 = return 1;
-def useCounter2359(){c2358} = {
+let oneIncrement2362 = return 1;
+def useCounter2359{c2358} = {
   {
     val v_r_23873305: Int398 = c2358.get();
     val v_r_23883306: Unit394 = println4(v_r_23873305);
@@ -56,10 +56,10 @@ def useCounter2359(){c2358} = {
 def counterAsEffect2360() = {
   val v_r_23933303: Int398 = return 0;
   var count2365 = v_r_23933303 ;
-  val v_r_24053322: Unit394 = reset { (){p3311} =>
+  val v_r_24053322: Unit394 = reset { {p3311} =>
     def counter2369 = new Counter2357 {
       def increment2363() =
-        shift(p3311) { (){k3314} =>
+        shift(p3311) { {k3314} =>
           def resume2367(a3315: Unit394) = resume(k3314) {
             return a3315
           }
@@ -72,7 +72,7 @@ def counterAsEffect2360() = {
           return v_r_23983316
         }
       def get2364() =
-        shift(p3311) { (){k3317} =>
+        shift(p3311) { {k3317} =>
           def resume2368(a3318: Int398) = resume(k3317) {
             return a3318
           }
@@ -81,7 +81,7 @@ def counterAsEffect2360() = {
           return v_r_24023320
         }
     }
-    val v_r_24043321: Unit394 = useCounter2359(counter2369);
+    val v_r_24043321: Unit394 = useCounter2359{counter2369};
     return v_r_24043321
   };
   return v_r_24053322
```