### PR TITLE
Use trampolining Control[A] for bindings in machine transformer

### DIFF
--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -8,6 +8,9 @@ import effekt.symbols.builtins.TState
 import effekt.util.messages.ErrorReporter
 import effekt.symbols.ErrorMessageInterpolator
 
+import util.control.{Control, Computation,  ReturnCont, Impure, Result, pure}
+import util.control
+
 object Transformer {
 
   private def ErrorReporter(using E: ErrorReporter): ErrorReporter = E
@@ -532,7 +535,7 @@ object Transformer {
   }
 
   def binding[A](c: A, run: (Statement => Statement)) = {
-    Computation[A] { k =>
+    Computation { k =>
       Impure(pure(c), ReturnCont(v => run(Result.trampoline(k(v)))))
     }
   }

--- a/effekt/shared/src/main/scala/effekt/util/Control.scala
+++ b/effekt/shared/src/main/scala/effekt/util/Control.scala
@@ -50,7 +50,7 @@ package object control {
 
   private[control] sealed trait ω
 
-  private[control] final case class Computation[+A](body: MetaCont[A, ω] => Result[ω]) extends Control[A] {
+  private[effekt] final case class Computation[+A](body: MetaCont[A, ω] => Result[ω]) extends Control[A] {
     def apply[R](k: MetaCont[A, R]): Result[R] =
       body(k.asInstanceOf[MetaCont[A, ω]]).asInstanceOf[Result[R]]
   }
@@ -90,7 +90,7 @@ package object control {
 
   private[control] case class Pure[A](value: A) extends Result[A] { val isPure = true }
 
-  private[control] case class Impure[A, R](c: Control[R], k: MetaCont[R, A]) extends Result[A] {
+  private[effekt] case class Impure[A, R](c: Control[R], k: MetaCont[R, A]) extends Result[A] {
     val isPure = false
   }
 
@@ -106,7 +106,7 @@ package object control {
     }
   }
 
-  private[control] sealed trait MetaCont[-A, +B] extends Serializable {
+  private[option] sealed trait MetaCont[-A, +B] extends Serializable {
     def apply(a: A): Result[B]
 
     def append[C](s: MetaCont[B, C]): MetaCont[A, C]
@@ -124,7 +124,7 @@ package object control {
     def bind(key: AnyRef, value: Any): MetaCont[A, B] = StateCont(mutable.Map(key -> value), this)
   }
 
-  private[control] case class ReturnCont[-A, +B](f: A => B) extends MetaCont[A, B] {
+  private[effekt] case class ReturnCont[-A, +B](f: A => B) extends MetaCont[A, B] {
     final def apply(a: A): Result[B] = Pure(f(a))
 
     final def append[C](s: MetaCont[B, C]): MetaCont[A, C] = s map f


### PR DESCRIPTION
Closes #855.

This mostly works, but I have some trouble rewriting code like this:

``` scala
Binding { k =>
  LiteralDouble(literal_binding, v, k(literal_binding))
}
```

For now I did

``` scala
binding(literal_binding, l =>
  LiteralDouble(literal_binding, v, l)
)

// where binding is
def binding[A](c: A, run: (Statement => Statement)) = {
  Computation { k =>
    Impure(pure(c), ReturnCont(v => run(Result.trampoline(k(v)))))
  }
```

Which is of course wrong, but I find most definitions in `Control[A]` deeply confusing, so I'd welcome some help!

I also had to make some private functions in utils.control public, not sure if this is okay (we don't use the library anywhere else anyway)