### PR TITLE
Try to fix #926 by providing more information about type variable origins 

### DIFF
--- a/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ConcreteEffects.scala
@@ -92,7 +92,14 @@ private[typer] def assertConcreteEffect(eff: InterfaceType)(using C: Context): U
 private[typer] def assertConcreteFunction(id: source.Id, tpe: BlockType)(using C: Context): Unit =
   unknowns(tpe) match {
     case us if us.nonEmpty =>
-      C.abort(pretty"Cannot fully infer type for ${id}: ${tpe}")
+      val stuckUnificationVars = us.collect {
+        case UnificationVar(underlying, callTree) => pp"${underlying} from ${callTree}" // TODO: get symbol here, ideally print the typevars like `Failure[T, E]`?
+      }.mkString(", ")
+      if (stuckUnificationVars.isEmpty) {
+        C.abort(pretty"Cannot fully infer type for ${id}: ${tpe}")
+      } else {
+        C.abort(pretty"Cannot fully infer type for ${id}: ${tpe}, because the following type variables are ambiguous: ${stuckUnificationVars}")
+      }
     case _ => ()
   }
 

--- a/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
@@ -208,7 +208,10 @@ class Constraints(
     types.foreach {
       case x @ UnificationVar(underlying, callTree) =>
         if (!typeSubstitution.isDefinedAt(getNode(x))) C.at(callTree) {
-          C.error(s"Cannot infer type argument ${underlying}, maybe consider annotating it?")
+          val callName = callTree match
+            case call: source.Call => pp" of ${call.target}" // TODO: get symbol here, ideally print the typevars like `Failure[T, E]`
+            case _ => ""
+          C.error(pp"Cannot infer type argument ${underlying}${callName}, maybe consider annotating it?")
         }
     }
 


### PR DESCRIPTION
I quickly hacked together a prototype of a way to resolve #926.
Please, feel free to assign yourself and clean this up. :)

Example:

```scala
type Result[T, E] {
  Success(value: T)
  Failure(errors: List[E])
}

def addError[T, E](result: Result[T, E], e: E) =
  result match {
    case Success(value)  => Failure([e])
    case Failure(errors) => Failure(Cons(e, errors))
  }

def main() = ()
```

now reports:

```scala
[error] ambig.effekt:6:1: Cannot fully infer type for addError: [T, E](Result[T, E], E) => Result[T, E], because the following type variables are ambiguous: T from Call(IdTarget(IdRef(List(),Failure)),List(),List(Call(IdTarget(IdRef(List(),Cons)),List(),List(Var(IdRef(List(),e)), Call(IdTarget(IdRef(List(),Nil)),List(),List(),List())),List())),List())
def addError[T, E](result: Result[T, E], e: E) =
^
[error] ambig.effekt:8:29: Cannot infer type argument T of IdTarget(IdRef(List(),Failure)), maybe consider annotating it?
    case Success(value)  => Failure([e])
                            ^^^^^^^^^^^^
[error] ambig.effekt:9:29: Cannot infer type argument T of IdTarget(IdRef(List(),Failure)), maybe consider annotating it?
    case Failure(errors) => Failure(Cons(e, errors))
                            ^^^^^^^^^^^^^^^^^^^^^^^^
```

---

What I'd reasonably want it to report is:
```scala
[error] ambig.effekt:6:1: Cannot fully infer type for addError: [T, E](Result[T, E], E) => Result[T, E], because the following type variables are ambiguous: T from Failure[T, E]
def addError[T, E](result: Result[T, E], e: E) =
^
[error] ambig.effekt:8:29: Cannot infer type argument T of Failure[T, E], maybe consider annotating it?
    case Success(value)  => Failure([e])
                            ^^^^^^^^^^^^
[error] ambig.effekt:9:29: Cannot infer type argument T of Failure[T, E], maybe consider annotating it?
    case Failure(errors) => Failure(Cons(e, errors))
                            ^^^^^^^^^^^^^^^^^^^^^^^^
```

My ideal error message would be:
```scala
[error] ambig.effekt:6:1: Cannot fully infer type for addError: [T, E](Result[T, E], E) => Result[T, E], because of ambiguous type arguments.
def addError[T, E](result: Result[T, E], e: E) =
^
    [note] ambig.effekt:8:29: Cannot infer type argument T of Failure[T, E] used here, consider annotating it.
        case Success(value)  => Failure([e])
                                ^^^^^^^^^^^^
    [note] ambig.effekt:9:29: Cannot infer type argument T of Failure[T, E] used here, consider annotating it.
        case Failure(errors) => Failure(Cons(e, errors))
                                ^^^^^^^^^^^^^^^^^^^^^^^^
```

---

TODOs:

- [ ] get symbol from the call tree to pretty-print origin of the type variable
- [ ] clean up