### PR TITLE
Add a fast, but ugly, pretty printer

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/js/FastPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/FastPrinter.scala
@@ -11,14 +11,31 @@ import scala.language.implicitConversions
 
 class FastPrinter {
 
-  var buffer = new StringBuffer()
-
   def pretty(stmt: List[Stmt]): Document =
     buffer = new StringBuffer()
-    stmt foreach { s => toDoc(s); emit("\n") }
+    stmt foreach { s => toDoc(s); line() }
     Document(buffer.toString, Nil)
 
+  // The `emit` effect
+  private var buffer = new StringBuffer()
+
   inline def emit(str: String): Unit = buffer.append(str)
+
+  // the `line` / `indent` effect
+  private var level = 0
+
+  private inline def indented[T](p: => T): T =
+    val before = level
+    level = level + 1
+    val res = p
+    level = before
+    res
+
+  private inline def indent(): Unit =
+    var i = 0
+    while (i < level) { emit("  "); i += 1 }
+
+  private inline def line(): Unit = { emit("\n"); indent() }
 
   private def toDoc(name: JSName): Unit = emit(name.name)
 
@@ -31,7 +48,7 @@ class FastPrinter {
     case IfExpr(cond, thn, els)       => parens { toDoc(cond) } <+> "?" <+> toDoc(thn) <+> ":" <+> toDoc(els)
     case Lambda(params, Return(obj: js.Object)) => sep(params, toDoc, "(", ", ", ")") <+> "=>" <+> parens { toDoc(expr) }
     case Lambda(params, Return(expr)) => sep(params, toDoc, "(", ", ", ")") <+> "=>" <+> toDoc(expr)
-    case Lambda(params, Block(stmts)) => sep(params, toDoc, "(", ", ", ")") <+> "=>" <+> jsBlock { stmts.foreach(toDoc) }
+    case Lambda(params, Block(stmts)) => sep(params, toDoc, "(", ", ", ")") <+> "=>" <+> jsBlock(stmts, toDoc)
     case Lambda(params, body)         => sep(params, toDoc, "(", ", ", ")") <+> "=>" <+> jsBlock { toDoc(body) }
     case Object(properties)           => jsBlock {
       properties.foreach { case (n, d) => toDoc(n) <> emit(":") <+> toDoc(d) <> ", " }
@@ -59,25 +76,25 @@ class FastPrinter {
 
   private def toDoc(stmt: Stmt): Unit = stmt match {
     case RawStmt(strings, args)        => intercalate(strings, args, toDocAsAtom)
-    case Block(stmts)                  => jsBlock(stmts foreach toDoc)
+    case Block(stmts)                  => jsBlock(stmts, toDoc)
     case Return(expr)                  => "return" <+> toDoc(expr) <> ";"
     case ExprStmt(expr)                => toDoc(expr) <> ";"
     case Const(id, expr)               => "const" <+> toDoc(id) <+> "=" <+> toDoc(expr) <> ";"
     case Let(id, expr)                 => "let" <+> toDoc(id) <+> "=" <+> toDoc(expr) <> ";"
     case Destruct(ids, expr)           => "const" <+> braces { ids.foreach { id => toDoc(id) <> ", " } } <+> "=" <+> toDoc(expr) <> ";"
     case Assign(target, expr)          => toDoc(target) <+> "=" <+> toDoc(expr) <> ";"
-    case Function(name, params, stmts) => "function" <+> toDoc(name) <> sep(params, toDoc, "(", ", ", ")") <+> jsBlock(stmts foreach toDoc)
-    case Class(name, methods)          => "class" <+> toDoc(name) <+> jsBlock(methods.foreach(jsMethod))
+    case Function(name, params, stmts) => "function" <+> toDoc(name) <> sep(params, toDoc, "(", ", ", ")") <+> jsBlock(stmts, toDoc)
+    case Class(name, methods)          => "class" <+> toDoc(name) <+> jsBlock(methods, jsMethod)
     case If(cond, thn, Block(Nil))     => "if" <+> parens(toDoc(cond)) <+> toDocBlock(thn)
     case If(cond, thn, els)            => "if" <+> parens(toDoc(cond)) <+> toDocBlock(thn) <+> "else" <+> toDocBlock(els)
-    case Try(prog, id, handler, Nil)   => "try" <+> jsBlock(prog.foreach(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.foreach(toDoc))
-    case Try(prog, id, handler, fin)    => "try" <+> jsBlock(prog.foreach(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.foreach(toDoc)) <+> "finally" <+> jsBlock(fin.foreach(toDoc))
+    case Try(prog, id, handler, Nil)   => "try" <+> jsBlock(prog, toDoc) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler, toDoc)
+    case Try(prog, id, handler, fin)    => "try" <+> jsBlock(prog, toDoc) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler, toDoc) <+> "finally" <+> jsBlock(fin, toDoc)
     case Throw(expr)                   => "throw" <+> toDoc(expr) <> ";"
     case Break()                       => emit("break;")
     case Continue(label)               => "continue" <> label.foreach(l => " " <> toDoc(l)) <> ";"
     case While(cond, stmts, label)     =>
       label.foreach(l => toDoc(l) <> ": ") <>
-        "while" <+> parens(toDoc(cond)) <+> jsBlock(stmts.foreach(toDoc))
+        "while" <+> parens(toDoc(cond)) <+> jsBlock(stmts, toDoc)
 
     case Switch(sc, branches, default) => "switch" <+> parens(toDoc(sc)) <+> jsBlock(branches.foreach {
       case (tag, stmts) => "case" <+> toDoc(tag) <> ":" <+> (stmts foreach toDoc)
@@ -92,7 +109,7 @@ class FastPrinter {
 
   private def jsMethod(c: js.Function): Unit = c match {
     case js.Function(name, params, stmts) =>
-      toDoc(name) <> sep(params, toDoc, "(", ", ", ")") <+> jsBlock(stmts.foreach(toDoc))
+      toDoc(name) <> sep(params, toDoc, "(", ", ", ")") <+> jsBlock(stmts, toDoc)
   }
 
   private def toDoc(pattern: Pattern): Unit = pattern match {
@@ -134,14 +151,16 @@ class FastPrinter {
     emit(after)
   }
 
+  private def sep[A](l: List[A], f: A => Unit, separator: String): Unit = sep(l, f, emit(separator))
+
   @tailrec
-  private def sep[A](l: List[A], f: A => Unit, separator: String): Unit = {
+  private def sep[A](l: List[A], f: A => Unit, separator: => Unit): Unit = {
     l match {
       case Nil => ()
       case head :: Nil => f(head)
       case head :: tail =>
         f(head)
-        emit(separator)
+        separator
         sep(tail, f, separator)
     }
   }
@@ -150,7 +169,8 @@ class FastPrinter {
 
   private inline def braces(p: => Unit): Unit = { emit("{"); p; emit("}") }
 
-  private inline def line(): Unit = emit("\n")
+  private inline def jsBlock(content: => Unit): Unit = braces { indented { line() <> content } <> line() }
 
-  private inline def jsBlock(content: => Unit): Unit = braces(line() <> content <> line())
+  private inline def jsBlock[A](els: List[A], show: A => Unit): Unit =
+    braces { indented { line() <> sep(els, show, line()) } <> line() }
 }

--- a/effekt/shared/src/main/scala/effekt/generator/js/FastPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/FastPrinter.scala
@@ -1,0 +1,156 @@
+package effekt
+package generator
+package js
+
+import effekt.util.intercalate
+import kiama.output.ParenPrettyPrinter
+import kiama.output.PrettyPrinterTypes.Document
+
+import scala.annotation.tailrec
+import scala.language.implicitConversions
+
+class FastPrinter {
+
+  var buffer = new StringBuffer()
+
+  def pretty(stmt: List[Stmt]): Document =
+    buffer = new StringBuffer()
+    stmt foreach { s => toDoc(s); emit("\n") }
+    Document(buffer.toString, Nil)
+
+  inline def emit(str: String): Unit = buffer.append(str)
+
+  private def toDoc(name: JSName): Unit = emit(name.name)
+
+  private def toDoc(expr: Expr): Unit = expr match {
+    case Call(callee, args)           => toDocParens(callee) <> sep(args, toDoc, "(", ", ", ")")
+    case New(callee, args)            => "new" <+> toDocParens(callee) <> sep(args, toDoc, "(", ", ", ")")
+    case RawExpr(strings, args)       => intercalate(strings, args, toDocAsAtom)
+    case RawLiteral(content)          => emit(content)
+    case Member(callee, selection)    => toDocParens(callee) <> "." <> toDoc(selection)
+    case IfExpr(cond, thn, els)       => parens { toDoc(cond) } <+> "?" <+> toDoc(thn) <+> ":" <+> toDoc(els)
+    case Lambda(params, Return(obj: js.Object)) => sep(params, toDoc, "(", ", ", ")") <+> "=>" <+> parens { toDoc(expr) }
+    case Lambda(params, Return(expr)) => sep(params, toDoc, "(", ", ", ")") <+> "=>" <+> toDoc(expr)
+    case Lambda(params, Block(stmts)) => sep(params, toDoc, "(", ", ", ")") <+> "=>" <+> jsBlock { stmts.foreach(toDoc) }
+    case Lambda(params, body)         => sep(params, toDoc, "(", ", ", ")") <+> "=>" <+> jsBlock { toDoc(body) }
+    case Object(properties)           => jsBlock {
+      properties.foreach { case (n, d) => toDoc(n) <> emit(":") <+> toDoc(d) <> ", " }
+    }
+    case ArrayLiteral(elements)       => sep(elements, toDoc, "[", ", ", "]")
+    case Variable(name)               => toDoc(name)
+  }
+
+  // to be used in low precedence positions
+  private def toDocParens(e: Expr): Unit = e match {
+    case e: IfExpr => parens(toDoc(e))
+    case e: Lambda => parens(toDoc(e))
+    case o: js.Object => parens(toDoc(e))
+    case e => toDoc(e)
+  }
+
+  // to be used in really low precedence positions
+  private def toDocAsAtom(e: Expr): Unit = e match {
+    case e: Variable => toDoc(e)
+    case e: Object => toDoc(e)
+    case e: ArrayLiteral => toDoc(e)
+    case e: RawLiteral => toDoc(e)
+    case e => parens(toDoc(e))
+  }
+
+  private def toDoc(stmt: Stmt): Unit = stmt match {
+    case RawStmt(strings, args)        => intercalate(strings, args, toDocAsAtom)
+    case Block(stmts)                  => jsBlock(stmts foreach toDoc)
+    case Return(expr)                  => "return" <+> toDoc(expr) <> ";"
+    case ExprStmt(expr)                => toDoc(expr) <> ";"
+    case Const(id, expr)               => "const" <+> toDoc(id) <+> "=" <+> toDoc(expr) <> ";"
+    case Let(id, expr)                 => "let" <+> toDoc(id) <+> "=" <+> toDoc(expr) <> ";"
+    case Destruct(ids, expr)           => "const" <+> braces { ids.foreach { id => toDoc(id) <> ", " } } <+> "=" <+> toDoc(expr) <> ";"
+    case Assign(target, expr)          => toDoc(target) <+> "=" <+> toDoc(expr) <> ";"
+    case Function(name, params, stmts) => "function" <+> toDoc(name) <> sep(params, toDoc, "(", ", ", ")") <+> jsBlock(stmts foreach toDoc)
+    case Class(name, methods)          => "class" <+> toDoc(name) <+> jsBlock(methods.foreach(jsMethod))
+    case If(cond, thn, Block(Nil))     => "if" <+> parens(toDoc(cond)) <+> toDocBlock(thn)
+    case If(cond, thn, els)            => "if" <+> parens(toDoc(cond)) <+> toDocBlock(thn) <+> "else" <+> toDocBlock(els)
+    case Try(prog, id, handler, Nil)   => "try" <+> jsBlock(prog.foreach(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.foreach(toDoc))
+    case Try(prog, id, handler, fin)    => "try" <+> jsBlock(prog.foreach(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.foreach(toDoc)) <+> "finally" <+> jsBlock(fin.foreach(toDoc))
+    case Throw(expr)                   => "throw" <+> toDoc(expr) <> ";"
+    case Break()                       => emit("break;")
+    case Continue(label)               => "continue" <> label.foreach(l => " " <> toDoc(l)) <> ";"
+    case While(cond, stmts, label)     =>
+      label.foreach(l => toDoc(l) <> ": ") <>
+        "while" <+> parens(toDoc(cond)) <+> jsBlock(stmts.foreach(toDoc))
+
+    case Switch(sc, branches, default) => "switch" <+> parens(toDoc(sc)) <+> jsBlock(branches.foreach {
+      case (tag, stmts) => "case" <+> toDoc(tag) <> ":" <+> (stmts foreach toDoc)
+    } <+> default.foreach { stmts => "default:" <+> (stmts foreach toDoc) })
+  }
+
+  private def toDocBlock(stmt: Stmt): Unit = stmt match {
+    case Block(stmts) => toDoc(stmt)
+    case If(cond, thn, els) => toDoc(stmt)
+    case _ => jsBlock(toDoc(stmt))
+  }
+
+  private def jsMethod(c: js.Function): Unit = c match {
+    case js.Function(name, params, stmts) =>
+      toDoc(name) <> sep(params, toDoc, "(", ", ", ")") <+> jsBlock(stmts.foreach(toDoc))
+  }
+
+  private def toDoc(pattern: Pattern): Unit = pattern match {
+    case Pattern.Variable(name) => toDoc(name)
+    case Pattern.Array(ps) => sep(ps, toDoc, "[", ",", "]")
+  }
+
+  // some helpers
+  extension (d: Unit) {
+    inline def <>(other: => Unit): Unit = other
+    inline def <>(other: String): Unit = emit(other)
+    inline def <+>(other: => Unit): Unit = { emit(" "); other }
+    inline def <+>(other: String): Unit = { emit(" "); emit(other) }
+  }
+  extension (self: String) {
+    inline def <>(other: => Unit): Unit = { emit(self); other }
+    inline def <+>(other: => Unit): Unit = { emit(self); emit(" "); other }
+  }
+
+
+  @tailrec
+  private def intercalate[A](strings: List[String], els: List[A], f: A => Unit): Unit =
+    (strings, els) match {
+      case (Nil, Nil) => ()
+      case (str :: strs, el :: rest) =>
+        emit(str)
+        f(el)
+        intercalate(strs, rest, f)
+      case (strs, Nil) =>
+        strs.foreach(s => emit(s))
+      case (Nil, el :: rest) =>
+        f(el)
+        intercalate(Nil, rest, f)
+    }
+
+  private def sep[A](l: List[A], f: A => Unit, before: String, separator: String, after: String): Unit = {
+    emit(before)
+    sep(l, f, separator)
+    emit(after)
+  }
+
+  @tailrec
+  private def sep[A](l: List[A], f: A => Unit, separator: String): Unit = {
+    l match {
+      case Nil => ()
+      case head :: Nil => f(head)
+      case head :: tail =>
+        f(head)
+        emit(separator)
+        sep(tail, f, separator)
+    }
+  }
+
+  private inline def parens(p: => Unit): Unit = { emit("("); p; emit(")") }
+
+  private inline def braces(p: => Unit): Unit = { emit("{"); p; emit("}") }
+
+  private inline def line(): Unit = emit("\n")
+
+  private inline def jsBlock(content: => Unit): Unit = braces(line() <> content <> line())
+}

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -59,7 +59,7 @@ class JavaScript(additionalFeatureFlags: List[String] = Nil) extends Compiler[St
   lazy val Compile = CPSTransformed map {
     case (mainSymbol, mainFile, core, cps) =>
       val res = TransformerCps.compile(cps, core, mainSymbol).commonjs
-      val doc = if Context.config.debug() then pretty(res) else FastPrinter().pretty(res)
+      val doc = Context.timed("pretty-js", "out") { if Context.config.debug() then pretty(res) else FastPrinter().pretty(res) }
       (Map(mainFile -> doc.layout), mainFile)
   }
 


### PR DESCRIPTION
Quick benchmarks show that it is roughly 10x faster than the pretty one (8ms instead of 80ms on anf.effekt.md).

By default the ugly printer is used, but LSP and `--debug` will show the nice output.

The implementation is purposefully in combinator style to look similar to the pretty version, since the two need to be kept in sync.