### PR TITLE
CI: Extract reusable 'test' and 'build' actions

### DIFF
--- a/.github/actions/run-effekt-tests/action.yml
+++ b/.github/actions/run-effekt-tests/action.yml
@@ -1,0 +1,58 @@
+name: 'Run Effekt Tests'
+description: 'Runs Effekt tests with configurable options'
+
+inputs:
+  full-test:
+    description: 'Whether to run full test suite'
+    required: false
+    default: 'true'
+  use-retry:
+    description: 'Whether to use retry mechanism for tests'
+    required: false
+    default: 'true'
+  retry-max-attempts:
+    description: 'Maximum number of retry attempts'
+    required: false
+    default: '3'
+  retry-timeout:
+    description: 'Timeout for retry in minutes'
+    required: false
+    default: '120'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run basic tests
+      if: ${{ inputs.full-test != 'true' || runner.os == 'Windows' }}
+      run: sbt "effektJVM/clean; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\[...]"
+      shell: bash
+
+    - name: Run full test suite with retry
+      if: ${{ inputs.full-test == 'true' && runner.os != 'Windows' && inputs.use-retry == 'true' }}
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: ${{ inputs.retry-timeout }}
+        max_attempts: ${{ inputs.retry-max-attempts }}
+        retry_on: error
+        command: EFFEKT_VALGRIND=1 EFFEKT_DEBUG=1 sbt -J-Xss1G clean test
+        new_command_on_retry: sbt testQuick
+
+    - name: Run full test suite without retry
+      if: ${{ inputs.full-test == 'true' && runner.os != 'Windows' && inputs.use-retry != 'true' }}
+      run: EFFEKT_VALGRIND=1 EFFEKT_DEBUG=1 sbt -J-Xss1G clean test
+      shell: bash
+
+    - name: Assemble fully optimized js file
+      if: ${{ inputs.full-test == 'true' && runner.os != 'Windows' }}
+      run: sbt effektJS/fullOptJS
+      shell: bash
+
+    - name: Try installing effekt binary
+      if: ${{ inputs.full-test == 'true' && runner.os != 'Windows' }}
+      run: sbt install
+      shell: bash
+
+    - name: Run effekt binary
+      if: ${{ inputs.full-test == 'true' && runner.os != 'Windows' }}
+      run: effekt.sh --help
+      shell: bash

--- a/.github/actions/setup-effekt/action.yml
+++ b/.github/actions/setup-effekt/action.yml
@@ -1,0 +1,68 @@
+name: 'Setup Effekt Environment'
+description: 'Sets up Java, Node, SBT, and system dependencies for Effekt'
+
+inputs:
+  java-version:
+    description: 'Java version to install'
+    required: false
+    default: '11'
+  node-version:
+    description: 'Node version to install'
+    required: false
+    default: '16.x'
+  llvm-version:
+    description: 'LLVM version to install'
+    required: false
+    default: '15'
+  install-dependencies:
+    description: 'Whether to install system dependencies (Linux only)'
+    required: false
+    default: 'false'
+  install-valgrind:
+    description: 'Whether to install valgrind (Linux only)'
+    required: false
+    default: 'false'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JDK ${{ inputs.java-version }}
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: 'zulu'
+        cache: 'sbt'
+
+    - name: Setup SBT
+      uses: sbt/setup-sbt@v1
+
+    - name: Set up NodeJS ${{ inputs.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    # Only run the following on Linux-based runners
+    - name: Update apt database
+      if: ${{ inputs.install-dependencies == 'true' && runner.os == 'Linux' }}
+      run: sudo apt-get update
+      shell: bash
+
+    - name: Install Chez Scheme
+      if: ${{ inputs.install-dependencies == 'true' && runner.os == 'Linux' }}
+      run: sudo apt-get install -y chezscheme
+      shell: bash
+
+    - name: Install LLVM ${{ inputs.llvm-version }}
+      if: ${{ inputs.install-dependencies == 'true' && runner.os == 'Linux' }}
+      run: sudo apt-get install -y llvm-${{ inputs.llvm-version }}
+      shell: bash
+
+    - name: Install Valgrind
+      if: ${{ inputs.install-valgrind == 'true' && runner.os == 'Linux' }}
+      run: sudo apt-get install -y valgrind
+      shell: bash
+
+    - name: Install libuv
+      if: ${{ inputs.install-dependencies == 'true' && runner.os == 'Linux' }}
+      run: sudo apt-get install -y libuv1-dev
+      shell: bash

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -106,14 +106,10 @@ jobs:
       with:
         install-dependencies: 'true'
 
-    - name: Run tests with retry
-      uses: nick-fields/retry@v3
+    - uses: ./.github/actions/run-effekt-tests
       with:
-        timeout_minutes: 120
-        max_attempts: 3
-        retry_on: error
-        command: sbt clean test
-        new_command_on_retry: sbt testQuick # should only rerun failed tests
+        full-test: 'true'
+        use-retry: 'false'
 
   set-version:
     name: Bump Version

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -109,7 +109,9 @@ jobs:
     - uses: ./.github/actions/run-effekt-tests
       with:
         full-test: 'true'
-        use-retry: 'false'
+        use-retry: 'true'
+          # Since we're on 'master', we can assume that the tests already passed.
+          # Therefore retrying is OK (to prevent flaky tests from cancelling the deploy).
 
   set-version:
     name: Bump Version

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -6,10 +6,6 @@ on:
     - cron: '0 3 * * 1'  # Every Monday at 3am UTC
   workflow_dispatch: # For manual triggering
 
-env:
-  JAVA_VERSION: '11'
-  NODE_VERSION: '16.x'
-
 jobs:
   check-release-needed:
     name: Check if release is needed
@@ -96,7 +92,7 @@ jobs:
           
           echo "All checks passed. Release is needed!"
 
-  run-tests: # redux of usual CI defined in `ci.yml`
+  run-tests:
     name: Run tests
     needs: [check-release-needed]
     runs-on: ubuntu-latest
@@ -106,28 +102,14 @@ jobs:
       with:
         submodules: 'true'
 
-    - name: Set up JDK ${{ env.JAVA_VERSION }}
-      uses: actions/setup-java@v4
+    - uses: ./.github/actions/setup-effekt
       with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: 'zulu'
-        cache: 'sbt'
-
-    - name: Setup SBT
-      uses: sbt/setup-sbt@v1
-
-    - name: Set up NodeJS ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-
-    - name: Install Chez Scheme, LLVM & libuv
-      run: sudo apt-get install -y chezscheme llvm-15 libuv1-dev
+        install-dependencies: 'true'
 
     - name: Run tests with retry
       uses: nick-fields/retry@v3
       with:
-        timeout_minutes: 120 # NOTE: This needs _some_ value. As of writing this, 2 hours should be future-proof. :)
+        timeout_minutes: 120
         max_attempts: 3
         retry_on: error
         command: sbt clean test
@@ -145,15 +127,7 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'zulu'
-          cache: 'sbt'
-
-      - name: Setup SBT
-        uses: sbt/setup-sbt@v1
+      - uses: ./.github/actions/setup-effekt
 
       - name: Bump Effekt version using sbt
         id: set-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,10 @@
-name: Continuous Integration
+name: CI
 
 on:
   push:
     branches:
       - master
   pull_request:
-
-env:
-  JAVA_VERSION: '11'
-  NODE_VERSION: '16.x'
 
 jobs:
   run-hello-world:
@@ -23,23 +19,11 @@ jobs:
       with:
         submodules: 'true'
 
-    - name: Set up JDK ${{ env.JAVA_VERSION }}
-      uses: actions/setup-java@v4
+    - uses: ./.github/actions/setup-effekt
+
+    - uses: ./.github/actions/run-effekt-tests
       with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: 'zulu'
-        cache: 'sbt'
-
-    - name: Setup SBT
-      uses: sbt/setup-sbt@v1
-
-    - name: Set up NodeJS ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-
-    - name: Run tests
-      run: sbt "effektJVM/clean; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\\/]*coverage.*"
+        full-test: 'false'
 
   build-jar:
     strategy:
@@ -53,48 +37,12 @@ jobs:
       with:
         submodules: 'true'
 
-    - name: Set up JDK ${{ env.JAVA_VERSION }}
-      uses: actions/setup-java@v4
+    - uses: ./.github/actions/setup-effekt
       with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: 'zulu'
-        cache: 'sbt'
+        install-dependencies: 'true'
+        install-valgrind: 'true'
 
-    - name: Setup SBT
-      uses: sbt/setup-sbt@v1
-
-    - name: Update apt database
-      if: matrix.os != 'windows-latest'
-      run: sudo apt-get update
-
-    - name: Install Chez Scheme
-      if: matrix.os != 'windows-latest'
-      run: sudo apt-get install chezscheme
-
-    - name: Install LLVM 15
-      if: matrix.os != 'windows-latest'
-      run: sudo apt-get install llvm-15
-
-    - name: Install Valgrind
-      if: matrix.os != 'windows-latest'
-      run: sudo apt-get install valgrind
-
-    - name: Install libuv
-      run: sudo apt-get install libuv1-dev
-
-    - name: Set up NodeJS ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
+    - uses: ./.github/actions/run-effekt-tests
       with:
-        node-version: ${{ env.NODE_VERSION }}
-
-    - name: Run tests
-      run: EFFEKT_VALGRIND=1 EFFEKT_DEBUG=1 sbt -J-Xss1G clean test
-
-    - name: Assemble fully optimized js file
-      run: sbt effektJS/fullOptJS
-
-    - name: Try installing effekt binary
-      run: sbt install
-
-    - name: Run effekt binary
-      run: effekt.sh --help
+        full-test: 'true'
+        use-retry: 'false'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,3 @@
-# This is a copy-and-paste version of ci.yml but additionally creating a release
 name: Release Artifacts
 
 on:
@@ -9,10 +8,6 @@ on:
     workflows: ["Create Version and Tag"] # 'autorelease.yml'
     types:
       - completed
-
-env:
-  JAVA_VERSION: '11'
-  NODE_VERSION: '16.x'
 
 jobs:
   build-jar:
@@ -30,19 +25,9 @@ jobs:
         fetch-depth: 0
         submodules: 'true'
 
-    - name: Set up JDK ${{ env.JAVA_VERSION }}
-      uses: actions/setup-java@v4
+    - uses: ./.github/actions/setup-effekt
       with:
         java-version: ${{ env.JAVA_VERSION }}
-        distribution: 'zulu'
-        cache: 'sbt'
-
-    - name: Setup SBT
-      uses: sbt/setup-sbt@v1
-
-    - name: Set up NodeJS ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
-      with:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Get the version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,6 @@ jobs:
         submodules: 'true'
 
     - uses: ./.github/actions/setup-effekt
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        node-version: ${{ env.NODE_VERSION }}
 
     - name: Get the version
       id: get_version


### PR DESCRIPTION
I was sitting on this idea for a while: the CI is somewhat difficult to navigate since we keep building the env anew every single time...

GitHub Actions allows us to make reusable actions which we can use like subroutines for the actual workflows.
Here, we have:
- `run-effekt-tests` which just runs tests (we can choose whether full tests or partial ones or if it should retry)
- `setup-effekt` which prepares the devenv

See docs [here](https://docs.github.com/en/actions/sharing-automations/avoiding-duplication).

Now it's much easier to, say, change the LLVM version in _all_ CI actions! :^)

---

No idea if this works, most of this was vibe-coded with Sonnet 3.7 and I have no way of testing this locally anyways... 🤷‍♂️ 😎 