### PR TITLE
Stdlib: Binary/Byte stream utilities

### DIFF
--- a/libraries/common/binstream.effekt
+++ b/libraries/common/binstream.effekt
@@ -24,6 +24,12 @@ record Signed[A](raw: A)
 /// Bits
 type Bit { B0(); B1() }
 
+/// not on Bits
+def not(b: Bit): Bit = b match {
+  case B0() => B1()
+  case B1() => B0()
+}
+
 /// Splices allowed in hex/byte stream literals
 effect HexSplices = {
   splice[Char], splice[String], 
@@ -89,7 +95,10 @@ def signedBytesLE(int: Int): Unit / emit[Byte] = signedBytesLE(int, 4)
 /// emit bytes of the given int as 4 bytes (in 2s-complement) in big-endian byte order
 def signedBytesBE(int: Int): Unit / emit[Byte] = signedBytesBE(int, 4)
 
+/// emit bits of the given int as 32 Bits in big-endian bit order
 def bitsBE(int: Int): Unit / emit[Bit] = bitsBE(int, 32)
+
+/// collect bits in big-endian bit order into an Int
 def collectBitsBE{ body: => Unit / emit[Bit] }: Int = {
   var res = 0
   try body() with emit[Bit] { b =>
@@ -101,11 +110,10 @@ def collectBitsBE{ body: => Unit / emit[Bit] }: Int = {
   }
   res
 }
-def not(b: Bit): Bit = b match {
-  case B0() => B1()
-  case B1() => B0()
-}
+
+/// bitwise not on integers
 def bitwiseNot(n: Int): Int = {
+  // TODO currently implemented in Effekt, should use extern ?
   collectBitsBE{
     try bitsBE(n) with emit[Bit]{ b => resume(do emit(not(b))) }
   }
@@ -114,6 +122,8 @@ def bitwiseNot(n: Int): Int = {
 // Splicers
 // --------
 
+/// Splicer to emit the bytes in hex notation given, plus evenutal splices
+/// Ignores whitespace
 def hex{ body: => Unit / { literal, HexSplices } }: Unit / emit[Byte] = {
   try {
     try {
@@ -153,6 +163,7 @@ def hex{ body: => Unit / { literal, HexSplices } }: Unit / emit[Byte] = {
   with splice[OfWidth[BE[Signed[Int]]]] { w => signedBytesBE(w.raw.raw.raw, w.width); resume(()) }
 }
 
+/// convert the given hex notation to an integer (big-endian)
 def x{ body: => Unit / { literal, HexSplices } }: Int = {
   var res = 0
   for[Byte]{ hex{body} }{ v => res = res * 256 + v.toInt }
@@ -161,8 +172,16 @@ def x{ body: => Unit / { literal, HexSplices } }: Int = {
 
 // Counting and padding
 // --------------------
+// TODO could also be part of stream library
+
+/// Request padding to a multiple of fac, by calling gen for each
 effect pad[A](fac: Int){ gen: => A }: Unit
+
+/// get current position in stream
 effect getPos(): Int
+
+/// Track position in stream, starting with init
+/// Handles getPos and pad
 def tracking[A](init: Int){ body: => Unit / { emit[A], getPos, pad[A] } }: Unit / emit[A] = {
   var n = init
   try body()
@@ -177,6 +196,9 @@ def tracking[A](init: Int){ body: => Unit / { emit[A], getPos, pad[A] } }: Unit 
     }
   }
 }
+
+/// Track how many bytes were emitted
+/// Handles getPos and pad
 def tracking[A]{ body: => Unit / { emit[A], getPos, pad[A] } }: Unit / emit[A] =
   tracking[A](0){body}
 

--- a/libraries/common/binstream.effekt
+++ b/libraries/common/binstream.effekt
@@ -95,29 +95,7 @@ def signedBytesLE(int: Int): Unit / emit[Byte] = signedBytesLE(int, 4)
 /// emit bytes of the given int as 4 bytes (in 2s-complement) in big-endian byte order
 def signedBytesBE(int: Int): Unit / emit[Byte] = signedBytesBE(int, 4)
 
-/// emit bits of the given int as 32 Bits in big-endian bit order
-def bitsBE(int: Int): Unit / emit[Bit] = bitsBE(int, 32)
 
-/// collect bits in big-endian bit order into an Int
-def collectBitsBE{ body: => Unit / emit[Bit] }: Int = {
-  var res = 0
-  try body() with emit[Bit] { b =>
-    res = b match {
-      case B0() => res * 2
-      case B1() => res * 2 + 1
-    }
-    resume(())
-  }
-  res
-}
-
-/// bitwise not on integers
-def bitwiseNot(n: Int): Int = {
-  // TODO currently implemented in Effekt, should use extern ?
-  collectBitsBE{
-    try bitsBE(n) with emit[Bit]{ b => resume(do emit(not(b))) }
-  }
-}
 
 // Splicers
 // --------
@@ -207,6 +185,7 @@ def tracking[A]{ body: => Unit / { emit[A], getPos, pad[A] } }: Unit / emit[A] =
 
 // From/to Bytes
 // -------------
+/// emit bits of the given Byte as 8 Bits in little-endian bit order
 def bitsLE(byte: Byte): Unit / emit[Bit] = {
   val v = byte.toInt
   var mask = 1
@@ -218,6 +197,8 @@ def bitsLE(byte: Byte): Unit / emit[Bit] = {
     mask = mask * 2
   }
 }
+
+/// emit bits of the given Byte as 8 Bits in big-endian bit order
 def bitsBE(byte: Byte): Unit / emit[Bit] = {
   val v = byte.toInt
   var mask = 128
@@ -229,7 +210,11 @@ def bitsBE(byte: Byte): Unit / emit[Bit] = {
     mask = mask / 2
   }
 }
+
+/// emit bits of the given Byte as 8 Bits in big-endian bit order
 def bits(byte: Byte): Unit / emit[Bit] = bitsBE(byte)
+
+/// emit bits of the given Byte as width Bits in little-endian bit order
 def bitsLE(v: Int, width: Int): Unit / emit[Bit] = {
   var mask = 1
   repeat(width){
@@ -240,18 +225,8 @@ def bitsLE(v: Int, width: Int): Unit / emit[Bit] = {
     mask = mask * 2
   }
 }
-def pow(n: Int, exp: Int): Int = {
-  def go(n: Int, exp: Int, acc: Int): Int = {
-    if (exp == 0) {
-      acc 
-    } else if (mod(exp, 2) == 0) {
-      go(n * n, exp / 2, acc)
-    } else {
-      go(n * n, exp / 2, acc * n)
-    }
-  }
-  go(n, exp, 1)
-}
+
+/// emit bits of the given int as width Bits in big-endian bit order
 def bitsBE(v: Int, width: Int): Unit / emit[Bit] = {
   var mask = pow(2, width - 1)
   repeat(width){
@@ -262,6 +237,31 @@ def bitsBE(v: Int, width: Int): Unit / emit[Bit] = {
     mask = mask / 2
   }
 }
+
+/// emit bits of the given int as 32 Bits in big-endian bit order
+def bitsBE(int: Int): Unit / emit[Bit] = bitsBE(int, 32)
+
+/// collect bits in big-endian bit order into an Int
+def collectBitsBE{ body: => Unit / emit[Bit] }: Int = {
+  var res = 0
+  try body() with emit[Bit] { b =>
+    res = b match {
+      case B0() => res * 2
+      case B1() => res * 2 + 1
+    }
+    resume(())
+  }
+  res
+}
+
+/// bitwise not on integers
+def bitwiseNot(n: Int): Int = {
+  // TODO currently implemented in Effekt, should use extern ?
+  collectBitsBE{
+    try bitsBE(n) with emit[Bit]{ b => resume(do emit(not(b))) }
+  }
+}
+
 def ungroupBytes{ body: => Unit / emit[Byte] }: Unit / emit[Bit] =
   for[Byte]{body}{ b => bits(b) }
 def twoscomplementLE{ body: => Unit / emit[Bit] }: Unit / emit[Bit] = {

--- a/libraries/common/binstream.effekt
+++ b/libraries/common/binstream.effekt
@@ -262,8 +262,11 @@ def bitwiseNot(n: Int): Int = {
   }
 }
 
+/// split emitted bytes and emit the individual bits in big-endian bit order
 def ungroupBytes{ body: => Unit / emit[Byte] }: Unit / emit[Bit] =
   for[Byte]{body}{ b => bits(b) }
+
+/// streaming negation in 2s-complement for little-endian bitstreams
 def twoscomplementLE{ body: => Unit / emit[Bit] }: Unit / emit[Bit] = {
   var carry = true
   try body()
@@ -272,6 +275,9 @@ def twoscomplementLE{ body: => Unit / emit[Bit] }: Unit / emit[Bit] = {
     case B1() => if(carry) { do emit(B1()); carry = false } else { do emit(B0()) }; resume(())
   }
 }  
+
+/// group 8 bits into a byte each, big-endian bit order.
+/// NOTE: The remainder is dropped.
 def groupBytesBE{ body: => Unit / emit[Bit] }: Unit / emit[Byte] = {
   var next = 0
   var p = 128
@@ -288,6 +294,9 @@ def groupBytesBE{ body: => Unit / emit[Bit] }: Unit / emit[Byte] = {
     }
   }
 }
+
+/// group 8 bits into a byte each, little-endian bit order.
+/// NOTE: The remainder is dropped.
 def groupBytesLE{ body: => Unit / emit[Bit] }: Unit / emit[Byte] = {
   var next = 0
   var p = 1
@@ -304,9 +313,15 @@ def groupBytesLE{ body: => Unit / emit[Bit] }: Unit / emit[Byte] = {
     }
   }
 }
+
+/// group 8 bits into a byte each, big-endian bit order.
+/// NOTE: The remainder is dropped.
 def groupBytes{ body: => Unit / emit[Bit] }: Unit / emit[Byte] =
   groupBytesBE{body}
 
+/// Return just nth element of the given stream.
+/// Raises MissingValue if not enough elements are emitted
+// TODO could be in stream
 def nth[A](n: Int){ body: => Unit / emit[A] }: A / Exception[MissingValue] = {
   var m = n
   try {
@@ -322,6 +337,10 @@ def nth[A](n: Int){ body: => Unit / emit[A] }: A / Exception[MissingValue] = {
     }
   }
 }
+
+/// Return just first element of the given stream.
+/// Raises MissingValue if no elements are emitted
+// TODO could be in stream
 def first[A]{ body: => Unit / emit[A] }: A / Exception[MissingValue] = {
   try {
     body()
@@ -331,7 +350,8 @@ def first[A]{ body: => Unit / emit[A] }: A / Exception[MissingValue] = {
 }
 // Literals/splices
 // ----------------
-effect BinSplices = {
+/// Splices allowed in bit stream literals
+effect BitSplices = {
   splice[Unit], splice[Bit],
   splice[Byte],
   splice[LE[Int]], splice[BE[Int]],
@@ -339,7 +359,9 @@ effect BinSplices = {
   splice[OfWidth[LE[Int]]], splice[OfWidth[BE[Int]]],
   splice[OfWidth[LE[Signed[Int]]]], splice[OfWidth[BE[Signed[Int]]]]
 }
-def bit{ body: => Unit / { literal, BinSplices } }: Unit / emit[Bit] = {
+/// Splicer to emit the bits in binary notation given, plus evenutal splices
+/// Ignores whitespace
+def bit{ body: => Unit / { literal, BitSplices } }: Unit / emit[Bit] = {
   try {
     ungroupBytes{
       try {
@@ -394,6 +416,8 @@ def bit{ body: => Unit / { literal, BinSplices } }: Unit / emit[Bit] = {
   }
 }
 
+// Simple usage examples
+// =====================
 namespace examples {
   def main() = {
     mainSuite("Simple literals"){

--- a/libraries/common/binstream.effekt
+++ b/libraries/common/binstream.effekt
@@ -140,8 +140,8 @@ def x{ body: => Unit / { literal, HexSplices } }: Int = {
 // --------------------
 effect pad[A](fac: Int){ gen: => A }: Unit
 effect getPos(): Int
-def tracking[A]{ body: => Unit / { emit[A], getPos, pad[A] } }: Unit / emit[A] = {
-  var n = 0
+def tracking[A](init: Int){ body: => Unit / { emit[A], getPos, pad[A] } }: Unit / emit[A] = {
+  var n = init
   try body()
   with emit[A] { b => n = n + 1; resume(do emit[A](b)) }
   with getPos{ resume(n) }
@@ -154,6 +154,8 @@ def tracking[A]{ body: => Unit / { emit[A], getPos, pad[A] } }: Unit / emit[A] =
     }
   }
 }
+def tracking[A]{ body: => Unit / { emit[A], getPos, pad[A] } }: Unit / emit[A] =
+  tracking[A](0){body}
 
 // Sub-Byte
 // ========

--- a/libraries/common/binstream.effekt
+++ b/libraries/common/binstream.effekt
@@ -1,0 +1,401 @@
+import option
+import stringbuffer
+import stream
+import char
+import test
+import io/error
+import bytearray
+
+// assumes by default:
+// BE byteorder, BE bitorder, unsigned
+
+// Wrappers
+// --------
+record BE[A](raw: A)
+record LE[A](raw: A)
+record OfWidth[A](raw: A, width: Int)
+record Signed[A](raw: A)
+
+/// Bits
+type Bit { B0(); B1() }
+
+/// Effect alias
+effect HexSplices = {
+  splice[Char], splice[String], 
+  splice[Unit], 
+  splice[Int],
+  splice[Byte],
+  splice[BE[Int]], splice[LE[Int]],
+  splice[LE[Signed[Int]]], splice[OfWidth[LE[Int]]], splice[OfWidth[LE[Signed[Int]]]],
+  splice[BE[Signed[Int]]], splice[OfWidth[BE[Int]]], splice[OfWidth[BE[Signed[Int]]]],
+  splice[ByteArray]
+}
+
+// Splitting
+// ---------
+def bytesLE(int: Int, w: Int): Unit / emit[Byte] = {
+  var c = int
+  repeat(w){
+    do emit(mod(c, 256).toByte)
+    c = c / 256
+  }
+}
+def bytesLE(int: Int): Unit / emit[Byte] = bytesLE(int, 4)
+def bytesBE(n: Int, width: Int): Unit / emit[Byte] = {
+  var pos = pow(256, width - 1)
+  repeat(width){
+    do emit((bitwiseAnd(n, pos * 255) / pos).toByte)
+    pos = pos / 256
+  }
+}
+def bytesBE(n: Int): Unit / emit[Byte] = bytesBE(n, 4)
+def bytes(n: Int): Unit / emit[Byte] = bytesBE(n)
+def signedBytesLE(int: Int, width: Int): Unit / emit[Byte] = {
+  if (int < 0) {
+    bytesLE(bitwiseNot(neg(int)) + 1, width)
+  } else {
+    bytesLE(int, width)
+  }
+}
+def signedBytesBE(int: Int, width: Int): Unit / emit[Byte] = {
+  if (int < 0) {
+    bytesBE(bitwiseNot(neg(int)) + 1, width)
+  } else {
+    bytesBE(int, width)
+  }
+}
+def signedBytesLE(int: Int): Unit / emit[Byte] = signedBytesLE(int, 4)
+def signedBytesBE(int: Int): Unit / emit[Byte] = signedBytesBE(int, 4)
+def bitsBE(int: Int): Unit / emit[Bit] = bitsBE(int, 32)
+def collectBitsBE{ body: => Unit / emit[Bit] }: Int = {
+  var res = 0
+  try body() with emit[Bit] { b =>
+    res = b match {
+      case B0() => res * 2
+      case B1() => res * 2 + 1
+    }
+    resume(())
+  }
+  res
+}
+def not(b: Bit): Bit = b match {
+  case B0() => B1()
+  case B1() => B0()
+}
+def bitwiseNot(n: Int): Int = {
+  collectBitsBE{
+    try bitsBE(n) with emit[Bit]{ b => resume(do emit(not(b))) }
+  }
+}
+
+// Splicers
+// --------
+
+def hex{ body: => Unit / { literal, HexSplices } }: Unit / emit[Byte] = {
+  try {
+    try {
+      body()
+    }
+    with splice[String] { s =>
+      feed(s){ exhaustively{ do splice[Char](do read[Char]()) } }
+      resume(())
+    }
+    with splice[ByteArray] { ba =>
+      ba.foreach{ b => do splice[Byte](b) }
+      resume(())
+    }
+  }
+  with literal { s =>
+      feed(s){
+        exhaustively {
+          with on[MissingValue].default{ () }
+          val upper: Int = hexDigitValue(do read[Char]()).value
+          val lower: Int = hexDigitValue(do read[Char]()).value
+          do emit[Byte]((16 * upper + lower).toByte)
+        }
+      }
+      resume(())
+    }
+  with splice[Char] { c => do emit[Byte](c.toInt.toByte); resume(()) }
+  with splice[Byte] { b => do emit(b); resume(()) }
+  with splice[Unit] { u => resume(()) }
+  with splice[Int] { n => bytesBE(n); resume(()) }
+  with splice[LE[Int]] { w => bytesLE(w.raw); resume(()) }
+  with splice[BE[Int]] { v => bytesBE(v.raw); resume(()) }
+  with splice[LE[Signed[Int]]] { w => signedBytesLE(w.raw.raw); resume(()) }
+  with splice[OfWidth[LE[Int]]] { w => bytesLE(w.raw.raw, w.width); resume(()) }
+  with splice[OfWidth[LE[Signed[Int]]]] { w => signedBytesLE(w.raw.raw.raw, w.width); resume(()) }
+  with splice[BE[Signed[Int]]] { w => signedBytesBE(w.raw.raw); resume(()) }
+  with splice[OfWidth[BE[Int]]] { w => bytesBE(w.raw.raw, w.width); resume(()) }
+  with splice[OfWidth[BE[Signed[Int]]]] { w => signedBytesBE(w.raw.raw.raw, w.width); resume(()) }
+}
+
+def x{ body: => Unit / { literal, HexSplices } }: Int = {
+  var res = 0
+  for[Byte]{ hex{body} }{ v => res = res * 256 + v.toInt }
+  res
+}
+
+// Counting and padding
+// --------------------
+effect pad[A](fac: Int){ gen: => A }: Unit
+effect getPos(): Int
+def tracking[A]{ body: => Unit / { emit[A], getPos, pad[A] } }: Unit / emit[A] = {
+  var n = 0
+  try body()
+  with emit[A] { b => n = n + 1; resume(do emit[A](b)) }
+  with getPos{ resume(n) }
+  with pad[A] { fac => 
+    resume { {gen} =>
+      while(mod(n, fac) != 0){
+        do emit[A](gen())
+        n = n + 1
+      }
+    }
+  }
+}
+
+// Sub-Byte
+// ========
+
+// From/to Bytes
+// -------------
+def bitsLE(byte: Byte): Unit / emit[Bit] = {
+  val v = byte.toInt
+  var mask = 1
+  repeat(8){
+    bitwiseAnd(v, mask) match {
+      case 0 => do emit(B0())  
+      case _ => do emit(B1())
+    }
+    mask = mask * 2
+  }
+}
+def bitsBE(byte: Byte): Unit / emit[Bit] = {
+  val v = byte.toInt
+  var mask = 128
+  repeat(8){
+    bitwiseAnd(v, mask) match {
+      case 0 => do emit(B0())  
+      case _ => do emit(B1())
+    }
+    mask = mask / 2
+  }
+}
+def bits(byte: Byte): Unit / emit[Bit] = bitsBE(byte)
+def bitsLE(v: Int, width: Int): Unit / emit[Bit] = {
+  var mask = 1
+  repeat(width){
+    bitwiseAnd(v, mask) match {
+      case 0 => do emit(B0())  
+      case _ => do emit(B1())
+    }
+    mask = mask * 2
+  }
+}
+def pow(n: Int, exp: Int): Int = {
+  def go(n: Int, exp: Int, acc: Int): Int = {
+    if (exp == 0) {
+      acc 
+    } else if (mod(exp, 2) == 0) {
+      go(n * n, exp / 2, acc)
+    } else {
+      go(n * n, exp / 2, acc * n)
+    }
+  }
+  go(n, exp, 1)
+}
+def bitsBE(v: Int, width: Int): Unit / emit[Bit] = {
+  var mask = pow(2, width - 1)
+  repeat(width){
+    bitwiseAnd(v, mask) match {
+      case 0 => do emit(B0())  
+      case _ => do emit(B1())
+    }
+    mask = mask / 2
+  }
+}
+def ungroupBytes{ body: => Unit / emit[Byte] }: Unit / emit[Bit] =
+  for[Byte]{body}{ b => bits(b) }
+def twoscomplementLE{ body: => Unit / emit[Bit] }: Unit / emit[Bit] = {
+  var carry = true
+  try body()
+  with emit[Bit] {
+    case B0() => if(carry) { do emit(B0()) } else { do emit(B1()) }; resume(())
+    case B1() => if(carry) { do emit(B1()); carry = false } else { do emit(B0()) }; resume(())
+  }
+}  
+def groupBytesBE{ body: => Unit / emit[Bit] }: Unit / emit[Byte] = {
+  var next = 0
+  var p = 128
+  for[Bit]{body}{ b =>
+    b match {
+      case B0() => ()
+      case B1() => next = next + p
+    }
+    p = p / 2
+    if(p == 0) {
+      do emit(next.toByte)
+      next = 0
+      p = 128
+    }
+  }
+}
+def groupBytesLE{ body: => Unit / emit[Bit] }: Unit / emit[Byte] = {
+  var next = 0
+  var p = 1
+  for[Bit]{body}{ b =>
+    b match {
+      case B0() => ()
+      case B1() => next = next + p
+    }
+    p = p * 2
+    if(p == 256) {
+      do emit(next.toByte)
+      next = 0
+      p = 1
+    }
+  }
+}
+def groupBytes{ body: => Unit / emit[Bit] }: Unit / emit[Byte] =
+  groupBytesBE{body}
+
+def nth[A](n: Int){ body: => Unit / emit[A] }: A / Exception[MissingValue] = {
+  var m = n
+  try {
+    body()
+    val r: A = do raise[MissingValue](MissingValue(), "code in first did not emit any values")
+    r
+  } with emit[A] { a => 
+    if (m == 0) {
+      a
+    } else {
+      m = m - 1
+      resume(())
+    }
+  }
+}
+def first[A]{ body: => Unit / emit[A] }: A / Exception[MissingValue] = {
+  try {
+    body()
+    val r: A = do raise[MissingValue](MissingValue(), "code in first did not emit any values")
+    r
+  } with emit[A] { a => a }
+}
+// Literals/splices
+// ----------------
+effect BinSplices = {
+  splice[Unit], splice[Bit],
+  splice[Byte],
+  splice[LE[Int]], splice[BE[Int]],
+  splice[LE[Signed[Int]]], splice[BE[Signed[Int]]],
+  splice[OfWidth[LE[Int]]], splice[OfWidth[BE[Int]]],
+  splice[OfWidth[LE[Signed[Int]]]], splice[OfWidth[BE[Signed[Int]]]]
+}
+def bit{ body: => Unit / { literal, BinSplices } }: Unit / emit[Bit] = {
+  try {
+    ungroupBytes{
+      try {
+        body()
+      }
+      with splice[LE[Int]] { i => bytesLE(i.raw); resume(()) }
+      with splice[BE[Int]] { i => bytesBE(i.raw); resume(()) }
+      with splice[LE[Signed[Int]]] { i => signedBytesLE(i.raw.raw); resume(()) }
+      with splice[BE[Signed[Int]]] { i => signedBytesBE(i.raw.raw); resume(()) }
+    }
+  }
+  with literal { s =>
+    feed(s){
+      exhaustively {
+        do read[Char]() match {
+          case '0' => do emit(B0())
+          case '1' => do emit(B1())
+          case _ => ()
+        }
+      }
+    }
+    resume(())
+  }
+  with splice[Unit] { _ => resume(()) }
+  with splice[Bit] { b => do emit(b); resume(()) }
+  with splice[Byte] { b => bits(b); resume(()) }
+  with splice[OfWidth[LE[Int]]] { i =>
+    bitsLE(i.raw.raw, i.width)
+    resume(())
+  }
+  with splice[OfWidth[LE[Signed[Int]]]] { i =>
+    if(i.raw.raw.raw < 0){
+      twoscomplementLE{ bitsLE(0 - i.raw.raw.raw, i.width) }
+    } else {
+      bitsLE(i.raw.raw.raw, i.width)
+    }
+    resume(())
+  }
+  with splice[OfWidth[BE[Int]]] { i =>
+    bitsBE(i.raw.raw, i.width)
+    resume(())
+  }
+  with splice[OfWidth[BE[Signed[Int]]]] { i =>
+    collectList[Bit]{
+      if(i.raw.raw.raw < 0){
+        twoscomplementLE{ bitsLE(0 - i.raw.raw.raw, i.width) }
+      } else {
+        bitsLE(i.raw.raw.raw, i.width)
+      }
+    }.reverse.each
+    resume(())
+  }
+}
+
+namespace examples {
+  def main() = {
+    mainSuite("Simple literals"){
+      test("literal hex 10"){ assertEqual(x"10${()}", 16) }
+      test("literal hex ff"){ assertEqual(x"ff${()}", 255) }
+      test("literal char a"){ assertEqual(x"${'a'}", x"61${()}") }
+      test("literal string ba"){ assertEqual(x"${"ba"}", x"62${()}" * 256 + x"61${()}") }
+      test("int back-and-forth (17)"){ assertEqual(x"${17}", 17)}
+      test("int back-and-forth (17), explicit BE"){ assertEqual(x"${17.BE}", 17) }
+      test("int back-and-forth (17), explicit LE"){ assertEqual(x"${17.LE}", 17 * 256 * 256 * 256) }
+      test("byte 00101010"){
+        with on[MissingValue].default{ assertEqual(true, false) }
+        assertEqual(first[Byte]{groupBytes{ bit"00101010${()}" }}.toInt, 42)
+      }
+      test("to bits and back"){ 
+        with on[MissingValue].default{ assertEqual(true, false) }
+        [42.toByte, 12.toByte, 113.toByte, 0.toByte, 255.toByte].foreach{ v =>
+          assertEqual(first[Byte]{ groupBytes{ bits(v) } }, v)
+        }
+      }
+      test("to bits and back LE bitorder"){ 
+        with on[MissingValue].default{ assertEqual(true, false) }
+        [42.toByte, 12.toByte, 113.toByte, 0.toByte, 255.toByte].foreach{ v =>
+          assertEqual(first[Byte]{ groupBytesLE{ bitsLE(v) } }, v)
+        }
+      }
+      test("to bits and back BE bitorder"){ 
+        with on[MissingValue].default{ assertEqual(true, false) }
+        [42.toByte, 12.toByte, 113.toByte, 0.toByte, 255.toByte].foreach{ v =>
+          assertEqual(first[Byte]{ groupBytesBE{ bitsBE(v) } }, v)
+        }
+      }
+      test("append 0 means *2"){
+        with on[MissingValue].default{ assertEqual(true, false) }
+        [42.toByte, 12.toByte, 127.toByte].foreach{ v =>
+          assertEqual(nth[Byte](1){ groupBytes{ repeat(7){ do emit(B0()) }; bits(v); do emit(B0()) } }, (v.toInt * 2).toByte)
+        }
+      }
+      test("pow agrees with double one"){
+        assertEqual(pow(2,5), pow(2.0,5).toInt)
+      }
+      test("LE 2s-complement"){
+        with on[MissingValue].default{ assertEqual(true, false) }
+        assertEqual(first[Byte]{ groupBytesLE{ twoscomplementLE{ bitsLE(6.toByte) } } }, 250.toByte)
+      }
+      test("BE 2s-complement"){
+        with on[MissingValue].default{ assertEqual(true, false) }
+        assertEqual(first[Byte]{ groupBytesBE{ bit"${-6.Signed.BE.OfWidth(8)}" } }, 250.toByte)
+      }
+    }
+  }
+}

--- a/libraries/common/binstream.effekt
+++ b/libraries/common/binstream.effekt
@@ -11,15 +11,20 @@ import bytearray
 
 // Wrappers
 // --------
+/// A with explicit big-endian order
 record BE[A](raw: A)
+/// A with explicit little-endian order
 record LE[A](raw: A)
+/// A with explicit width in current unit
+/// (bits for bitstreams, bytes for bytestreams)
 record OfWidth[A](raw: A, width: Int)
+/// explicitly signed A
 record Signed[A](raw: A)
 
 /// Bits
 type Bit { B0(); B1() }
 
-/// Effect alias
+/// Splices allowed in hex/byte stream literals
 effect HexSplices = {
   splice[Char], splice[String], 
   splice[Unit], 
@@ -33,6 +38,8 @@ effect HexSplices = {
 
 // Splitting
 // ---------
+
+/// emit bytes of the given int as a w bytes in little-endian byte order
 def bytesLE(int: Int, w: Int): Unit / emit[Byte] = {
   var c = int
   repeat(w){
@@ -40,7 +47,11 @@ def bytesLE(int: Int, w: Int): Unit / emit[Byte] = {
     c = c / 256
   }
 }
+
+/// emit bytes of the given int as a 4 bytes in little-endian byte order
 def bytesLE(int: Int): Unit / emit[Byte] = bytesLE(int, 4)
+
+/// emit bytes of the given int as a w bytes in big-endian byte order
 def bytesBE(n: Int, width: Int): Unit / emit[Byte] = {
   var pos = pow(256, width - 1)
   repeat(width){
@@ -48,8 +59,14 @@ def bytesBE(n: Int, width: Int): Unit / emit[Byte] = {
     pos = pos / 256
   }
 }
+
+/// emit bytes of the given int as a 4 bytes in big-endian byte order
 def bytesBE(n: Int): Unit / emit[Byte] = bytesBE(n, 4)
+
+/// emit bytes of the given int as a 4 bytes in big-endian byte order
 def bytes(n: Int): Unit / emit[Byte] = bytesBE(n)
+
+/// emit bytes of the given int as width bytes (in 2s-complement) in little-endian byte order
 def signedBytesLE(int: Int, width: Int): Unit / emit[Byte] = {
   if (int < 0) {
     bytesLE(bitwiseNot(neg(int)) + 1, width)
@@ -57,6 +74,7 @@ def signedBytesLE(int: Int, width: Int): Unit / emit[Byte] = {
     bytesLE(int, width)
   }
 }
+/// emit bytes of the given int as width bytes (in 2s-complement) in big-endian byte order
 def signedBytesBE(int: Int, width: Int): Unit / emit[Byte] = {
   if (int < 0) {
     bytesBE(bitwiseNot(neg(int)) + 1, width)
@@ -64,8 +82,13 @@ def signedBytesBE(int: Int, width: Int): Unit / emit[Byte] = {
     bytesBE(int, width)
   }
 }
+
+/// emit bytes of the given int as 4 bytes (in 2s-complement) in little-endian byte order
 def signedBytesLE(int: Int): Unit / emit[Byte] = signedBytesLE(int, 4)
+
+/// emit bytes of the given int as 4 bytes (in 2s-complement) in big-endian byte order
 def signedBytesBE(int: Int): Unit / emit[Byte] = signedBytesBE(int, 4)
+
 def bitsBE(int: Int): Unit / emit[Bit] = bitsBE(int, 32)
 def collectBitsBE{ body: => Unit / emit[Bit] }: Int = {
   var res = 0

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -419,6 +419,22 @@ def pow(base: Double, exponent: Int): Double = {
   }
 }
 
+/// Computes n^exp for integers.
+/// 
+/// Precondition: exp >= 0
+def pow(n: Int, exp: Int): Int = {
+  def go(n: Int, exp: Int, acc: Int): Int = {
+    if (exp == 0) {
+      acc 
+    } else if (mod(exp, 2) == 0) {
+      go(n * n, exp / 2, acc)
+    } else {
+      go(n * n, exp / 2, acc * n)
+    }
+  }
+  go(n, exp, 1)
+}
+
 extern pure def pow(base: Double, exponent: Double): Double =
   js "Math.pow(${base}, ${exponent})"
   chez "(expt ${base} ${exponent})"


### PR DESCRIPTION
This adds a `binstream` file to the stdlib that can be used to easily create streams of bytes.
See #870 for a usage example (this was mostly factored out from there).

- [ ] Replace `bitwiseNot` as implemented here with an extern
- [ ] Move some of the general utilities into `streams`? (esp. `tracking`)