### PR TITLE
Cache phases Parser until Typer

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -266,15 +266,17 @@ class LSPTests extends FunSuite {
     }
   }
 
-  // FIXME: Hovering over holes does not work at the moment.
-  // https://github.com/effekt-lang/effekt/issues/549
-  test("Hovering over hole shows nothing") {
+  test("Hovering over hole shows inside and outside types") {
     withClientAndServer { (client, server) =>
       val (textDoc, cursor) = raw"""
-                                |def foo(x: Int) = <>
-                                |                  ↑
+                                |def foo(x: Int): Bool = <{ x }>
+                                |                          ↑
                                 |""".textDocumentAndPosition
-      val hoverContents = ""
+      val hoverContents =
+        raw"""| | Outside       | Inside        |
+             | |:------------- |:------------- |
+             | | `Bool` | `Int` |
+             |""".stripMargin
 
       val didOpenParams = new DidOpenTextDocumentParams()
       didOpenParams.setTextDocument(textDoc)

--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -192,7 +192,7 @@ trait Compiler[Executable] {
    *       Note that it is not sufficient to just cache the Parser phase because BoxUnboxInference
    *       will rewrite the tree, meaning some nodes change their original object identity.
    */
-  val ParserUntilTyper: Phase[kiama.util.Source, Typechecked]= Phase.cached[Typechecked]("parser-until-typer") {
+  val ParserUntilTyper = Phase.cached("parser-until-typer") {
     /**
      * Parses a file to a syntax tree
      * [[Source]] --> [[Parsed]]

--- a/examples/neg/cyclic_a.check
+++ b/examples/neg/cyclic_a.check
@@ -1,10 +1,10 @@
-[error] examples/neg/cyclic_a.effekt:3:1: Cyclic import: cyclic_a depends on itself, via:
+[error] ./examples/neg/cyclic_a.effekt:3:1: Cyclic import: cyclic_a depends on itself, via:
 	cyclic_a -> cyclic_b -> cyclic_a
 import examples/neg/cyclic_b
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-[error] examples/neg/cyclic_a.effekt:3:1: Cannot compile dependency: ./examples/neg/cyclic_a
+[error] ./examples/neg/cyclic_a.effekt:3:1: Cannot compile dependency: ./examples/neg/cyclic_a
 import examples/neg/cyclic_b
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-[error] examples/neg/cyclic_a.effekt:3:1: Cannot compile dependency: ./examples/neg/cyclic_b
+[error] ./examples/neg/cyclic_a.effekt:3:1: Cannot compile dependency: ./examples/neg/cyclic_b
 import examples/neg/cyclic_b
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Previously, our annotations relied on the object identity of the syntax tree that directly results from parsing.
However, some phases, in particular the `BoxUnboxInference` phase, rewrite the tree which changes the object identity of nodes.
This led to issues such as #897 and #549.
Finishing what we started at the end of the Hackathon last friday, this PR now caches the phases `Parser` until `Typer` rather than just `Typer` and uses the resulting tree for `getAST` queries.
This is probably not the final solution for this problem, but it improves the status quo.
