### PR TITLE
Cache substitutions

### DIFF
--- a/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
@@ -123,8 +123,12 @@ class Constraints(
   private var pendingInactive: Set[CNode] = Set.empty
 )(using C: ErrorReporter) {
 
+  /**
+   * Caches type substitutions, which are only invalidated if the mapping from node to typevar changes.
+   *
+   * This significantly improves the performance of Typer (see https://github.com/effekt-lang/effekt/pull/954)
+   */
   private var _typeSubstitution:  Map[TypeVar, ValueType] = _
-
   private def invalidate(): Unit = _typeSubstitution = null
 
   /**

--- a/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Constraints.scala
@@ -121,16 +121,22 @@ class Constraints(
    * Unification variables which are not in scope anymore, but also haven't been solved, yet.
    */
   private var pendingInactive: Set[CNode] = Set.empty
-
 )(using C: ErrorReporter) {
+
+  private var _substitutions: Substitutions = _
+
+  private def invalidate(): Unit = _substitutions = null
 
   /**
    * The currently known substitutions
    */
   def subst: Substitutions =
-    val types = classes.flatMap[TypeVar, ValueType] { case (k, v) => typeSubstitution.get(v).map { k -> _ } }
-    val captures = captSubstitution.asInstanceOf[Map[CaptVar, Captures]]
-    Substitutions(types, captures)
+    if _substitutions == null then {
+      val types = classes.flatMap[TypeVar, ValueType] { case (k, v) => typeSubstitution.get(v).map { k -> _ } }
+      val captures = captSubstitution.asInstanceOf[Map[CaptVar, Captures]]
+      _substitutions = Substitutions(types, captures)
+    }
+    _substitutions
 
   /**
    * Should only be called on unification variables where we do not know any types, yet
@@ -307,17 +313,22 @@ class Constraints(
     private [typer] def lowerNodes: Map[CNode, Filter] = getData(x).lowerNodes
     private [typer] def upperNodes: Map[CNode, Filter] = getData(x).upperNodes
     private def lower_=(bounds: Set[Capture]): Unit =
+      invalidate()
       captureConstraints = captureConstraints.updated(x, getData(x).copy(lower = Some(bounds)))
+
     private def upper_=(bounds: Set[Capture]): Unit =
+      invalidate()
       captureConstraints = captureConstraints.updated(x, getData(x).copy(upper = Some(bounds)))
+
     private def addLower(other: CNode, exclude: Filter): Unit =
       val oldData = getData(x)
 
       // compute the intersection of filters
       val oldFilter = oldData.lowerNodes.get(other)
       val newFilter = oldFilter.map { _ intersect exclude }.getOrElse { exclude }
-
+      invalidate()
       captureConstraints = captureConstraints.updated(x, oldData.copy(lowerNodes = oldData.lowerNodes + (other -> newFilter)))
+
     private def addUpper(other: CNode, exclude: Filter): Unit =
       val oldData = getData(x)
 
@@ -462,10 +473,11 @@ class Constraints(
    */
   private def updateSubstitution(): Unit =
     val substitution = subst
+    invalidate()
     typeSubstitution = typeSubstitution.map { case (node, tpe) => node -> substitution.substitute(tpe) }
 
   private def getNode(x: UnificationVar): Node =
-    classes.getOrElse(x, { val rep = new Node; classes += (x -> rep); rep })
+    classes.getOrElse(x, { val rep = new Node; invalidate(); classes += (x -> rep); rep })
 
   private def typeOf(n: Node): Option[ValueType] =
     typeSubstitution.get(n)

--- a/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Substitution.scala
@@ -31,12 +31,6 @@ case class Substitutions(
   }
   def get(x: CaptUnificationVar): Option[Captures] = captures.get(x)
 
-  // amounts to first substituting this, then other
-  def updateWith(other: Substitutions): Substitutions =
-    Substitutions(
-      values.view.mapValues { t => other.substitute(t) }.toMap,
-      captures.view.mapValues { t => other.substitute(t) }.toMap) ++ other
-
   // amounts to parallel substitution
   def ++(other: Substitutions): Substitutions = Substitutions(values ++ other.values, captures ++ other.captures)
 


### PR DESCRIPTION
Substitutions are used multiple times but computed over and over again. This PR caches them until any modification happens.

On my machine, this brings down typer from `1150ms` to `720ms` with 

```
effekt --time text examples/casestudies/anf.effekt.md
```

This shaves of 25% of the total compile time, which is reduced from 2.5s to 2s.