### PR TITLE
Use given pattern names when compiling patterns

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
@@ -4,7 +4,6 @@ package core
 import effekt.context.Context
 import effekt.core.substitutions.Substitution
 import effekt.symbols.TmpValue
-import effekt.util.messages.INTERNAL_ERROR
 
 import scala.collection.mutable
 

--- a/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
@@ -192,6 +192,7 @@ object PatternMatchingCompiler {
 
       normalized.foreach {
         case Clause(Split(Pattern.Tag(constructor, patternsAndTypes), restPatterns, restConds), label, args) =>
+          // NOTE: Ideally, we would use a `DeclarationContext` here, but we cannot: we're currently in the Source->Core transformer, so we do not have all of the details yet.
           val fieldNames: List[String] = constructor match {
             case c: symbols.Constructor => c.fields.map(_.name.name)
             case _ => List.fill(patternsAndTypes.size) { "y" } // NOTE: Only reached in PatternMatchingTests

--- a/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
@@ -184,9 +184,9 @@ object PatternMatchingCompiler {
           constructor,
           fieldInfo.map {
             // if it's a pattern named by the user in the program, use the supplied name
-            case ((Pattern.Any(id), tpe),         _) => ValueVar(TmpValue(id.name.name), tpe)
+            case ((Pattern.Any(id), tpe),         _) => ValueVar(Id(id.name.name), tpe)
             // otherwise, use the field name of the given field
-            case ((_,               tpe), fieldName) => ValueVar(TmpValue(fieldName),    tpe)
+            case ((_,               tpe), fieldName) => ValueVar(Id(fieldName),    tpe)
           }
         )
 

--- a/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
@@ -184,14 +184,16 @@ object PatternMatchingCompiler {
         varsFor.getOrElseUpdate(
           constructor,
           fieldInfo.map {
+            // if it's a pattern named by the user in the program, use the supplied name
             case ((Pattern.Any(id), tpe),         _) => ValueVar(TmpValue(id.name.name), tpe)
+            // otherwise, use the field name of the given field
             case ((_,               tpe), fieldName) => ValueVar(TmpValue(fieldName),    tpe)
           }
         )
 
       normalized.foreach {
         case Clause(Split(Pattern.Tag(constructor, patternsAndTypes), restPatterns, restConds), label, args) =>
-          val fieldNames = constructor match {
+          val fieldNames: List[String] = constructor match {
             case c: symbols.Constructor => c.fields.map(_.name.name)
             case _ => List.fill(patternsAndTypes.size) { "y" } // NOTE: Only reached in PatternMatchingTests
           }


### PR DESCRIPTION
~~Addresses one part of #793:~~
Resolves #793 completely.

> I also think we could sometimes use the original pattern names, but I'm not 100% certain of that, would need to investigate.

I'm doing this since it helps me to debug problems just a little bit more easily :)

Note that this does not actually use the names of the fields as declared.

---

```scala
def isShorterThan(x: List[Int], y: List[Int]): Bool =
  (x, y) match {
    case (_head, Nil()) => false
    case (Nil(), _tail) => true
    case (Cons(_x, xs),Cons(_y, ys)) => isShorterThan(xs, ys)
  }
```

Here's a comparison before (red) vs after (green).
Just to drive my point home further, I removed the numbers after the identifier :)

<img width="478" alt="Screenshot 2025-02-21 at 22 37 44" src="https://github.com/user-attachments/assets/9c3db8a9-1c1d-4994-999e-7508be530af0" />
