### PR TITLE
Fix canonical ordering by using the ordering at the declaration site

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -699,7 +699,7 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
 
       val effs = resolve(effects).distinct
-      effs.canonical.foreach { eff =>
+      CanonicalOrdering(effs.toList) foreach { eff =>
         val cap = CaptureParam(eff.name)
         cps = cps :+ cap
       }

--- a/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
@@ -37,7 +37,7 @@ package object kinds {
   def wellformed(b: FunctionType)(using C: Context): Unit = b match {
     case FunctionType(tps, cps, vps, bps, res, effs) =>
       // TODO we could also check whether the same type variable shows up twice
-      if (cps.size != (bps.size + effs.canonical.size)) {
+      if (cps.size != (bps.size + effs.distinct.size)) {
         C.panic(s"Compiler invariant violated: different size of capture parameters and block parameters: ${b}")
       }
       vps.foreach { tpe => wellformed(tpe) }

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -152,7 +152,7 @@ trait Callable extends BlockSymbol {
       effects = effs.distinct
       // TODO currently the return type cannot refer to the annotated effects, so we can make up capabilities
       //   in the future namer needs to annotate the function with the capture parameters it introduced.
-      capt = effects.canonical.map { tpe => CaptureParam(tpe.name) }
+      capt = CanonicalOrdering(effects.toList).map { tpe => CaptureParam(tpe.name) }
     } yield toType(ret, effects, capt)
 }
 

--- a/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
@@ -10,6 +10,8 @@ import effekt.util.messages.ErrorMessageReifier
  * All effects inferred by Typer are required to be concrete and dealiased.
  *
  * This way, we can easily compare them for equality.
+ *
+ * This is a _set_ of effects and does not guarantee order!
  */
 class ConcreteEffects private[typer] (protected val effects: List[InterfaceType]) {
 


### PR DESCRIPTION
This tries to fix issue #849 by NOT canonicalizing AFTER unification.

Instead, we canonicalize FIRST on the function type and then MAINTAIN the order at the callsite.

This requires us to NOT go into type `Effect`, which is a set and thus removes duplicates and destroys the ordering...

Sadly, it is very difficult to write a test for this :(