### PR TITLE
Name join points introduced when compiling clauses

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -400,7 +400,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     //   def loop$13() = if ([[cond]]) { [[ body ]]; loop$13() } else { return () }
     //   loop$13()
     case source.While(guards, body, default) =>
-      val loopName = TmpBlock("whileLoop")
+      val loopName = TmpBlock("while")
       val loopType = core.BlockType.Function(Nil, Nil, Nil, Nil, core.Type.TUnit)
 
       // TODO double check: probably we are forgetting the capture of the guards!
@@ -408,7 +408,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       val loopCall = Stmt.App(core.BlockVar(loopName, loopType, loopCapt), Nil, Nil, Nil)
 
       val transformedBody = transform(body)
-      val thenBranch = Stmt.Val(TmpValue("whileThen"), transformedBody.tpe, transformedBody, loopCall)
+      val thenBranch = Stmt.Val(TmpValue("while_thn"), transformedBody.tpe, transformedBody, loopCall)
       val elseBranch = default.map(transform).getOrElse(Return(Literal((), core.Type.TUnit)))
 
       val loopBody = guards match {


### PR DESCRIPTION
Quick drive-by from #841 that deserves to be considered separately.

Instead of naming each join point created for the RHS of a clause as `b_k_123`, we can give a slightly more specific name based on the origin of the clause.

Feel free to bikeshed the names chosen or close this PR altogether if it's useless.
FWIW, it helps me ever-so-slightly in the `b_k${index of the case in the source}_123` case when debugging.