### PR TITLE
Unification benchmark using 'map' and 'stream'

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
@@ -160,6 +160,9 @@ object Normalizer { normal =>
 
   def normalize(s: Stmt)(using C: Context): Stmt = s match {
 
+     case Stmt.Def(id, block, body) if !C.usage.contains(id) || C.usage.get(id).contains(Usage.Never) => // see #798
+      normalize(body)
+
     case Stmt.Def(id, block, body) =>
       val normalized = active(block).dealiased
       Stmt.Def(id, normalized, normalize(body)(using C.bind(id, normalized)))

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
@@ -66,6 +66,9 @@ object Normalizer { normal =>
       case None => false
     }
 
+  private def isUnused(id: Id)(using ctx: Context): Boolean =
+    ctx.usage.get(id).forall { u => u == Usage.Never }
+
   def normalize(entrypoints: Set[Id], m: ModuleDecl, maxInlineSize: Int, preserveBoxing: Boolean): ModuleDecl = {
     // usage information is used to detect recursive functions (and not inline them)
     val usage = Reachable(entrypoints, m)
@@ -161,7 +164,7 @@ object Normalizer { normal =>
   def normalize(s: Stmt)(using C: Context): Stmt = s match {
 
     // see #798 for context (led to stack overflow)
-    case Stmt.Def(id, block, body) if !C.usage.contains(id) || C.usage.get(id).contains(Usage.Never) =>
+    case Stmt.Def(id, block, body) if isUnused(id) =>
       normalize(body)
 
     case Stmt.Def(id, block, body) =>

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
@@ -160,9 +160,8 @@ object Normalizer { normal =>
 
   def normalize(s: Stmt)(using C: Context): Stmt = s match {
 
-     case Stmt.Def(id, block, body) if !C.usage.contains(id) || C.usage.get(id).contains(Usage.Never) => // see #798
+    case Stmt.Def(id, block, body) if !C.usage.contains(id) || C.usage.get(id).contains(Usage.Never) => // see #798
       normalize(body)
-
     case Stmt.Def(id, block, body) =>
       val normalized = active(block).dealiased
       Stmt.Def(id, normalized, normalize(body)(using C.bind(id, normalized)))

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
@@ -160,8 +160,10 @@ object Normalizer { normal =>
 
   def normalize(s: Stmt)(using C: Context): Stmt = s match {
 
-    case Stmt.Def(id, block, body) if !C.usage.contains(id) || C.usage.get(id).contains(Usage.Never) => // see #798
+    // see #798 for context (led to stack overflow)
+    case Stmt.Def(id, block, body) if !C.usage.contains(id) || C.usage.get(id).contains(Usage.Never) =>
       normalize(body)
+
     case Stmt.Def(id, block, body) =>
       val normalized = active(block).dealiased
       Stmt.Def(id, normalized, normalize(body)(using C.bind(id, normalized)))

--- a/examples/benchmarks/other/unify.check
+++ b/examples/benchmarks/other/unify.check
@@ -1,5 +1,4 @@
 Unification successful!
   a -> List(Int)
 Unification successful!
-Found: 4096
-Expected: 4096
+4096

--- a/examples/benchmarks/other/unify.check
+++ b/examples/benchmarks/other/unify.check
@@ -1,3 +1,5 @@
 Unification successful!
-Substitution:
   a -> List(Int)
+Unification successful!
+Found: 65536
+Expected: 65536

--- a/examples/benchmarks/other/unify.check
+++ b/examples/benchmarks/other/unify.check
@@ -1,5 +1,5 @@
 Unification successful!
   a -> List(Int)
 Unification successful!
-Found: 65536
-Expected: 65536
+Found: 4096
+Expected: 4096

--- a/examples/benchmarks/other/unify.check
+++ b/examples/benchmarks/other/unify.check
@@ -1,0 +1,3 @@
+Unification successful!
+Substitution:
+  a -> List(Int)

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -97,6 +97,7 @@ def show(err: UnificationError): String = err match {
     "Cannot unify " ++ tps2.map { showType }.join(", ") ++ " with " ++ tps1.map { showType }.join(", ")
 }
 
+/// Worker wrapper
 def reporting { body : => Substitution / Exception[UnificationError] }: Unit / emit[(String, Type)] = {
   val res = result[Substitution, UnificationError] {
     body()
@@ -115,6 +116,29 @@ def reporting { body : => Substitution / Exception[UnificationError] }: Unit / e
   }
 }
 
+/// Used for testing to generate two `depth`-deep, nested types of the shape:
+/// ```
+/// (Nested
+///   (Nested
+///     ...
+///       XLLLLLLLL
+///       XLLLLLLLR)
+/// ```
+/// for `baseVar = X`.
+def generateDeepType(depth: Int, baseVar: String): Type = {
+  def recur(currentDepth: Int, varSuffix: String): Type =
+    if (currentDepth == 0) {
+      Var(baseVar ++ varSuffix)
+    } else {
+      Con("Nested", [
+        recur(currentDepth - 1, varSuffix ++ "L"),
+        recur(currentDepth - 1, varSuffix ++ "R")
+      ])
+    }
+
+  recur(depth, "")
+}
+
 def main() = {
   def printBinding(pair: (String, Type)): Unit =
     println("  " ++ pair.first ++ " -> " ++ showType(pair.second))
@@ -130,27 +154,12 @@ def main() = {
     }
   } { printBinding }
 
-  val N = 16
-
+  // the actual test
+  val N = 12
   var found = 0
 
-  // the actual test
   for {
     reporting {
-      def generateDeepType(depth: Int, baseVar: String): Type = {
-        def recur(currentDepth: Int, varSuffix: String): Type =
-          if (currentDepth == 0) {
-            Var(baseVar ++ varSuffix)
-          } else {
-            Con("Nested", [
-              recur(currentDepth - 1, varSuffix ++ "L"),
-              recur(currentDepth - 1, varSuffix ++ "R")
-            ])
-          }
-
-        recur(depth, "")
-      }
-
       val deepType1 = generateDeepType(N, "A")
       val deepType2 = generateDeepType(N, "B")
       unify(deepType1, deepType2)

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -1,6 +1,7 @@
 /// Robinson-style Unification Algorithm
 module examples/benchmarks/unify
 
+import examples/benchmarks/runner
 import map
 import result
 import bytearray
@@ -141,7 +142,7 @@ def generateDeepType(depth: Int, baseVar: String): Type = {
   recur(depth, "")
 }
 
-def main() = {
+def run(N: Int) = {
   def printBinding(pair: (String, Type)): Unit =
     println("  " ++ pair.first ++ " -> " ++ showType(pair.second))
 
@@ -157,7 +158,6 @@ def main() = {
   } { printBinding }
 
   // the actual test
-  val N = 12
   var found = 0
 
   for {
@@ -173,6 +173,11 @@ def main() = {
       println("error! " ++ l ++ " -> " ++ showType(r))
   }
 
-  println("Found: " ++ found.show)
-  println("Expected: " ++ 2.0.pow(N).show)
+  val expected = 2.0.pow(N).toInt
+  if (found != expected) {
+    panic("found: " ++ found.show ++ ", but expected: " ++ expected.show)
+  }
+  found
 }
+
+def main() = benchmark(12){run}

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -96,7 +96,7 @@ def show(err: UnificationError): String = err match {
     "Occurs check failed: " ++ variable ++ " occurs in " ++ showType(ty)
   case UnificationFailure(ty1, ty2) =>
     "Cannot unify " ++ showType(ty1) ++ " with " ++ showType(ty2)
-    case UnificationManyFailure(tps1, tps2) =>
+  case UnificationManyFailure(tps1, tps2) =>
     "Cannot unify " ++ tps2.map { showType }.join(", ") ++ " with " ++ tps1.map { showType }.join(", ")
 }
 

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -132,6 +132,8 @@ def main() = {
 
   val N = 16
 
+  var found = 0
+
   // the actual test
   for {
     reporting {
@@ -154,7 +156,12 @@ def main() = {
       unify(deepType1, deepType2)
     }
   } {
-    case (l, Var(r)) and l.substring(1) == r.substring(1) => ()
-    case (l, r) => println("error! " ++ l ++ " -> " ++ showType(r))
+    case (l, Var(r)) and l.substring(1) == r.substring(1) =>
+      found = found + 1
+    case (l, r) =>
+      println("error! " ++ l ++ " -> " ++ showType(r))
   }
+
+  println("Found: " ++ found.show)
+  println("Expected: " ++ 2.0.pow(N).show)
 }

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -21,15 +21,14 @@ type UnificationError {
 
 // Check if a type variable occurs in another type
 def occurs(variable: String, ty: Type): Bool = ty match {
-  case Var(name) => name == variable
+  case Var(name)    => name == variable
   case Con(_, args) => args.any { arg => variable.occurs(arg) }
 }
 
 // Apply a substitution to a type
 def apply(subst: Substitution, ty: Type): Type = ty match {
   case Var(name) =>
-    val substitutedType = subst.getOrElse(name) { () => ty }
-    subst.apply(substitutedType)
+    subst.getOrElse(name) { () => ty }
   case Con(name, args) =>
     Con(name, args.map { arg => subst.apply(arg) })
 }
@@ -127,7 +126,7 @@ def main() = {
 
      unify(typeVar, listType)
   }
-/*
+
   reporting {
     val functionalType =
       Con("Func", [
@@ -168,5 +167,37 @@ def main() = {
       ])
 
     unify(functionalType, concreteType, initialSubstitution)
-  }*/
+  }
+
+  reporting {
+    val x = Var("X")
+        val z = Var("Z")
+
+    def pairOf(x: Type) = Con("Pair", [x, x])
+    val intPair = pairOf(Con("Int", []))
+
+    val term1 = Con("Pair", [
+      Con("Pair", [pairOf(x), pairOf(x)]),
+      Con("Pair", [pairOf(x), pairOf(x)])
+    ])
+
+    val term2 = Con("Pair", [
+      Con("Pair", [intPair, Var("y")]),
+      z
+    ])
+
+    val subst1 = unify(term1, term2)
+
+    val term3 = Con("Pair", [
+      Con("Pair", [pairOf(z), pairOf(z)]),
+      Con("Pair", [pairOf(z), pairOf(z)])
+    ])
+
+    val term4 = Con("Pair", [
+      Con("Pair", [Var("a"), Var("b")]),
+      Var("c")
+    ])
+
+    unify(term3, term4, subst1)
+  }
 }

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -97,7 +97,7 @@ def show(err: UnificationError): String = err match {
     "Cannot unify " ++ tps2.map { showType }.join(", ") ++ " with " ++ tps1.map { showType }.join(", ")
 }
 
-def reporting { body : => Substitution / Exception[UnificationError] }: Unit = {
+def reporting { body : => Substitution / Exception[UnificationError] }: Unit / emit[(String, Type)] = {
   val res = result[Substitution, UnificationError] {
     body()
   }
@@ -105,10 +105,7 @@ def reporting { body : => Substitution / Exception[UnificationError] }: Unit = {
   res match {
     case Success(subst) => {
       println("Unification successful!")
-      println("Substitution:")
-      for { subst.each } { case (k, v) =>
-        println("  " ++ k ++ " -> " ++ showType(v))
-      }
+      subst.each
     }
     case Error(err, msg) =>
       println("Unification failed: " ++ show(err))
@@ -119,85 +116,45 @@ def reporting { body : => Substitution / Exception[UnificationError] }: Unit = {
 }
 
 def main() = {
-  reporting {
-     val intType = Con("Int", [])
-     val listType = Con("List", [intType])
-     val typeVar = Var("a")
+  def printBinding(pair: (String, Type)): Unit =
+    println("  " ++ pair.first ++ " -> " ++ showType(pair.second))
 
-     unify(typeVar, listType)
-  }
+  // sanity check
+  for {
+    reporting {
+      val intType = Con("Int", [])
+      val listType = Con("List", [intType])
+      val typeVar = Var("a")
 
-  reporting {
-    val functionalType =
-      Con("Func", [
-        Var("a"),
-        Con("List", [Var("b")]),
-        Var("c")
-      ])
+      unify(typeVar, listType)
+    }
+  } { printBinding }
 
-    val concreteType =
-      Con("Func", [
-        Con("Int", []),
-        Con("List", [Con("String", [])]),
-        Con("Bool", [])
-      ])
+  val N = 16
 
-    unify(functionalType, concreteType)
-  }
+  // the actual test
+  for {
+    reporting {
+      def generateDeepType(depth: Int, baseVar: String): Type = {
+        def recur(currentDepth: Int, varSuffix: String): Type =
+          if (currentDepth == 0) {
+            Var(baseVar ++ varSuffix)
+          } else {
+            Con("Nested", [
+              recur(currentDepth - 1, varSuffix ++ "L"),
+              recur(currentDepth - 1, varSuffix ++ "R")
+            ])
+          }
 
-  val initialSubstitution = map::fromList([
-    ("one", Con("Int", [])),
-    ("zero", Con("Int", [])),
-    ("defaultList", Con("List", [Var("elem")]))
-  ], box bytearray::compareStringBytes)
+        recur(depth, "")
+      }
 
-  reporting {
-    val functionalType =
-      Con("Func", [
-        Var("a"),
-        Con("List", [Var("b")]),
-        Var("one")
-      ])
-
-    val concreteType =
-      Con("Func", [
-        Con("Int", []),
-        Var("defaultList"),
-        Var("e")
-      ])
-
-    unify(functionalType, concreteType, initialSubstitution)
-  }
-
-  reporting {
-    val x = Var("X")
-        val z = Var("Z")
-
-    def pairOf(x: Type) = Con("Pair", [x, x])
-    val intPair = pairOf(Con("Int", []))
-
-    val term1 = Con("Pair", [
-      Con("Pair", [pairOf(x), pairOf(x)]),
-      Con("Pair", [pairOf(x), pairOf(x)])
-    ])
-
-    val term2 = Con("Pair", [
-      Con("Pair", [intPair, Var("y")]),
-      z
-    ])
-
-    val subst1 = unify(term1, term2)
-
-    val term3 = Con("Pair", [
-      Con("Pair", [pairOf(z), pairOf(z)]),
-      Con("Pair", [pairOf(z), pairOf(z)])
-    ])
-
-    val term4 = Con("Pair", [
-      Con("Pair", [Var("a"), Var("b")]),
-      Var("c")
-    ])
-
-    unify(term3, term4, subst1)
+      val deepType1 = generateDeepType(N, "A")
+      val deepType2 = generateDeepType(N, "B")
+      unify(deepType1, deepType2)
+    }
+  } {
+    case (l, Var(r)) and l.substring(1) == r.substring(1) => ()
+    case (l, r) => println("error! " ++ l ++ " -> " ++ showType(r))
   }
 }

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -1,0 +1,172 @@
+/// Robinson-style Unification Algorithm
+module examples/benchmarks/unify
+
+import map
+import result
+import bytearray
+import stream
+
+type Type {
+  Var(name: String)
+  Con(name: String, args: List[Type])
+}
+
+type Substitution = Map[String, Type]
+
+type UnificationError {
+  OccursCheckFailure(variable: String, tpe: Type)
+  UnificationFailure(tpe1: Type, tpe2: Type)
+  UnificationManyFailure(tps1: List[Type], tps2: List[Type])
+}
+
+// Check if a type variable occurs in another type
+def occurs(variable: String, ty: Type): Bool = ty match {
+  case Var(name) => name == variable
+  case Con(_, args) => args.any { arg => variable.occurs(arg) }
+}
+
+// Apply a substitution to a type
+def apply(subst: Substitution, ty: Type): Type = ty match {
+  case Var(name) =>
+    val substitutedType = subst.getOrElse(name) { () => ty }
+    subst.apply(substitutedType)
+  case Con(name, args) =>
+    Con(name, args.map { arg => subst.apply(arg) })
+}
+
+def unify(ty1: Type, ty2: Type, subst: Substitution): Substitution / Exception[UnificationError] = {
+  val substTy1 = subst.apply(ty1)
+  val substTy2 = subst.apply(ty2)
+
+  (substTy1, substTy2) match {
+    // If both are the same variable, return current substitution
+    case (Var(x), Var(y)) and x == y =>
+      subst
+
+    // If first is a variable, try to bind it
+    case (Var(x), _) =>
+      if (x.occurs(substTy2)) {
+        do raise(OccursCheckFailure(x, substTy2), "")
+      } else {
+        subst.put(x, substTy2)
+      }
+
+    // If second is a variable, try to bind it
+    case (_, Var(y)) =>
+      if (occurs(y, substTy1)) {
+        do raise(OccursCheckFailure(y, substTy1), "")
+      } else {
+        subst.put(y, substTy1)
+      }
+
+    // If both are constructors, unify their arguments
+    case (Con(name1, args1), Con(name2, args2)) =>
+      if (name1 != name2 || args1.size != args2.size) {
+        do raise(UnificationFailure(substTy1, substTy2), "Different number of arguments!")
+      } else {
+        unifyMany(args1, args2, subst)
+      }
+  }
+}
+
+// Unify a list of arguments with a current substitution
+def unifyMany(args1: List[Type], args2: List[Type], subst: Substitution): Substitution / Exception[UnificationError] =
+  (args1, args2) match {
+    case (Nil(), Nil()) => subst
+    case (Cons(a1, rest1), Cons(a2, rest2)) =>
+      val newSubst = unify(a1, a2, subst)
+      unifyMany(rest1, rest2, newSubst)
+    case _ => do raise(UnificationManyFailure(args1, args2), "Different numbers of types on each side!")
+  }
+
+def unify(ty1: Type, ty2: Type): Substitution / Exception[UnificationError] =
+  unify(ty1, ty2, map::empty(box bytearray::compareStringBytes))
+
+def showType(ty: Type): String = ty match {
+  case Var(name) => name
+  case Con(name, Nil()) => name
+  case Con(name, args) =>
+    name ++ "(" ++ args.map { t => showType(t) }.join(", ") ++ ")"
+}
+
+def show(err: UnificationError): String = err match {
+  case OccursCheckFailure(variable, ty) =>
+    "Occurs check failed: " ++ variable ++ " occurs in " ++ showType(ty)
+  case UnificationFailure(ty1, ty2) =>
+    "Cannot unify " ++ showType(ty1) ++ " with " ++ showType(ty2)
+    case UnificationManyFailure(tps1, tps2) =>
+    "Cannot unify " ++ tps2.map { showType }.join(", ") ++ " with " ++ tps1.map { showType }.join(", ")
+}
+
+def reporting { body : => Substitution / Exception[UnificationError] }: Unit = {
+  val res = result[Substitution, UnificationError] {
+    body()
+  }
+
+  res match {
+    case Success(subst) => {
+      println("Unification successful!")
+      println("Substitution:")
+      for { subst.each } { case (k, v) =>
+        println("  " ++ k ++ " -> " ++ showType(v))
+      }
+    }
+    case Error(err, msg) =>
+      println("Unification failed: " ++ show(err))
+      if (msg.length > 0) {
+        println(msg)
+      }
+  }
+}
+
+def main() = {
+  reporting {
+    val intType = Con("Int", [])
+    val listType = Con("List", [intType])
+    val typeVar = Var("a")
+
+    unify(typeVar, listType)
+  }
+/*
+  reporting {
+    val functionalType =
+      Con("Func", [
+        Var("a"),
+        Con("List", [Var("b")]),
+        Var("c")
+      ])
+
+    val concreteType =
+      Con("Func", [
+        Con("Int", []),
+        Con("List", [Con("String", [])]),
+        Con("Bool", [])
+      ])
+
+    unify(functionalType, concreteType)
+  }
+
+  val initialSubstitution = map::fromList([
+    ("one", Con("Int", [])),
+    ("zero", Con("Int", [])),
+    ("defaultList", Con("List", [Var("elem")]))
+  ], box bytearray::compareStringBytes)
+
+  reporting {
+    val functionalType =
+      Con("Func", [
+        Var("a"),
+        Con("List", [Var("b")]),
+        Var("one")
+      ])
+
+    val concreteType =
+      Con("Func", [
+        Con("Int", []),
+        Var("defaultList"),
+        Var("e")
+      ])
+
+    unify(functionalType, concreteType, initialSubstitution)
+  }*/
+}

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -120,14 +120,13 @@ def reporting { body : => Substitution / Exception[UnificationError] }: Unit = {
 }
 
 def main() = {
-  ()
-  // reporting {
-  //   val intType = Con("Int", [])
-  //   val listType = Con("List", [intType])
-  //   val typeVar = Var("a")
+  reporting {
+     val intType = Con("Int", [])
+     val listType = Con("List", [intType])
+     val typeVar = Var("a")
 
-  //   unify(typeVar, listType)
-  // }
+     unify(typeVar, listType)
+  }
 /*
   reporting {
     val functionalType =

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -60,7 +60,9 @@ def unify(ty1: Type, ty2: Type, subst: Substitution): Substitution / Exception[U
 
     // If both are constructors, unify their arguments
     case (Con(name1, args1), Con(name2, args2)) =>
-      if (name1 != name2 || args1.size != args2.size) {
+      if (name1 != name2) {
+        do raise(UnificationFailure(substTy1, substTy2), "Different constructors!")
+      } else if (args1.size != args2.size) {
         do raise(UnificationFailure(substTy1, substTy2), "Different number of arguments!")
       } else {
         unifyMany(args1, args2, subst)

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -120,13 +120,14 @@ def reporting { body : => Substitution / Exception[UnificationError] }: Unit = {
 }
 
 def main() = {
-  reporting {
-    val intType = Con("Int", [])
-    val listType = Con("List", [intType])
-    val typeVar = Var("a")
+  ()
+  // reporting {
+  //   val intType = Con("Int", [])
+  //   val listType = Con("List", [intType])
+  //   val typeVar = Var("a")
 
-    unify(typeVar, listType)
-  }
+  //   unify(typeVar, listType)
+  // }
 /*
   reporting {
     val functionalType =


### PR DESCRIPTION
Resolves #796 

It's an OK (not great, not terrible) benchmark:
1. generates two nested, deep pair types like `(...((XLLL, XLLR), (XLRL, XLRR)), ...` for `X = { A, B }`,
2. then unifies them,
3. and checks that the substitutions are like `ALLL -> BLLL`.

Configurable with a given `N` if some tweaking is needed.

### Perf:

#### My machine

On my computer with `N = 12`:
- JS compilation only: 4.5s
- LLVM compilation only: 5.5s
- then hyperfined:

```
$ hyperfine --warmup 5 --min-runs 20 './out/unify-js' './out/unify-llvm'
Benchmark 1: ./out/unify-js
  Time (mean ± σ):     703.0 ms ±   7.8 ms    [User: 1035.2 ms, System: 77.1 ms]
  Range (min … max):   690.9 ms … 721.1 ms    20 runs

Benchmark 2: ./out/unify-llvm
  Time (mean ± σ):      37.6 ms ±   0.5 ms    [User: 36.1 ms, System: 1.0 ms]
  Range (min … max):    37.1 ms …  39.7 ms    69 runs

Summary
  ./out/unify-llvm ran
   18.68 ± 0.32 times faster than ./out/unify-js
```

On my computer with `N = 16` (16x more work than `N = 12`)
- JS compilation only: 4.7s
- LLVM compilation only: 5.6s
- then hyperfined:

```
Benchmark 1: ./out/unify-js
  Time (mean ± σ):     19.982 s ±  0.608 s    [User: 26.011 s, System: 1.525 s]
  Range (min … max):   19.300 s … 21.267 s    20 runs

Benchmark 2: ./out/unify-llvm
  Time (mean ± σ):     928.2 ms ±  20.8 ms    [User: 906.3 ms, System: 16.1 ms]
  Range (min … max):   913.3 ms … 1006.2 ms    20 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  ./out/unify-llvm ran
   21.53 ± 0.81 times faster than ./out/unify-js
```

#### CI

With `N = 12` in CI (measured imprecisely in two CI rounds):
- 9.2-12.0 seconds on Chez backends
- 8.0-8.9 seconds on JS
- 9.9-12.7 seconds on LLVM

With `N = 16` in CI (measured imprecisely in two CI rounds):
- 21-29 seconds on Chez backends
- 55-57 seconds on JS
- 79-86 seconds on LLVM