### PR TITLE
Make 'core.Renamer' quicker by simplifying scope handling

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
@@ -113,4 +113,23 @@ class RenamerTests extends CoreTests {
         |""".stripMargin
     assertRenamingPreservesAlpha(code)
   }
+  test("shadowing let bindings inside a def") {
+    val code =
+      """ module main
+        |
+        | def main = { () =>
+        |   def foo = { () =>
+        |     let x = 1
+        |     return x: Int
+        |   }
+        |   let x = 2
+        |   def bar = { () =>
+        |     let x = 3
+        |     return x: Int
+        |   }
+        |   return x:Int
+        | }
+        |""".stripMargin
+    assertRenamingPreservesAlpha(code)
+  }
 }

--- a/effekt/jvm/src/test/scala/effekt/core/TestRenamer.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/TestRenamer.scala
@@ -110,11 +110,3 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "") extends 
     rewrite(s)
   }
 }
-
-object TestRenamer {
-  def rename(b: Block): Block = Renamer().rewrite(b)
-  def rename(b: BlockLit): (BlockLit, Map[Id, Id]) =
-    val renamer = Renamer()
-    val res = renamer.rewrite(b)
-    (res, renamer.renamed)
-}

--- a/effekt/shared/src/main/scala/effekt/core/Renamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Renamer.scala
@@ -27,13 +27,16 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
     if prefix.isEmpty then Id(id) else Id(id.name.rename { _current => prefix })
 
   def withBindings[R](ids: List[Id])(f: => R): R =
-    val before = scope
+    val scopeBefore = scope
     try {
-      val newScope = ids.map { x => x -> freshIdFor(x) }.toMap
-      scope = scope ++ newScope
-      renamed.addAll(newScope)
+      ids.foreach { x =>
+        val fresh = freshIdFor(x)
+        scope = scope + (x -> fresh)
+        renamed.put(x, fresh)
+      }
+
       f
-    } finally { scope = before }
+    } finally { scope = scopeBefore }
 
   /** Alias for withBindings(List(id)){...} */
   def withBinding[R](id: Id)(f: => R): R = withBindings(List(id))(f)

--- a/effekt/shared/src/main/scala/effekt/core/Renamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Renamer.scala
@@ -1,7 +1,8 @@
 package effekt.core
 
+import scala.collection.mutable
+
 import effekt.{ core, symbols }
-import effekt.context.Context
 
 /**
  * Freshens bound names in a given Core term.
@@ -20,7 +21,7 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
   private var scope: Map[Id, Id] = Map.empty
 
   // All renamings: map of bound symbols to their renamed variants, globally!
-  var renamed: Map[Id, Id] = Map.empty
+  val renamed: mutable.HashMap[Id, Id] = mutable.HashMap.empty
 
   def freshIdFor(id: Id): Id =
     if prefix.isEmpty then Id(id) else Id(id.name.rename { _current => prefix })
@@ -30,7 +31,7 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
     try {
       val newScope = ids.map { x => x -> freshIdFor(x) }.toMap
       scope = scope ++ newScope
-      renamed = renamed ++ newScope
+      renamed.addAll(newScope)
       f
     } finally { scope = before }
 
@@ -105,7 +106,7 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
 
 object Renamer {
   def rename(b: Block): Block = Renamer().rewrite(b)
-  def rename(b: BlockLit): (BlockLit, Map[Id, Id]) =
+  def rename(b: BlockLit): (BlockLit, mutable.HashMap[Id, Id]) =
     val renamer = Renamer()
     val res = renamer.rewrite(b)
     (res, renamer.renamed)


### PR DESCRIPTION
I don't know what the nested list is for, but we don't seem to use it anywhere. Therefore I'm removing the nesting and using mutable hashmaps: it's on a hot path!

Renamer then goes from 2.4-3.4s to 0.6-0.4s :) [measured a few times via profiling]
(for reference, before #938, it was somewhere between 3 and 4 seconds)