### PR TITLE
Prevent stack overflows by using larger stacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Run tests
-      run: sbt -J-Xss1G "effektJVM/clean; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\\/]*coverage.*"
+      run: sbt /J-Xss1G "effektJVM/clean; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\\/]*coverage.*"
 
   build-jar:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Run tests
-      run: sbt "effektJVM/clean; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\\/]*coverage.*"
+      run: sbt -J-Xss1G "effektJVM/clean; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\\/]*coverage.*"
 
   build-jar:
     strategy:
@@ -88,7 +88,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Run tests
-      run: EFFEKT_VALGRIND=1 EFFEKT_DEBUG=1 sbt clean test
+      run: EFFEKT_VALGRIND=1 EFFEKT_DEBUG=1 sbt -J-Xss1G clean test
 
     - name: Assemble fully optimized js file
       run: sbt effektJS/fullOptJS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Run tests
-      run: sbt /J-Xss1G "effektJVM/clean; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\\/]*coverage.*"
+      run: sbt "effektJVM/clean; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\\/]*coverage.*"
 
   build-jar:
     strategy:


### PR DESCRIPTION
Closes #847. Error occurred in #828, #841, #851, #852.

Unfortunately I don't think we can set the stack size in `build.sbt` unless we use a forked JVM, so we have to set it manually using an argument to SBT (or an environment variable).

The problem mainly comes from our abundant use of non-tail recursion, we could refactor this in the future. We should also decide on a specific stack size, I've set it to 1G for now which is quite large.