### PR TITLE
Fixed ResizableArray bounds check including a test

### DIFF
--- a/examples/stdlib/resizable_array/resizable_array.effekt
+++ b/examples/stdlib/resizable_array/resizable_array.effekt
@@ -27,6 +27,19 @@ def main() = {
       assert(a.popRight(), 1)
       assert(a.popRight(), 1)
     }
+    test("out of bounds check") {
+      def checkOutOfBounds(arr: ResizableArray[Int], index: Int) = {
+        with on[OutOfBounds].default { () }
+        arr.get(index)
+        assertTrue(false, "not out of bounds")
+      }
+      with on[OutOfBounds].default { assertTrue(false, "out of bounds") }
+      val a = resizableArray()
+      a.checkOutOfBounds(-1)
+      a.add(1)
+      a.add(2)
+      a.checkOutOfBounds(2)
+    }
   };
   ()
 }

--- a/libraries/common/resizable_array.effekt
+++ b/libraries/common/resizable_array.effekt
@@ -29,7 +29,7 @@ def resizableArray[T](): ResizableArray[T] = resizableArray(8)
 
 /// Throw an OutOfBounds exception if index is not a valid index into arr
 def boundsCheck[T](arr: ResizableArray[T], index: Int): Unit / Exception[OutOfBounds] = {
-  if (index < 0 && index >= arr.size) {
+  if (index < 0 || index >= arr.size) {
     do raise(OutOfBounds(), "Array index out of bounds: " ++ show(index))
   }
 }


### PR DESCRIPTION
Fixed a bug where the bounds check of ResizableArray used `&&` instead of `||` for the bounds check condition, leading to it never `raise()`ing OutOfBounds.