### PR TITLE
Fix: make type pretty printer less confusing for boxed types

### DIFF
--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -66,13 +66,17 @@ object TypePrinter extends ParenPrettyPrinter {
       val tps = if (tparams.isEmpty) emptyDoc else typeParams(tparams)
       val ps: Doc = (vparams, bparams) match {
         case (Nil, Nil)       => "()"
+        case (List(tpe: BoxedType), Nil) => parens(toDoc(tpe))
         case (List(tpe), Nil) => if (tparams.isEmpty) toDoc(tpe) else parens(toDoc(tpe))
         case (_, _) =>
           val vps = if (vparams.isEmpty) emptyDoc else parens(hsep(vparams.map(toDoc), comma))
           val bps = if (bparams.isEmpty) emptyDoc else hcat(bparams.map(toDoc).map(braces))
           vps <> bps
       }
-      val ret = toDoc(result)
+      val ret = result match {
+        case _: BoxedType => parens(toDoc(result))
+        case _ => toDoc(result)
+      }
       val eff = if (effects.isEmpty) emptyDoc else space <> "/" <+> toDoc(effects)
       tps <> ps <+> "=>" <+> ret <> eff
 

--- a/examples/neg/lambdas/inference.check
+++ b/examples/neg/lambdas/inference.check
@@ -1,22 +1,22 @@
 [error] Expected type
-  Int => Bool at {} => String
+  (Int => Bool at {}) => String
 but got type
-  Int => Unit at {} => String
+  (Int => Unit at {}) => String
 
 Type mismatch between Bool and Unit.
   comparing the argument types of
-    Int => Unit at {} => String (given)
-    Int => Bool at {} => String (expected)
+    (Int => Unit at {}) => String (given)
+    (Int => Bool at {}) => String (expected)
   when comparing the return type of the function.
 [error] examples/neg/lambdas/inference.effekt:13:8: Expected type
-  Int => Bool at {} => String at {}
+  (Int => Bool at {}) => String at {}
 but got type
-  Int => Unit at {} => String at ?C
+  (Int => Unit at {}) => String at ?C
 
 Type mismatch between Bool and Unit.
   comparing the argument types of
-    Int => Unit at {} => String (given)
-    Int => Bool at {} => String (expected)
+    (Int => Unit at {}) => String (given)
+    (Int => Bool at {}) => String (expected)
   when comparing the return type of the function.
   hof2(fun(f: (Int) => Unit at {}) { "" })
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #659, but not #667. I propose deferring fixing #667 to a later point in time, as it requires more design.

I also noticed that both

```
interface Exc {
	def throw(msg: String): Nothing
}

def divide(n: Int, m: Int) {exc: Exc}: (Int => Exc at {exc}) at {io} = {
	def res(x: Int) = { println(x); exc }
	res
}
```

and

```
interface Exc {
	def throw(msg: String): Nothing
}

def divide(n: Int, m: Int) {exc: Exc}: Int => (Exc at {exc}) at {io} = {
	def res(x: Int) = { println(x); exc }
	res
}
```

parse, yet the former is parsed as the latter regardless. This is very surprising to me, since these types clearly mean different things. In fact, boxed value types (first examples) should fail during type checking and not be accidentally transformed to a correct type.

What this PR does, for now, is to parenthesize boxed types when occurring in parameter or return type positions. For example `(Int => Int at {}) => Int` instead of `Int => Int at {} => Int`, which, in my opinion, is utterly unreadable.