### PR TITLE
CI: fix autorelease, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Update schedule for GitHub Actions
+# from https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 2
+    labels:
+      - "github-actions"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"
+

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -174,7 +174,7 @@ jobs:
         run: sbt updateVersions
 
       - name: Upload updated files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: updated-files
           path: |


### PR DESCRIPTION
Resolves #817 

As a bonus, it adds GitHub's Dependabot support to ensure we don't have to do this manually again: it'll just open a PR with the GitHub Action dependency bumped automagically every month. 