### PR TITLE
Add a CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: "If you use this work, please the 'Effects as capabilities' paper linked below."
+preferred-citation:
+  type: article
+  authors:
+    - family-names: "Brachthäuser"
+      given-names: "Jonathan Immanuel"
+      orcid: "https://orcid.org/0000-0001-9128-0391"
+    - family-names: "Schuster"
+      given-names: "Philipp"
+      orcid: "https://orcid.org/0000-0001-8011-0506"
+    - family-names: "Ostermann"
+      given-names: "Klaus"
+      orcid: https://orcid.org/0000-0001-5294-5506
+  title: "Effects as capabilities: effect handlers and lightweight effect polymorphism"
+  doi: "10.1145/3428194"
+  journal: "Proc. ACM Program. Lang."
+  publisher: "Association for Computing Machinery"
+  volume: "4"
+  issue: "OOPSLA"
+  month: 11
+  year: 2020
+  url: "https://doi.org/10.1145/3428194"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you use this work, please the 'Effects as capabilities' paper linked below."
+message: "If you use this work, please cite the 'Effects as capabilities' paper."
 preferred-citation:
   type: article
   authors:


### PR DESCRIPTION
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files for more details

Here's how it looks on a test repo:
<img width="419" alt="Screenshot 2025-04-16 at 14 47 23" src="https://github.com/user-attachments/assets/fb96487e-0eae-4d9b-999e-0819aa5a8ef2" />

and here's the generated BibTeX file as-is:
```BibTeX
@article{Brachthauser_Effects_as_capabilities_2020,
author = {Brachthäuser, Jonathan Immanuel and Schuster, Philipp and Ostermann, Klaus},
doi = {10.1145/3428194},
journal = {Proc. ACM Program. Lang.},
month = nov,
number = {OOPSLA},
title = {{Effects as capabilities: effect handlers and lightweight effect polymorphism}},
url = {https://doi.org/10.1145/3428194},
volume = {4},
year = {2020}
}
```

As an alternative, GitHub also seems to suggest [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files#other-citation-files) that we could just add a `.bib` file directly.