### PR TITLE
JSWeb: report all collected errors upon aborting

### DIFF
--- a/effekt/js/src/main/scala/effekt/LanguageServer.scala
+++ b/effekt/js/src/main/scala/effekt/LanguageServer.scala
@@ -98,18 +98,12 @@ class LanguageServer extends Intelligence {
     file(path).lastModified
 
   @JSExport
-  def compileFile(path: String): String = {
-    val mainOutputPath = compileCached(VirtualFileSource(path)).getOrElseAborting {
-      throw js.JavaScriptException(s"Cannot compile ${path}")
+  def compileFile(path: String): String =
+    compileCached(VirtualFileSource(path)).getOrElseAborting {
+      // report all collected error messages
+      val formattedErrors = context.messaging.formatMessages(context.messaging.get)
+      throw js.JavaScriptException(formattedErrors)
     }
-    try {
-      mainOutputPath
-    } catch {
-      case FatalPhaseError(msg) =>
-        val formattedError = context.messaging.formatMessage(msg)
-        throw js.JavaScriptException(formattedError)
-    }
-  }
 
   @JSExport
   def showCore(path: String): String = {


### PR DESCRIPTION
Currently, when encountering an error (e.g. through calling `Context.abort`) in the JSWeb backend, all encountered errors are discarded and a JS exception is thrown. All information is lost there, which leads to a singular (unhelpful) error message `Cannot compile interactive.effekt`. It would be more helpful for the user to see the cause.

https://github.com/effekt-lang/effekt/blob/8abbff5c34d71f8d3396c9db4b75ad6fdb16a4f5/effekt/js/src/main/scala/effekt/LanguageServer.scala#L101-L112

In line 103 this exception is thrown. Notice that the following line attempt to catch a `FatalPhaseError`, however `mainOutputPath` is a string and thus not lazily evaluated. Furthermore, `Phase.apply` already catches `FatalPhaseError`s and converts them to `None`. Hence, the exception handler is never executed.

Instead, we report all collected error messages.

Before:
![image](https://github.com/user-attachments/assets/26ee6ae5-c20f-4c16-ba7f-3f4b20058934)

After:
<img width="1254" alt="image" src="https://github.com/user-attachments/assets/5fabe8c4-5776-44ba-8fe8-7ecce575184a" />

(the increased resolution is not part of this PR)