### PR TITLE
Inlay hints: scaffolding and captures

### DIFF
--- a/effekt/js/src/main/scala/effekt/LanguageServer.scala
+++ b/effekt/js/src/main/scala/effekt/LanguageServer.scala
@@ -122,7 +122,9 @@ class LanguageServer extends Intelligence {
   @JSExport
   def inferredCaptures(path: String): js.Array[lsp.CaptureInfo] = {
     typecheck(path)
-    getInferredCaptures(VirtualFileSource(path)).map {
+    val source = VirtualFileSource(path)
+    val range = kiama.util.Range(source.offsetToPosition(0), source.offsetToPosition(source.charCount))
+    getInferredCaptures(range).map {
       case (p, c) => new lsp.CaptureInfo(toLSPPosition(p), c.toString)
     }.toJSArray
   }

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -221,20 +221,6 @@ trait LSPServer extends kiama.util.Server[Tree, EffektConfig, EffektError] with 
     tpe1 != tpe2 || effs1 != effs2
   }
 
-  case class CaptureInfo(location: Location, captureText: String)
-
-  override def executeCommand(src: Source, params: ExecuteCommandParams): Option[Any] =
-    None
-    /*
-    if (params.getCommand == "inferredCaptures") {
-      val captures = getInferredCaptures(src)(using context).map {
-        case (p, c) => CaptureInfo(positionToLocation(p), TypePrinter.show(c))
-      }
-      if (captures.isEmpty) None else Some(captures.toArray)
-    } else {
-      None
-    }*/
-
   override def createServices(config: EffektConfig) = new LSPServices(this, config)
 
   // Class to easily test custom LSP services not (yet) meant to go into kiama.Services

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -133,22 +133,7 @@ trait LSPServer extends kiama.util.Server[Tree, EffektConfig, EffektError] with 
         InlayHint(InlayHintKind.Type, p, prettyCaptures, markdownTooltip = s"captures: `${prettyCaptures}`", paddingRight = true, effektKind = "capture")
     }.toVector
 
-    // TODO: Also do this for un-annotated `val`s and `var`s.
-    val unannotated = getTreesInRange(range)(using context).map { trees =>
-      trees.collect {
-        // Functions without an annotated type:
-        case fun: FunDef if fun.ret.isEmpty => for {
-          // TODO(question): `context.inferredTypeAndEffectOption(fun)` didn't work here. Why?
-          sym <- context.symbolOption(fun.id)
-          tpe <- context.functionTypeOption(sym)
-          pos <- positions.getFinish(fun.bparams) // TODO(bug): This position doesn't always work. Ideally, I'd use the position of `fun.ret`, but that doesn't exist!
-          res = InlayHint(InlayHintKind.Type, pos, pp": ${tpe.result} / ${tpe.effects}", resolveToLabel = true, paddingLeft = true, effektKind = "missing-type-annotation")
-        } yield res
-      }.flatten
-    }.getOrElse(Vector())
-
-    val allHints = captures ++ unannotated
-    if allHints.isEmpty then None else Some(allHints)
+    if captures.isEmpty then None else Some(captures)
 
   // settings might be null
   override def setSettings(settings: Object): Unit = {

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -127,7 +127,7 @@ trait LSPServer extends kiama.util.Server[Tree, EffektConfig, EffektError] with 
     } yield allRefs.toVector
 
   override def getInlayHints(range: kiama.util.Range): Option[Vector[InlayHint]] =
-    val captures = getInferredCaptures(range.from.source)(using context).map {
+    val captures = getInferredCaptures(range)(using context).map {
       case (p, c) =>
         val prettyCaptures = TypePrinter.show(c)
         InlayHint(InlayHintKind.Type, p, prettyCaptures, Some(s"captures: `${prettyCaptures}`"), paddingRight = true)

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -36,13 +36,9 @@ trait Intelligence {
     }
   }
 
-  def getTreesAt(position: Position)(implicit C: Context): Option[Vector[Tree]] = for {
-    decl <- C.compiler.getAST(position.source)
-    tree = new EffektTree(decl)
-    allTrees = tree.nodes.collect { case t: Tree => t }
-    pos = C.positions
-    trees = pos.findNodesContaining(allTrees, position)
-    nodes = trees.sortWith {
+  private def sortByPosition(trees: Vector[Tree])(using C: Context): Vector[Tree] =
+    val pos = C.positions
+    trees.sortWith {
       (t1, t2) =>
         val p1s = pos.getStart(t1).get
         val p2s = pos.getStart(t2).get
@@ -55,14 +51,29 @@ trait Intelligence {
           p2s < p1s
         }
     }
+
+  def getTreesAt(position: Position)(using C: Context): Option[Vector[Tree]] = for {
+    decl <- C.compiler.getAST(position.source)
+    tree = new EffektTree(decl)
+    allTrees = tree.nodes.collect { case t: Tree => t }
+    trees = C.positions.findNodesContaining(allTrees, position)
+    nodes = sortByPosition(trees)
   } yield nodes
 
-  def getIdTreeAt(position: Position)(implicit C: Context): Option[source.Id] = for {
+  def getTreesInRange(range: kiama.util.Range)(using C: Context): Option[Vector[Tree]] =  for {
+    decl <- C.compiler.getAST(range.from.source)
+    tree = new EffektTree(decl)
+    allTrees = tree.nodes.collect { case t: Tree => t }
+    trees = C.positions.findNodesInRange(allTrees, range)
+    nodes = sortByPosition(trees)
+  } yield nodes
+
+  def getIdTreeAt(position: Position)(using C: Context): Option[source.Id] = for {
     trees <- getTreesAt(position)
     id <- trees.collectFirst { case id: source.Id => id }
   } yield id
 
-  def getSymbolAt(position: Position)(implicit C: Context): Option[(Tree, Symbol)] =
+  def getSymbolAt(position: Position)(using C: Context): Option[(Tree, Symbol)] =
     def identifiers = for {
       id <- getIdTreeAt(position)
       sym <- C.symbolOption(id)
@@ -82,12 +93,12 @@ trait Intelligence {
       case _ => None
     }
 
-  def getDefinitionAt(position: Position)(implicit C: Context): Option[Tree] = for {
+  def getDefinitionAt(position: Position)(using C: Context): Option[Tree] = for {
     (_, sym) <- getSymbolAt(position)
     decl <- getDefinitionOf(resolveCallTarget(sym))
   } yield decl
 
-  def getDefinitionOf(s: Symbol)(implicit C: Context): Option[Tree] = s match {
+  def getDefinitionOf(s: Symbol)(using C: Context): Option[Tree] = s match {
     case u: UserFunction => Some(u.decl)
     case u: Binder       => Some(u.decl)
     case d: Operation    => C.definitionTreeOption(d.interface)
@@ -102,9 +113,9 @@ trait Intelligence {
     case s             => s
   }
 
-  def getHoleInfo(hole: source.Hole)(implicit C: Context): Option[String] = for {
-    outerTpe <- C.inferredTypeAndEffectOption(hole)
-    innerTpe <- C.inferredTypeAndEffectOption(hole.stmts)
+  def getHoleInfo(hole: source.Hole)(using C: Context): Option[String] = for {
+    (outerTpe, outerEff) <- C.inferredTypeAndEffectOption(hole)
+    (innerTpe, innerEff) <- C.inferredTypeAndEffectOption(hole.stmts)
   } yield pp"""| | Outside       | Inside        |
                | |:------------- |:------------- |
                | | `${outerTpe}` | `${innerTpe}` |
@@ -134,7 +145,7 @@ trait Intelligence {
       } yield (pos, capt)
     }.flatten
 
-  def getInfoOf(sym: Symbol)(implicit C: Context): Option[SymbolInfo] = PartialFunction.condOpt(resolveCallTarget(sym)) {
+  def getInfoOf(sym: Symbol)(using C: Context): Option[SymbolInfo] = PartialFunction.condOpt(resolveCallTarget(sym)) {
 
     case b: ExternFunction =>
       SymbolInfo(b, "External function definition", Some(DeclPrinter(b)), None)


### PR DESCRIPTION
~~Requires https://github.com/effekt-lang/kiama/pull/7 (blocked)~~
Requires the newest version of the VSCode extension (v0.2.4)
Requires that the VSCode user enables inlay hints (see a separate comment below on how to set them up).

As part of the scaffolding, I also replaced Scala 2 `implicit`s with Scala 3 `using`

Instead of using our hand-rolled `inferredCaptures` command, we can _just_ use inlay hints 🥳 
(See #524 for more details)

Screenshots:
<img width="651" alt="Screenshot 2025-02-15 at 10 49 38" src="https://github.com/user-attachments/assets/bb00d842-70a8-4d83-83e9-b436e11a59b4" />
<img width="576" alt="Screenshot 2025-02-15 at 10 54 19" src="https://github.com/user-attachments/assets/fe1ce6a7-ec6b-4034-b718-c2ab8d36ca60" />

Bugs:
- see comment below.
