### PR TITLE
Don't reallocate StringBuffer when flushing

### DIFF
--- a/examples/stdlib/stringbuffer.check
+++ b/examples/stdlib/stringbuffer.check
@@ -1,0 +1,3 @@
+hello, world
+
+Effekt = Effekt

--- a/examples/stdlib/stringbuffer.effekt
+++ b/examples/stdlib/stringbuffer.effekt
@@ -1,0 +1,3 @@
+import stringbuffer
+
+def main() = stringbuffer::examples::main()

--- a/libraries/common/stringbuffer.effekt
+++ b/libraries/common/stringbuffer.effekt
@@ -35,10 +35,11 @@ def stringBuffer[A] { prog: => A / StringBuffer }: A = {
       resume(())
     }
     def flush() = {
-      // resize buffer to strip trailing zeros that otherwise would be converted into 0x00 characters
+      // resize (& copy) buffer to strip trailing zeros that otherwise would be converted into 0x00 characters
       val str = bytearray::resize(buffer, pos).toString()
-      // after flushing, the stringbuffer should be empty again
-      buffer = bytearray::allocate(initialCapacity)
+      // NOTE: Keep the `buffer` as-is (no wipe, no realloc),
+      //       just reset the `pos` in case we want to use it again.
+      pos = 0
       resume(str)
     }
   }

--- a/libraries/common/stringbuffer.effekt
+++ b/libraries/common/stringbuffer.effekt
@@ -56,11 +56,22 @@ def s { prog: () => Unit / { literal, splice[String] } }: String =
 namespace examples {
   def main() = {
     with stringBuffer
+
     do write("hello")
     do write(", world")
     // prints `hello, world`
     println(do flush())
+
     // prints the empty string
+    println(do flush())
+
+    do write("Ef")
+    do write("fe")
+    do write("kt")
+    do write(" = ")
+    do write("")
+    do write("Effekt")
+    // prints `Effekt = Effekt`
     println(do flush())
   }
 }


### PR DESCRIPTION
I think that the allocation here is not needed, so I'd like to avoid it.