### PR TITLE
Add a clear Main entrypoint for the JVM binary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
 
     // Assembling one big jar-file and packaging it
     // --------------------------------------------
-    assembly / mainClass := Some("effekt.Server"),
+    assembly / mainClass := Some("effekt.Main"),
 
     assembly / assemblyJarName := "effekt.jar",
 
@@ -131,7 +131,7 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
     Compile / unmanagedResourceDirectories += (ThisBuild / baseDirectory).value / "licenses",
 
     // cli flag so sbt doesn't crash when effekt does
-    addCommandAlias("run", "runMain effekt.Server --no-exit-on-error"),
+    addCommandAlias("run", "runMain effekt.Main --no-exit-on-error"),
 
     assembleBinary := {
       val jarfile = assembly.value

--- a/build.sbt
+++ b/build.sbt
@@ -114,6 +114,9 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
     // --------------------------------------------
     assembly / mainClass := Some("effekt.Main"),
 
+    // Without this overwrite, sbt shows both Server and Main as main classes, but we do not use Server as an entrypoint.
+    Compile / discoveredMainClasses := Seq("effekt.Main"),
+
     assembly / assemblyJarName := "effekt.jar",
 
     // there is a conflict between the two transitive dependencies "gson:2.11.0"

--- a/effekt/jvm/src/main/scala/effekt/Driver.scala
+++ b/effekt/jvm/src/main/scala/effekt/Driver.scala
@@ -27,20 +27,6 @@ trait Driver extends kiama.util.Compiler[EffektConfig, EffektError] { outer =>
   // We always only have one global instance of the compiler
   object context extends Context(positions) with IOModuleDB { val messaging = outer.messaging }
 
-  /**
-   * If no file names are given, run the REPL
-   */
-  override def run(config: EffektConfig): Unit =
-    if (config.repl()) {
-      new Repl(this).run(config)
-    // This is overridden by kiama.Server to launch the LSP server.
-    // TODO: remove dynamic dispatch here and consider replacing inheritance by composition.
-    } else if (config.server()) {
-      super.run(config)
-    } else for (filename <- config.filenames()) {
-      compileFile(filename, config)
-    }
-
   override def createConfig(args: Seq[String]) =
     new EffektConfig(args)
 

--- a/effekt/jvm/src/main/scala/effekt/Main.scala
+++ b/effekt/jvm/src/main/scala/effekt/Main.scala
@@ -1,0 +1,50 @@
+package effekt
+
+import org.rogach.scallop.exceptions.ScallopException
+
+object Main {
+  /**
+   * Main entry point for the Effekt compiler.
+   *
+   * Depending on the command line arguments, we run in one of the following modes:
+   *
+   * - Launch the Effekt language server (e.g. `effekt --server`)
+   * - Launch the REPL (e.g. `effekt`)
+   * - Build the provided files (e.g. `effekt --build hello.effekt`)
+   */
+  def main(args: Array[String]): Unit = {
+    val config = try {
+      parseArgs(args)
+    } catch {
+      case e: ScallopException =>
+        System.err.println(e.getMessage())
+        return
+    }
+
+    if (config.server()) {
+      Server.launch(config)
+    } else if (config.repl()) {
+      new Repl(Server).run(config)
+    } else {
+      compileFiles(config)
+    }
+  }
+
+  /**
+   * Parse command line arguments into an EffektConfig.
+   */
+  private def parseArgs(args: Array[String]): EffektConfig = {
+    val config = new EffektConfig(args.toIndexedSeq)
+    config.verify()
+    config
+  }
+
+  /**
+   * Compile files specified in the configuration.
+   */
+  private def compileFiles(config: EffektConfig): Unit = {
+    for (filename <- config.filenames()) {
+      Server.compileFile(filename, config)
+    }
+  }
+}

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -229,6 +229,6 @@ trait LSPServer extends kiama.util.Server[Tree, EffektConfig, EffektError] with 
 }
 
 /**
- * Main entry point for Effekt
+ * Singleton for the language server
  */
 object Server extends LSPServer


### PR DESCRIPTION
As a newcomer to this project, I found it hard to find the entrypoint to the JVM binary.
This PR adds a file `Main.scala` under `jvm/src/main/scala/effekt` which should be easy to find and understand.
This could also be one of the first baby steps to disentangle some parts of this project from Kiama such as the LSP Server.
The logic *should* reproduce the current behavior as far as I understand it.