### PR TITLE
Simplify core.Renamer to produce smaller symbols

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/CoreTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/CoreTests.scala
@@ -46,14 +46,14 @@ trait CoreTests extends munit.FunSuite {
                             expected: ModuleDecl,
                             clue: => Any = "values are not alpha-equivalent",
                             names: Names = Names(defaultNames))(using Location): Unit = {
-    val renamer = Renamer(names, "$")
+    val renamer = TestRenamer(names, "$")
     shouldBeEqual(renamer(obtained), renamer(expected), clue)
   }
   def assertAlphaEquivalentStatements(obtained: Stmt,
                             expected: Stmt,
                             clue: => Any = "values are not alpha-equivalent",
                             names: Names = Names(defaultNames))(using Location): Unit = {
-    val renamer = Renamer(names, "$")
+    val renamer = TestRenamer(names, "$")
     shouldBeEqual(renamer(obtained), renamer(expected), clue)
   }
   def parse(input: String,

--- a/effekt/jvm/src/test/scala/effekt/core/OptimizerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/OptimizerTests.scala
@@ -22,7 +22,7 @@ class OptimizerTests extends CoreTests {
     val pExpected = parse(moduleHeader + transformed, "expected", names)
 
     // the parser is not assigning symbols correctly, so we need to run renamer first
-    val renamed = Renamer(names).rewrite(pInput)
+    val renamed = TestRenamer(names).rewrite(pInput)
 
     val obtained = transform(renamed)
     assertAlphaEquivalent(obtained, pExpected, "Not transformed to")

--- a/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
@@ -5,15 +5,16 @@ package effekt.core
  */
 class RenamerTests extends CoreTests {
 
-  def assertRenamedTo(input: String,
-                      renamed: String,
-                      clue: => Any = "Not renamed to given value",
-                      names: Names = Names(defaultNames))(using munit.Location) = {
+  /**
+   * Check that the renamed input preserves alpha-equivalence using [[assertAlphaEquivalent]]
+   */
+  def assertRenamingPreservesAlpha(input: String,
+                                   clue: => Any = "Not renamed to given value",
+                                   names: Names = Names(defaultNames))(using munit.Location) = {
     val pInput = parse(input, "input", names)
-    val pExpected = parse(renamed, "expected", names)
     val renamer = new Renamer(names, "renamed")
     val obtained = renamer(pInput)
-    assertAlphaEquivalent(obtained, pExpected, clue)
+    assertAlphaEquivalent(obtained, pInput, clue)
   }
 
   test("No bound local variables"){
@@ -24,11 +25,11 @@ class RenamerTests extends CoreTests {
         |  return (bar: (Int) => Int @ {})(baz:Int)
         |}
         |""".stripMargin
-    assertRenamedTo(code, code)
+    assertRenamingPreservesAlpha(code)
   }
 
   test("val binding"){
-    val input =
+    val code =
       """module main
         |
         |def foo = { () =>
@@ -36,19 +37,11 @@ class RenamerTests extends CoreTests {
         |  return x:Int
         |}
         |""".stripMargin
-    val expected =
-      """module main
-        |
-        |def foo = { () =>
-        |  val renamed1 = (foo:(Int)=>Int@{})(4);
-        |  return renamed1:Int
-        |}
-        |""".stripMargin
-    assertRenamedTo(input, expected)
+    assertRenamingPreservesAlpha(code)
   }
 
   test("var binding"){
-    val input =
+    val code =
       """module main
         |
         |def foo = { () =>
@@ -56,37 +49,22 @@ class RenamerTests extends CoreTests {
         |  return x:Int
         |}
         |""".stripMargin
-    val expected =
-      """module main
-        |
-        |def foo = { () =>
-        |  var renamed1 @ global = (foo:(Int)=>Int@{})(4);
-        |  return renamed1:Int
-        |}
-        |""".stripMargin
-    assertRenamedTo(input, expected)
+    assertRenamingPreservesAlpha(code)
   }
 
   test("function (value) parameters"){
-    val input =
+    val code =
       """module main
         |
         |def foo = { (x:Int) =>
         |  return x:Int
         |}
         |""".stripMargin
-    val expected =
-      """module main
-        |
-        |def foo = { (renamed1:Int) =>
-        |  return renamed1:Int
-        |}
-        |""".stripMargin
-    assertRenamedTo(input, expected)
+    assertRenamingPreservesAlpha(code)
   }
 
   test("match clauses"){
-    val input =
+    val code =
       """module main
         |
         |type Data { X(a:Int, b:Int) }
@@ -96,39 +74,22 @@ class RenamerTests extends CoreTests {
         |  }
         |}
         |""".stripMargin
-    val expected =
-        """module main
-          |
-          |type Data { X(a:Int, b:Int) }
-          |def foo = { () =>
-          |  12 match {
-          |    X : {(renamed1:Int, renamed2:Int) => return renamed1:Int }
-          |  }
-          |}
-          |""".stripMargin
-    assertRenamedTo(input, expected)
+    assertRenamingPreservesAlpha(code)
   }
 
   test("type parameters"){
-    val input =
+    val code =
       """module main
         |
         |def foo = { ['A](a: A) =>
         |  return a:Identity[A]
         |}
         |""".stripMargin
-    val expected =
-      """module main
-        |
-        |def foo = { ['renamed1](renamed2: renamed1) =>
-        |  return renamed2:Identity[renamed1]
-        |}
-        |""".stripMargin
-    assertRenamedTo(input, expected)
+    assertRenamingPreservesAlpha(code)
   }
 
   test("pseudo recursive"){
-    val input =
+    val code =
       """ module main
         |
         | def bar = { () => return 1 }
@@ -138,22 +99,10 @@ class RenamerTests extends CoreTests {
         |   (foo : () => Unit @ {})()
         | }
         |""".stripMargin
-
-    val expected =
-      """ module main
-        |
-        | def bar = { () => return 1 }
-        | def main = { () =>
-        |   def renamed1 = { () => (bar : () => Unit @ {})() }
-        |   def renamed2 = { () => return 2 }
-        |   (renamed1 : () => Unit @ {})()
-        | }
-        |""".stripMargin
-
-    assertRenamedTo(input, expected)
+    assertRenamingPreservesAlpha(code)
   }
   test("shadowing let bindings"){
-    val input =
+    val code =
       """ module main
         |
         | def main = { () =>
@@ -162,17 +111,6 @@ class RenamerTests extends CoreTests {
         |   return x:Int
         | }
         |""".stripMargin
-
-    val expected =
-      """ module main
-        |
-        | def main = { () =>
-        |   let renamed1 = 1
-        |   let renamed2 = 2
-        |   return renamed2:Int
-        | }
-        |""".stripMargin
-
-    assertRenamedTo(input, expected)
+    assertRenamingPreservesAlpha(code)
   }
 }

--- a/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
@@ -1,9 +1,9 @@
 package effekt.core
 
 /**
- * This is testing the test/core.TestRenamer, not the main/core.Renamer :)
+ * This is testing the main/core.Renamer using the test/core.TestRenamer.
  */
-class TestRenamerTests extends CoreTests {
+class RenamerTests extends CoreTests {
 
   def assertRenamedTo(input: String,
                       renamed: String,
@@ -11,9 +11,9 @@ class TestRenamerTests extends CoreTests {
                       names: Names = Names(defaultNames))(using munit.Location) = {
     val pInput = parse(input, "input", names)
     val pExpected = parse(renamed, "expected", names)
-    val renamer = new TestRenamer(names, "renamed") // use "renamed" as prefix so we can refer to it
+    val renamer = new Renamer(names, "renamed")
     val obtained = renamer(pInput)
-    shouldBeEqual(obtained, pExpected, clue)
+    assertAlphaEquivalent(obtained, pExpected, clue)
   }
 
   test("No bound local variables"){

--- a/effekt/jvm/src/test/scala/effekt/core/TestRenamer.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/TestRenamer.scala
@@ -1,0 +1,120 @@
+package effekt.core
+
+import effekt.{ core, symbols }
+import effekt.context.Context
+
+/**
+ * Freshens bound names in a given term for tests.
+ * Please use this _only_ for tests.
+ *
+ * @param names used to look up a reference by name to resolve to the same symbols.
+ *              This is only used by tests to deterministically rename terms and check for
+ *              alpha-equivalence.
+ * @param prefix if the prefix is empty, the original name will be used as a prefix
+ *
+ * @param C the context is used to copy annotations from old symbols to fresh symbols
+ */
+class TestRenamer(names: Names = Names(Map.empty), prefix: String = "") extends core.Tree.Rewrite {
+
+  // list of scopes that map bound symbols to their renamed variants.
+  private var scopes: List[Map[Id, Id]] = List.empty
+
+  // Here we track ALL renamings
+  var renamed: Map[Id, Id] = Map.empty
+
+  private var suffix: Int = 0
+
+  def freshIdFor(id: Id): Id =
+    suffix = suffix + 1
+    val uniqueName = if prefix.isEmpty then id.name.name + "_" + suffix.toString else prefix + suffix.toString
+    names.idFor(uniqueName)
+
+  def withBindings[R](ids: List[Id])(f: => R): R =
+    val before = scopes
+    try {
+      val newScope = ids.map { x => x -> freshIdFor(x) }.toMap
+      scopes = newScope :: scopes
+      renamed = renamed ++ newScope
+      f
+    } finally { scopes = before }
+
+  /** Alias for withBindings(List(id)){...} */
+  def withBinding[R](id: Id)(f: => R): R = withBindings(List(id))(f)
+
+  // free variables are left untouched
+  override def id: PartialFunction[core.Id, core.Id] = {
+    case id => scopes.collectFirst {
+      case bnds if bnds.contains(id) => bnds(id)
+    }.getOrElse(id)
+  }
+
+  override def stmt: PartialFunction[Stmt, Stmt] = {
+    case core.Def(id, block, body) =>
+      // can be recursive
+      withBinding(id) { core.Def(rewrite(id), rewrite(block), rewrite(body)) }
+
+    case core.Let(id, tpe, binding, body) =>
+      val resolvedBinding = rewrite(binding)
+      withBinding(id) { core.Let(rewrite(id), rewrite(tpe), resolvedBinding, rewrite(body)) }
+
+    case core.Val(id, tpe, binding, body) =>
+      val resolvedBinding = rewrite(binding)
+      withBinding(id) { core.Val(rewrite(id), rewrite(tpe), resolvedBinding, rewrite(body)) }
+
+    case core.Alloc(id, init, reg, body) =>
+      val resolvedInit = rewrite(init)
+      val resolvedReg = rewrite(reg)
+      withBinding(id) { core.Alloc(rewrite(id), resolvedInit, resolvedReg, rewrite(body)) }
+
+    case core.Var(ref, init, capt, body) =>
+      val resolvedInit = rewrite(init)
+      val resolvedCapt = rewrite(capt)
+      withBinding(ref) { core.Var(rewrite(ref), resolvedInit, resolvedCapt, rewrite(body)) }
+
+    case core.Get(id, tpe, ref, capt, body) =>
+      val resolvedRef = rewrite(ref)
+      val resolvedCapt = rewrite(capt)
+      withBinding(id) { core.Get(rewrite(id), rewrite(tpe), resolvedRef, resolvedCapt, rewrite(body)) }
+
+  }
+
+  override def block: PartialFunction[Block, Block] = {
+    case Block.BlockLit(tparams, cparams, vparams, bparams, body) =>
+      withBindings(tparams ++ cparams ++ vparams.map(_.id) ++ bparams.map(_.id)) {
+        Block.BlockLit(tparams map rewrite, cparams map rewrite, vparams map rewrite, bparams map rewrite,
+          rewrite(body))
+      }
+  }
+
+  override def rewrite(o: Operation): Operation = o match {
+    case Operation(name, tparams, cparams, vparams, bparams, body) =>
+      withBindings(tparams ++ cparams ++ vparams.map(_.id) ++ bparams.map(_.id)) {
+        Operation(name,
+          tparams map rewrite,
+          cparams map rewrite,
+          vparams map rewrite,
+          bparams map rewrite,
+          rewrite(body))
+      }
+  }
+
+  def apply(m: core.ModuleDecl): core.ModuleDecl =
+    suffix = 0
+    m match {
+      case core.ModuleDecl(path, includes, declarations, externs, definitions, exports) =>
+        core.ModuleDecl(path, includes, declarations, externs, definitions map rewrite, exports)
+    }
+
+  def apply(s: Stmt): Stmt = {
+    suffix = 0
+    rewrite(s)
+  }
+}
+
+object TestRenamer {
+  def rename(b: Block): Block = Renamer().rewrite(b)
+  def rename(b: BlockLit): (BlockLit, Map[Id, Id]) =
+    val renamer = Renamer()
+    val res = renamer.rewrite(b)
+    (res, renamer.renamed)
+}

--- a/effekt/jvm/src/test/scala/effekt/core/TestRenamer.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/TestRenamer.scala
@@ -5,7 +5,7 @@ import effekt.context.Context
 
 /**
  * Freshens bound names in a given term for tests.
- * Please use this _only_ for tests.
+ * Please use this _only_ for tests. Otherwise, prefer [[effekt.core.Renamer]].
  *
  * @param names used to look up a reference by name to resolve to the same symbols.
  *              This is only used by tests to deterministically rename terms and check for

--- a/effekt/jvm/src/test/scala/effekt/core/TestRenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/TestRenamerTests.scala
@@ -2,6 +2,7 @@ package effekt.core
 
 /**
  * This is testing the test/core.TestRenamer, not the main/core.Renamer :)
+ * These tests are important, because we use TestRenamer for deciding test-friendly alpha-equivalence in CoreTests.
  */
 class TestRenamerTests extends CoreTests {
 

--- a/effekt/jvm/src/test/scala/effekt/core/TestRenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/TestRenamerTests.scala
@@ -1,7 +1,7 @@
 package effekt.core
 import effekt.symbols
 
-class RenamerTests extends CoreTests {
+class TestRenamerTests extends CoreTests {
 
   def assertRenamedTo(input: String,
                       renamed: String,
@@ -9,7 +9,7 @@ class RenamerTests extends CoreTests {
                       names: Names = Names(defaultNames))(using munit.Location) = {
     val pInput = parse(input, "input", names)
     val pExpected = parse(renamed, "expected", names)
-    val renamer = new Renamer(names, "renamed") // use "renamed" as prefix so we can refer to it
+    val renamer = new TestRenamer(names, "renamed") // use "renamed" as prefix so we can refer to it
     val obtained = renamer(pInput)
     shouldBeEqual(obtained, pExpected, clue)
   }

--- a/effekt/shared/src/main/scala/effekt/core/Renamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Renamer.scala
@@ -5,7 +5,7 @@ import effekt.context.Context
 
 /**
  * Freshens bound names in a given Core term.
- * Do not use for tests!
+ * Do not use for tests! See [[effekt.core.TestRenamer]].
  *
  * @param names used to look up a reference by name to resolve to the same symbols.
  *              This is only used by tests to deterministically rename terms and check for

--- a/effekt/shared/src/main/scala/effekt/core/Renamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Renamer.scala
@@ -4,7 +4,8 @@ import effekt.{ core, symbols }
 import effekt.context.Context
 
 /**
- * Freshens bound names in a given term
+ * Freshens bound names in a given Core term.
+ * Do not use for tests!
  *
  * @param names used to look up a reference by name to resolve to the same symbols.
  *              This is only used by tests to deterministically rename terms and check for

--- a/effekt/shared/src/main/scala/effekt/core/Renamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Renamer.scala
@@ -21,12 +21,8 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
   // Here we track ALL renamings
   var renamed: Map[Id, Id] = Map.empty
 
-  private var suffix: Int = 0
-
   def freshIdFor(id: Id): Id =
-    suffix = suffix + 1
-    val uniqueName = if prefix.isEmpty then id.name.name + "_" + suffix.toString else prefix + suffix.toString
-    names.idFor(uniqueName)
+    if prefix.isEmpty then Id(id) else Id(id.name.rename { _current => prefix })
 
   def withBindings[R](ids: List[Id])(f: => R): R =
     val before = scopes
@@ -98,14 +94,12 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
   }
 
   def apply(m: core.ModuleDecl): core.ModuleDecl =
-    suffix = 0
     m match {
       case core.ModuleDecl(path, includes, declarations, externs, definitions, exports) =>
         core.ModuleDecl(path, includes, declarations, externs, definitions map rewrite, exports)
     }
 
   def apply(s: Stmt): Stmt = {
-    suffix = 0
     rewrite(s)
   }
 }

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -91,10 +91,11 @@ sealed trait Tree extends Product {
  */
 type Id = symbols.Symbol
 object Id {
-  def apply(n: String): Id = new symbols.Symbol {
-    val name = symbols.Name.local(n)
+  def apply(n: symbols.Name): Id = new symbols.Symbol {
+    val name = n
   }
-  def apply(n: Id): Id = apply(n.name.name)
+  def apply(n: String): Id = apply(symbols.Name.local(n))
+  def apply(n: Id): Id = apply(n.name)
 }
 
 /**

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/StaticArguments.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/StaticArguments.scala
@@ -91,7 +91,8 @@ object StaticArguments {
     // the worker now closes over the static block arguments (`c` in the example above):
     val newCapture = blockLit.capt ++ selectStatic(staticB, freshCparams).toSet
 
-    val workerVar: Block.BlockVar = BlockVar(Id(id.name.name + "_worker"), workerType, newCapture)
+    val workerId = Id(id.name.rename { original => s"${original}_worker"})
+    val workerVar: Block.BlockVar = BlockVar(workerId, workerType, newCapture)
     ctx.workers(id) = workerVar
 
     BlockLit(

--- a/effekt/shared/src/main/scala/effekt/symbols/Symbol.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/Symbol.scala
@@ -38,7 +38,7 @@ trait Symbol {
     case _             => false
   }
 
-  def show: String = name.toString + id
+  def show: String = s"${name}_${id}"
 
   override def toString: String = name.toString
 }

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -211,8 +211,8 @@ case class CallTarget(symbols: List[Set[BlockSymbol]]) extends BlockSymbol { val
  * Introduced by Transformer
  */
 case class Wildcard() extends ValueSymbol { val name = Name.local("_") }
-case class TmpValue(hint: String = "tmp") extends ValueSymbol { val name = Name.local("v_" + hint + "_" + Symbol.fresh.next()) }
-case class TmpBlock(hint: String = "tmp") extends BlockSymbol { val name = Name.local("b_" + hint + "_" + Symbol.fresh.next()) }
+case class TmpValue(hint: String = "tmp") extends ValueSymbol { val name = Name.local("v_" + hint) }
+case class TmpBlock(hint: String = "tmp") extends BlockSymbol { val name = Name.local("b_" + hint) }
 
 /**
  * Type Symbols

--- a/effekt/shared/src/main/scala/effekt/util/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/util/PrettyPrinter.scala
@@ -16,7 +16,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def format(value: Any): Document = pretty(toDoc(value), 80)
 
   def toDoc(value: Any): Doc = value match {
-    case sym: effekt.symbols.Symbol => string(sym.name.name + "_" + sym.id.toString)
+    case sym: effekt.symbols.Symbol => string(sym.show)
     case Nil => "Nil"
     case l: List[a] => "List" <> parens(l.map(toDoc))
     case l: Map[a, b] => "Map" <> parens(l.map {


### PR DESCRIPTION
General idea: instead of building `name_123_109238_190238_109283019283_1092830192838019283` chains, what if we use the automagic `fresh.next` to get just a darn fresh number?
This will limit the identifiers to stuff like `b_k2_123_10928310283`, which is--at least to me--a pretty big improvement.

We use the full capabilities of a `Symbol`: it has a `name` (which is really a `String`) and a fresh `id` that gets assigned lazily. Instead of changing the name to be `${oldName}_${oldId}` and then putting a fresh `id` on top of that (to get `${oldName}_${oldId}_${newId}`), we just make a new `Symbol` with the same name, which forces a new, _fresher_, `id`.