### PR TITLE
Renamer: Add infrastructure for Checking Uniqueness of Generated Names

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
@@ -63,7 +63,7 @@ class RenamerTests extends CoreTests {
         }
       }
     }
-    check.query(pInput)
+    check.query(obtained)
   }
 
   test("No bound local variables"){

--- a/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
@@ -31,7 +31,6 @@ class RenamerTests extends CoreTests {
       assert(!seen.contains(id), clue)
       seen.add(id)
     }
-    given Unit = ()
     object check extends Tree.Query[Unit, Unit] {
       override def empty = ()
       override def combine = (_,_) => ()
@@ -63,7 +62,7 @@ class RenamerTests extends CoreTests {
         }
       }
     }
-    check.query(obtained)
+    check.query(obtained)(using ())
   }
 
   test("No bound local variables"){

--- a/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/RenamerTests.scala
@@ -75,6 +75,7 @@ class RenamerTests extends CoreTests {
         |}
         |""".stripMargin
     assertRenamingPreservesAlpha(code)
+    assertRenamingMakesDefsUnique(code)
   }
 
   test("val binding"){
@@ -87,6 +88,7 @@ class RenamerTests extends CoreTests {
         |}
         |""".stripMargin
     assertRenamingPreservesAlpha(code)
+    assertRenamingMakesDefsUnique(code)
   }
 
   test("var binding"){
@@ -99,6 +101,7 @@ class RenamerTests extends CoreTests {
         |}
         |""".stripMargin
     assertRenamingPreservesAlpha(code)
+    assertRenamingMakesDefsUnique(code)
   }
 
   test("function (value) parameters"){
@@ -110,6 +113,7 @@ class RenamerTests extends CoreTests {
         |}
         |""".stripMargin
     assertRenamingPreservesAlpha(code)
+    assertRenamingMakesDefsUnique(code)
   }
 
   test("match clauses"){
@@ -124,6 +128,7 @@ class RenamerTests extends CoreTests {
         |}
         |""".stripMargin
     assertRenamingPreservesAlpha(code)
+    assertRenamingMakesDefsUnique(code)
   }
 
   test("type parameters"){
@@ -135,6 +140,7 @@ class RenamerTests extends CoreTests {
         |}
         |""".stripMargin
     assertRenamingPreservesAlpha(code)
+    assertRenamingMakesDefsUnique(code)
   }
 
   test("pseudo recursive"){
@@ -149,6 +155,7 @@ class RenamerTests extends CoreTests {
         | }
         |""".stripMargin
     assertRenamingPreservesAlpha(code)
+    assertRenamingMakesDefsUnique(code)
   }
   test("shadowing let bindings"){
     val code =

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -432,6 +432,7 @@ object Tree {
         case (id, lit) => query(lit)
     }
     def query(b: ExternBody)(using Ctx): Res = structuralQuery(b, externBody)
+    def query(m: ModuleDecl)(using Ctx) = structuralQuery(m, PartialFunction.empty)
   }
 
   class Rewrite extends Structural {


### PR DESCRIPTION
After #938, the `RenamerTests` do not check that the names are actually unique.
This adds assertions checking that every `Id` only occurs in one definition-like construct.

(note that https://github.com/effekt-lang/effekt/pull/941/commits/4cf23710d2c4be2202a73d888e19d4df1ddf1645 is intentionally wrong to show it failing on shadowing :) )