### PR TITLE
Bump to llvm version 18 in CI

### DIFF
--- a/.github/actions/setup-effekt/action.yml
+++ b/.github/actions/setup-effekt/action.yml
@@ -13,7 +13,7 @@ inputs:
   llvm-version:
     description: 'LLVM version to install'
     required: false
-    default: '15'
+    default: '18'
   install-dependencies:
     description: 'Whether to install system dependencies (Linux only)'
     required: false

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -69,7 +69,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args.takeWhile(_ != "--
   val llvmVersion: ScallopOption[String] = opt[String](
     "llvm-version",
     descr = "the llvm version that should be used to compile the generated programs (only necessary if backend is llvm, defaults to 15)",
-    default = Some(sys.env.getOrElse("EFFEKT_LLVM_VERSION", "15")),
+    default = Some(sys.env.getOrElse("EFFEKT_LLVM_VERSION", "18")),
     noshort = true,
     group = advanced
   )

--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -68,7 +68,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args.takeWhile(_ != "--
 
   val llvmVersion: ScallopOption[String] = opt[String](
     "llvm-version",
-    descr = "the llvm version that should be used to compile the generated programs (only necessary if backend is llvm, defaults to 15)",
+    descr = "the llvm version that should be used to compile the generated programs (only necessary if backend is llvm, defaults to 18)",
     default = Some(sys.env.getOrElse("EFFEKT_LLVM_VERSION", "18")),
     noshort = true,
     group = advanced

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -267,8 +267,8 @@ object LLVMRunner extends Runner[String] {
   override def includes(path: File): List[File] = List(path / ".." / "llvm")
 
   lazy val gccCmd = discoverExecutable(List("cc", "clang", "gcc"), List("--version"))
-  lazy val llcCmd = discoverExecutable(List("llc", "llc-15", "llc-16"), List("--version"))
-  lazy val optCmd = discoverExecutable(List("opt", "opt-15", "opt-16"), List("--version"))
+  lazy val llcCmd = discoverExecutable(List("llc", "llc-18"), List("--version"))
+  lazy val optCmd = discoverExecutable(List("opt", "opt-18"), List("--version"))
 
   def checkSetup(): Either[String, Unit] =
     gccCmd.getOrElseAborting { return Left("Cannot find gcc. This is required to use the LLVM backend.") }


### PR DESCRIPTION
We are running into problems where the versions used for development and for the CI are differing so much that we sometimes write code in development that is invalid in the CI. (See #877)

I propose upping the Version to 18, which seems to be the Ubuntu standard

Edit: the latest release is 20.1.0, so we are also not in unstable territory