### PR TITLE
Add a regression test on capability ordering

### DIFF
--- a/examples/pos/cap_ordering.check
+++ b/examples/pos/cap_ordering.check
@@ -1,0 +1,8 @@
+Cons(1, Cons(2, Cons(3, Nil())))
+Cons(2, Cons(3, Nil()))
+Cons(1, Cons(3, Nil()))
+Cons(3, Nil())
+Cons(1, Cons(2, Nil()))
+Cons(2, Nil())
+Cons(1, Nil())
+Nil()

--- a/examples/pos/cap_ordering.effekt
+++ b/examples/pos/cap_ordering.effekt
@@ -1,0 +1,22 @@
+module cap_ordering
+
+// Regression test for capability ordering
+// Fails on 'ffde2091956d25dd3522f316ecb1dfc19a33a93e'
+
+effect flip[A](): A
+
+def subsets[A](list: List[A]): List[A] / {flip[A], flip[Bool]} = list match {
+  case Nil() => Nil()
+  case Cons(head, tail) =>
+    val rest = subsets(tail)
+    if (do flip[Bool]()) { Cons(head, rest) } else { rest }}
+
+def main() = {
+  try {
+    println(subsets([1, 2, 3]))
+  } with flip[Bool] {
+    resume(true); resume(false)
+  } with flip[Int] {
+    println("what")
+  }
+}


### PR DESCRIPTION
Discovered by @timsueberkrueb: on ffde2091956d25dd3522f316ecb1dfc19a33a93e (latest commit made on March 4), this prints:
```
what
```
but on `master` (after #859), it prints the correct solution:
```
Cons(1, Cons(2, Cons(3, Nil())))
Cons(2, Cons(3, Nil()))
Cons(1, Cons(3, Nil()))
Cons(3, Nil())
Cons(1, Cons(2, Nil()))
Cons(2, Nil())
Cons(1, Nil())
Nil()
```

Curiously, this seems to work fine on v0.21 and v0.22, so I'm not sure where the regression happened. 🤷‍♂️ 
Nevertheless, we really should have this as a regression test if it sometimes magically fails :)