### PR TITLE
LLVM: Emit most declared definitions as private

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/PrettyPrinter.scala
@@ -12,9 +12,9 @@ object PrettyPrinter {
     definitions.map(show).mkString("\n\n")
 
   def show(definition: Definition)(using C: Context): LLVMString = definition match {
-    case Function(callingConvention, returnType, name, parameters, basicBlocks) =>
+    case Function(linkage, callingConvention, returnType, name, parameters, basicBlocks) =>
       s"""
-define ${show(callingConvention)} ${show(returnType)} ${globalName(name)}(${commaSeparated(parameters.map(show))}) {
+define ${show(linkage)} ${show(callingConvention)} ${show(returnType)} ${globalName(name)}(${commaSeparated(parameters.map(show))}) {
     ${indentedLines(basicBlocks.map(show).mkString)}
 }
 """
@@ -36,6 +36,11 @@ define ${show(callingConvention)} ${show(returnType)} ${globalName(name)}(${comm
 
     case GlobalConstant(name, initializer) =>
       s"@$name = private constant ${show(initializer)}"
+  }
+
+  def show(linkage: Linkage): LLVMString = linkage match {
+    case External() => "external"
+    case Private() => "private"
   }
 
   def show(callingConvention: CallingConvention): LLVMString = callingConvention match {

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -25,7 +25,7 @@ object Transformer {
         Call("stack", Ccc(), stackType, withEmptyStack, List()),
         Call("_", Tailcc(false), VoidType(), transform(entry), List(LocalReference(stackType, "stack"))))
       val entryBlock = BasicBlock("entry", entryInstructions, RetVoid())
-      val entryFunction = Function(Ccc(), VoidType(), "effektMain", List(), List(entryBlock))
+      val entryFunction = Function(External(), Ccc(), VoidType(), "effektMain", List(), List(entryBlock))
 
       declarations.map(transform) ++ globals :+ entryFunction
   }
@@ -433,7 +433,7 @@ object Transformer {
     val instructions = BC.instructions; BC.instructions = null;
 
     val entryBlock = BasicBlock("entry", instructions, terminator);
-    val function = Function(Ccc(), VoidType(), name, parameters, entryBlock :: basicBlocks);
+    val function = Function(Private(), Ccc(), VoidType(), name, parameters, entryBlock :: basicBlocks);
 
     emit(function)
   }
@@ -448,7 +448,7 @@ object Transformer {
     val instructions = BC.instructions; BC.instructions = null;
 
     val entryBlock = BasicBlock("entry", instructions, terminator);
-    val function = Function(Tailcc(true), VoidType(), name, parameters :+ Parameter(stackType, "stack"), entryBlock :: basicBlocks);
+    val function = Function(Private(), Tailcc(true), VoidType(), name, parameters :+ Parameter(stackType, "stack"), entryBlock :: basicBlocks);
 
     emit(function)
   }

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Tree.scala
@@ -7,12 +7,18 @@ package llvm
  *  see: https://hackage.haskell.org/package/llvm-hs-pure-9.0.0/docs/LLVM-AST.html#t:Definition
  */
 enum Definition {
-  case Function(callingConvention: CallingConvention, returnType: Type, name: String, parameters: List[Parameter], basicBlocks: List[BasicBlock])
+  case Function(linkage: Linkage, callingConvention: CallingConvention, returnType: Type, name: String, parameters: List[Parameter], basicBlocks: List[BasicBlock])
   case VerbatimFunction(callingConvention: CallingConvention, returnType: Type, name: String, parameters: List[Parameter], body: String)
   case Verbatim(content: String)
   case GlobalConstant(name: String, initializer: Operand) // initializer should be constant
 }
 export Definition.*
+
+enum Linkage {
+  case External()
+  case Private()
+}
+export Linkage.*
 
 enum CallingConvention {
   case Ccc()


### PR DESCRIPTION
I was experimenting with making emitted function definitions `private` by default in llvm.

This seemed to only reduce the code size of our *.opt.ll files, which might not even be wanted, because now all the unused/inlined function definitions are gone.

Benchmarking this showed no improvement *except* for "examples/benchmarks/are_we_fast_yet/queens.effekt" which unexpectedly got 30% faster. Not sure what is going on