### PR TITLE
Add test for cyclic imports

### DIFF
--- a/examples/neg/cyclic_a.check
+++ b/examples/neg/cyclic_a.check
@@ -1,0 +1,10 @@
+[error] ./examples/neg/cyclic_a.effekt:3:1: Cyclic import: cyclic_a depends on itself, via:
+	cyclic_a -> cyclic_b -> cyclic_a
+import examples/neg/cyclic_b
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[error] ./examples/neg/cyclic_a.effekt:3:1: Cannot compile dependency: ./examples/neg/cyclic_a
+import examples/neg/cyclic_b
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[error] ./examples/neg/cyclic_a.effekt:3:1: Cannot compile dependency: ./examples/neg/cyclic_b
+import examples/neg/cyclic_b
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/neg/cyclic_a.effekt
+++ b/examples/neg/cyclic_a.effekt
@@ -1,0 +1,5 @@
+module cyclic_a
+
+import examples/neg/cyclic_b
+
+def main() = ()

--- a/examples/neg/cyclic_b.effekt
+++ b/examples/neg/cyclic_b.effekt
@@ -1,0 +1,5 @@
+module cyclic_b
+
+import examples/neg/cyclic_a
+
+def main() = ()


### PR DESCRIPTION
Fixes #760 by giving a more user-friendly error message like the following:

<img width="711" alt="Screenshot 2025-03-28 at 12 02 58" src="https://github.com/user-attachments/assets/72ce83a1-29a0-4309-8718-6d965c74ae22" />


## How it achieves this
In a dynamic variable, it keeps a shadow-stack of what `Namer` is currently processing, checking on insertion.
This check is moved into the processing of imports so the positioning information is correct.