### PR TITLE
Finer suppression for uv valgrind

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -94,7 +94,7 @@ trait Runner[Executable] {
    */
   def eval(executable: Executable)(using C: Context): Unit = {
     val execFile = build(executable)
-    val valgrindArgs = Seq("--leak-check=full", "--undef-value-errors=no", "--quiet", "--log-file=valgrind.log", "--error-exitcode=1")
+    val valgrindArgs = Seq("--leak-check=full", "--track-origins=yes", "--undef-value-errors=no", "--suppressions=./libraries/llvm/uv.supp", "--quiet", "--log-file=valgrind.log", "--error-exitcode=1")
     val process = if (C.config.valgrind())
       Process("valgrind", valgrindArgs ++ (execFile +: Context.config.runArgs()))
     else

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -94,7 +94,7 @@ trait Runner[Executable] {
    */
   def eval(executable: Executable)(using C: Context): Unit = {
     val execFile = build(executable)
-    val valgrindArgs = Seq("--leak-check=full", "--track-origins=yes", "--undef-value-errors=no", "--suppressions=./libraries/llvm/uv.supp", "--quiet", "--log-file=valgrind.log", "--error-exitcode=1")
+    val valgrindArgs = Seq("--leak-check=full", "--track-origins=yes", "--suppressions=./libraries/llvm/uv.supp", "--quiet", "--log-file=valgrind.log", "--error-exitcode=1")
     val process = if (C.config.valgrind())
       Process("valgrind", valgrindArgs ++ (execFile +: Context.config.runArgs()))
     else

--- a/libraries/llvm/uv.supp
+++ b/libraries/llvm/uv.supp
@@ -1,0 +1,20 @@
+{
+   UV uninitialized byte
+   Memcheck:Value8
+   ...
+   fun:resume_Int
+   fun:c_resume_int_fs
+   obj:/usr/lib/x86_64-linux-gnu/libuv.so.1.0.0
+   fun:uv_run
+   fun:main
+}
+{
+   UV uninitialized cond
+   Memcheck:Cond
+   ...
+   fun:resume_Int
+   fun:c_resume_int_fs
+   obj:/usr/lib/x86_64-linux-gnu/libuv.so.1.0.0
+   fun:uv_run
+   fun:main
+}


### PR DESCRIPTION
This PR adds some finer granularity for Valgrind suppression.

We can check for specific errors that originate from libuv instead of suppressing all undefined value errors.

Currently blocked on #827 because I can't test if this is all the suppressions we need.
