### PR TITLE
Fix invalid links

### DIFF
--- a/examples/casestudies/naturalisticdsls.effekt.md
+++ b/examples/casestudies/naturalisticdsls.effekt.md
@@ -234,11 +234,11 @@ def main() = {
 }
 ```
 
-[@hudak96building]: https://dl.acm.org/doi/10.1145/242224.242477
-[@lopes2003beyond]: https://dl.acm.org/doi/abs/10.1145/966051.966058
+[@hudak96building]: https://doi.org/10.1145/242224.242477
+[@lopes2003beyond]: https://doi.org/10.1145/966051.966058
 [@marvsik2016introducing]: https://hal.archives-ouvertes.fr/hal-01079206/
-[@erdweg11sugarj]: https://dl.acm.org/doi/abs/10.1145/2048066.2048099
-[@shan2005linguistic]: http://homes.sice.indiana.edu/ccshan/dissertation/book.pdf
-[@shan2004delimited]: https://arxiv.org/abs/cs/0404006
-[@barker2004continuations]: https://www.nyu.edu/projects/barker/barker-cw.pdf
-[@yallop2017staged]: https://dl.acm.org/doi/abs/10.1145/2847538.2847546
+[@erdweg11sugarj]: https://doi.org/10.1145/2048066.2048099
+[@shan2005linguistic]: https://homes.sice.indiana.edu/ccshan/dissertation/book.pdf
+[@shan2004delimited]: https://doi.org/10.48550/arXiv.cs/0404006
+[@barker2014continuations]: https://archive.org/details/continuationsnat0000bark/
+[@yallop2017staged]: https://doi.org/10.1145/2847538.2847546

--- a/examples/tour/captures.effekt.md
+++ b/examples/tour/captures.effekt.md
@@ -131,4 +131,4 @@ An example of a builtin resource is `io`, which is handled by the runtime. Other
 
 ## References
 
-- [Effects, capabilities, and boxes: from scope-based reasoning to type-based reasoning and back](https://dl.acm.org/doi/10.1145/3527320)
+- [Effects, capabilities, and boxes: from scope-based reasoning to type-based reasoning and back](https://doi.org/10.1145/3527320)

--- a/examples/tour/objects.effekt.md
+++ b/examples/tour/objects.effekt.md
@@ -85,4 +85,4 @@ def counterAsEffect2() = {
 counterAsEffect2()
 ```
 As part of its compilation pipeline, and guided by the type-and-effect system,
-the Effekt compiler performs this translation from implicitly handled effects to explicitly passed capabilities [Brachthäuser et al., 2020](https://dl.acm.org/doi/10.1145/3428194).
+the Effekt compiler performs this translation from implicitly handled effects to explicitly passed capabilities [Brachthäuser et al., 2020](https://doi.org/10.1145/3428194).

--- a/examples/tour/regions.effekt.md
+++ b/examples/tour/regions.effekt.md
@@ -136,5 +136,5 @@ We can return a closure that closes over a mutable reference. This is only possi
 
 ## References
 
-- [Region-based Resource Management and Lexical Exception Handlers in Continuation-Passing Style](https://link.springer.com/chapter/10.1007/978-3-030-99336-8_18)
-- [Effects, capabilities, and boxes: from scope-based reasoning to type-based reasoning and back](https://dl.acm.org/doi/10.1145/3527320)
+- [Region-based Resource Management and Lexical Exception Handlers in Continuation-Passing Style](https://doi.org/10.1007/978-3-030-99336-8_18)
+- [Effects, capabilities, and boxes: from scope-based reasoning to type-based reasoning and back](https://doi.org/10.1145/3527320)


### PR DESCRIPTION
In conjunction with https://github.com/effekt-lang/effekt-website/pull/85, this fixes all invalid URLs and file paths.