### PR TITLE
Specific info message for equally named effect operations

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -925,7 +925,7 @@ trait NamerOps extends ContextOps { Context: Context =>
           val allSyms = scope.lookupOverloaded(id, term => true).flatten
           val ops = scope.lookupOperation(id.path, id.name).flatten
 
-          // Provide specific error messages for operations
+          // Provide specific info messages for operations
           ops.foreach { op =>
             info(pretty"There is an equally named effect operation ${op} of interface ${op.interface}. Use syntax `do ${id}()` to call it.")
           }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -921,8 +921,6 @@ trait NamerOps extends ContextOps { Context: Context =>
         assignSymbol(id, value)
       case Right(blocks) =>
         if (blocks.isEmpty) {
-          // Use both lookupOverloaded and lookupOperation to ensure we handle all cases
-          val allSyms = scope.lookupOverloaded(id, term => true).flatten
           val ops = scope.lookupOperation(id.path, id.name).flatten
 
           // Provide specific info messages for operations
@@ -930,10 +928,8 @@ trait NamerOps extends ContextOps { Context: Context =>
             info(pretty"There is an equally named effect operation ${op} of interface ${op.interface}. Use syntax `do ${id}()` to call it.")
           }
 
-          // Abort with the generic message if no matches were found
-          if (ops.isEmpty && allSyms.isEmpty) {
-            abort(pretty"Cannot find a function named `${id}`.")
-          }
+          // Always abort with the generic message
+          abort(pretty"Cannot find a function named `${id}`.")
         }
         assignSymbol(id, CallTarget(blocks))
     }

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
@@ -1,6 +1,9 @@
-[error] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:6: Ambiguous overload.
-There are multiple overloads, which all would type check:
-- ambiguous_interfaces_overload::sayHello: () => Unit
-- ambiguous_interfaces_overload::sayHello: () => Unit
-  do sayHello() 
-     ^^^^^^^^
+[info] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
+    sayHello() 
+    ^^^^^^^^
+[info] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: There is an equally named effect operation sayHello of interface Welcome. Use syntax `do sayHello()` to call it.
+    sayHello() 
+    ^^^^^^^^
+[error] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: Cannot find a function named `sayHello`.
+    sayHello() 
+    ^^^^^^^^

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
@@ -1,0 +1,6 @@
+[error] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:6: Ambiguous overload.
+There are multiple overloads, which all would type check:
+- two_interfaces::sayHello: () => Unit
+- two_interfaces::sayHello: () => Unit
+  do sayHello() 
+     ^^^^^^^^

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
@@ -1,9 +1,9 @@
 [info] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:3: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
-sayHello() 
-^^^^^^^^
+  sayHello() 
+  ^^^^^^^^
 [info] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:3: There is an equally named effect operation sayHello of interface Welcome. Use syntax `do sayHello()` to call it.
-sayHello() 
-^^^^^^^^
+  sayHello() 
+  ^^^^^^^^
 [error] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:3: Cannot find a function named `sayHello`.
-sayHello() 
-^^^^^^^^
+  sayHello() 
+  ^^^^^^^^

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
@@ -1,6 +1,6 @@
 [error] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:6: Ambiguous overload.
 There are multiple overloads, which all would type check:
-- two_interfaces::sayHello: () => Unit
-- two_interfaces::sayHello: () => Unit
+- ambiguous_interfaces_overload::sayHello: () => Unit
+- ambiguous_interfaces_overload::sayHello: () => Unit
   do sayHello() 
      ^^^^^^^^

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
@@ -1,9 +1,9 @@
 [info] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:3: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
-    sayHello() 
-    ^^^^^^^^
+sayHello() 
+^^^^^^^^
 [info] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:3: There is an equally named effect operation sayHello of interface Welcome. Use syntax `do sayHello()` to call it.
-    sayHello() 
-    ^^^^^^^^
+sayHello() 
+^^^^^^^^
 [error] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:3: Cannot find a function named `sayHello`.
-    sayHello() 
-    ^^^^^^^^
+sayHello() 
+^^^^^^^^

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.check
@@ -1,9 +1,9 @@
-[info] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
+[info] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:3: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
     sayHello() 
     ^^^^^^^^
-[info] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: There is an equally named effect operation sayHello of interface Welcome. Use syntax `do sayHello()` to call it.
+[info] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:3: There is an equally named effect operation sayHello of interface Welcome. Use syntax `do sayHello()` to call it.
     sayHello() 
     ^^^^^^^^
-[error] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: Cannot find a function named `sayHello`.
+[error] examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:3: Cannot find a function named `sayHello`.
     sayHello() 
     ^^^^^^^^

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
@@ -3,20 +3,11 @@ interface Welcome { def sayHello(): Unit }
 
 def helloWorld() = try {
   sayHello() 
-  //[info] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
-  //     sayHello() 
-  //     ^^^^^^^^
-  // [info] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: There is an equally named effect operation sayHello of interface Welcome. Use syntax `do sayHello()` to call it.
-  //     sayHello() 
-  //     ^^^^^^^^
-  // [error] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: Cannot find a function named `sayHello`.
-  //     sayHello() 
-  //     ^^^^^^^^
 
   } with Greet {
   def sayHello() = { println("Hello from Greet!"); resume(()) }
 }
 
 def main() = {
-  helloWorld() // throws: Cannot find a function named `sayHello`
+  helloWorld() 
 }

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
@@ -1,0 +1,19 @@
+interface Greet { def sayHello(): Unit }
+interface Welcome { def sayHello(): Unit }
+
+def helloWorld() = try {
+  do sayHello() 
+  //[error] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/two_interfaces.effekt:5:6: Ambiguous overload.
+  //There are multiple overloads, which all would type check:
+  //- two_interfaces::sayHello: () => Unit
+  //- two_interfaces::sayHello: () => Unit
+  //  do sayHello() 
+  //     ^^^^^^^^
+
+  } with Greet {
+  def sayHello() = { println("Hello from Greet!"); resume(()) }
+}
+
+def main() = {
+  helloWorld() // throws: Ambiguous overload
+}

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
@@ -3,9 +3,8 @@ interface Welcome { def sayHello(): Unit }
 
 def helloWorld() = try {
   sayHello() 
-
   } with Greet {
-  def sayHello() = { println("Hello from Greet!"); resume(()) }
+    def sayHello() = { println("Hello from Greet!"); resume(()) }
 }
 
 def main() = {

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
@@ -2,12 +2,15 @@ interface Greet { def sayHello(): Unit }
 interface Welcome { def sayHello(): Unit }
 
 def helloWorld() = try {
-  do sayHello() 
-  //[error] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/two_interfaces.effekt:5:6: Ambiguous overload.
-  //There are multiple overloads, which all would type check:
-  //- two_interfaces::sayHello: () => Unit
-  //- two_interfaces::sayHello: () => Unit
-  //  do sayHello() 
+  sayHello() 
+  //[info] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
+  //     sayHello() 
+  //     ^^^^^^^^
+  // [info] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: There is an equally named effect operation sayHello of interface Welcome. Use syntax `do sayHello()` to call it.
+  //     sayHello() 
+  //     ^^^^^^^^
+  // [error] /home/jakub/Code/Effekt/effekt/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt:5:5: Cannot find a function named `sayHello`.
+  //     sayHello() 
   //     ^^^^^^^^
 
   } with Greet {
@@ -15,5 +18,5 @@ def helloWorld() = try {
 }
 
 def main() = {
-  helloWorld() // throws: Ambiguous overload
+  helloWorld() // throws: Cannot find a function named `sayHello`
 }

--- a/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
+++ b/examples/neg/namer/issue950/ambiguous_interfaces_overload.effekt
@@ -3,8 +3,8 @@ interface Welcome { def sayHello(): Unit }
 
 def helloWorld() = try {
   sayHello() 
-  } with Greet {
-    def sayHello() = { println("Hello from Greet!"); resume(()) }
+} with Greet {
+  def sayHello() = { println("Hello from Greet!"); resume(()) }
 }
 
 def main() = {

--- a/examples/neg/namer/issue950/cannot_find_function.check
+++ b/examples/neg/namer/issue950/cannot_find_function.check
@@ -1,3 +1,0 @@
-[error] examples/neg/namer/issue950/cannot_find_function.effekt:4:3: Cannot find a function named `Hello`.
-  Hello()
-  ^^^^^

--- a/examples/neg/namer/issue950/cannot_find_function.check
+++ b/examples/neg/namer/issue950/cannot_find_function.check
@@ -1,0 +1,3 @@
+[error] examples/neg/namer/issue950/cannot_find_function.effekt:4:3: Cannot find a function named `Hello`.
+  Hello()
+  ^^^^^

--- a/examples/neg/namer/issue950/cannot_find_function.effekt
+++ b/examples/neg/namer/issue950/cannot_find_function.effekt
@@ -1,12 +1,1 @@
-interface Greet { def sayHello(): Unit }
-
-def helloWorld() = try {
-  Hello()
-  // [error] Cannot find a function named `Hello`.
-} with Greet {
-  def sayHello() = { println("Hello!"); resume(()) }
-}
-
-def main() = {
-  helloWorld() // throws:  Cannot find a function named `Hello`.
-}
+def main() = doesNotExist() // ERROR Cannot find a function named `doesNotExist`.

--- a/examples/neg/namer/issue950/cannot_find_function.effekt
+++ b/examples/neg/namer/issue950/cannot_find_function.effekt
@@ -1,0 +1,12 @@
+interface Greet { def sayHello(): Unit }
+
+def helloWorld() = try {
+  Hello()
+  // [error] Cannot find a function named `Hello`.
+} with Greet {
+  def sayHello() = { println("Hello!"); resume(()) }
+}
+
+def main() = {
+  helloWorld() // throws:  Cannot find a function named `Hello`.
+}

--- a/examples/neg/namer/issue950/effect_operation_with_same_name.check
+++ b/examples/neg/namer/issue950/effect_operation_with_same_name.check
@@ -1,0 +1,6 @@
+[info] examples/neg/namer/issue950/effect_operation_with_same_name.effekt:4:3: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
+  sayHello() // info : There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it..
+  ^^^^^^^^
+[error] examples/neg/namer/issue950/effect_operation_with_same_name.effekt:4:3: Cannot typecheck call.
+  sayHello() // info : There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it..
+  ^^^^^^^^^^

--- a/examples/neg/namer/issue950/effect_operation_with_same_name.check
+++ b/examples/neg/namer/issue950/effect_operation_with_same_name.check
@@ -1,6 +1,6 @@
 [info] examples/neg/namer/issue950/effect_operation_with_same_name.effekt:4:3: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
-  sayHello() // info : There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it..
+  sayHello()
   ^^^^^^^^
 [error] examples/neg/namer/issue950/effect_operation_with_same_name.effekt:4:3: Cannot find a function named `sayHello`.
-  sayHello() // info : There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it..
+  sayHello() 
   ^^^^^^^^

--- a/examples/neg/namer/issue950/effect_operation_with_same_name.check
+++ b/examples/neg/namer/issue950/effect_operation_with_same_name.check
@@ -2,5 +2,5 @@
   sayHello()
   ^^^^^^^^
 [error] examples/neg/namer/issue950/effect_operation_with_same_name.effekt:4:3: Cannot find a function named `sayHello`.
-  sayHello() 
+  sayHello()
   ^^^^^^^^

--- a/examples/neg/namer/issue950/effect_operation_with_same_name.check
+++ b/examples/neg/namer/issue950/effect_operation_with_same_name.check
@@ -1,6 +1,6 @@
 [info] examples/neg/namer/issue950/effect_operation_with_same_name.effekt:4:3: There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it.
   sayHello() // info : There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it..
   ^^^^^^^^
-[error] examples/neg/namer/issue950/effect_operation_with_same_name.effekt:4:3: Cannot typecheck call.
+[error] examples/neg/namer/issue950/effect_operation_with_same_name.effekt:4:3: Cannot find a function named `sayHello`.
   sayHello() // info : There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it..
-  ^^^^^^^^^^
+  ^^^^^^^^

--- a/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
+++ b/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
@@ -1,11 +1,11 @@
 interface Greet { def sayHello(): Unit }
 
 def helloWorld() = try {
-  sayHello() // info : There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it..
+  sayHello()
 } with Greet {
   def sayHello() = { println("Hello!"); resume(()) }
 }
 
 def main() = {
-  helloWorld() // throws: Cannot find a function named `sayHello`.
+  helloWorld()
 }

--- a/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
+++ b/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
@@ -3,7 +3,7 @@ interface Greet { def sayHello(): Unit }
 def helloWorld() = try {
   sayHello()
 } with Greet {
-  def sayHello() = { println("Hello!"); resume(()) }
+    def sayHello() = { println("Hello!"); resume(()) }
 }
 
 def main() = {

--- a/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
+++ b/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
@@ -7,5 +7,5 @@ def helloWorld() = try {
 }
 
 def main() = {
-  helloWorld() // throws: Cannot typecheck call
+  helloWorld() // throws: Cannot find a function named `sayHello`.
 }

--- a/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
+++ b/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
@@ -3,7 +3,7 @@ interface Greet { def sayHello(): Unit }
 def helloWorld() = try {
   sayHello()
 } with Greet {
-    def sayHello() = { println("Hello!"); resume(()) }
+  def sayHello() = { println("Hello!"); resume(()) }
 }
 
 def main() = {

--- a/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
+++ b/examples/neg/namer/issue950/effect_operation_with_same_name.effekt
@@ -1,0 +1,11 @@
+interface Greet { def sayHello(): Unit }
+
+def helloWorld() = try {
+  sayHello() // info : There is an equally named effect operation sayHello of interface Greet. Use syntax `do sayHello()` to call it..
+} with Greet {
+  def sayHello() = { println("Hello!"); resume(()) }
+}
+
+def main() = {
+  helloWorld() // throws: Cannot typecheck call
+}


### PR DESCRIPTION
## Enhance  Reporting for Missing `do` Syntax in Effect Operations  

This pull request improves error messages for unresolved function calls in the presence of equally named effect operations, addressing issue [#950](https://github.com/effekt-lang/effekt/issues/950).

---

## Summary  
This update enhances the info message in the `Namer` component of Effekt when an equally named effect operation exists but has not been invoked using the `do` syntax. It ensures the user is provided with a more descriptive information message, avoiding the  generic  `"Cannot find a function named _"`.

---

## Changes  
### 1. **Improved Information in `Namer.scala`**:
   - Removed  `lookupOverloaded` and with it the never issued information on fields and added `lookupOperation` to capture equally named effect operations the `resolveFunctionCallTarget` method.
   - When an equally named effect operation is found, an **information message** is provided to the user with the recommended syntax (`do {operationName}()`).
   
### 3. **Added Negative Tests**:
   - Introduced three new tests in `examples/neg/namer/issue950` to verify the following cases:
     - An info message is displayed when an effect operation is invoked without the `do` syntax.
     - The generic message is displayed when no valid function or operation matches the call.
     - Overloaded Effects all get captured by the `foreach`

---


## Example Behavior  

### Before the Fix  
```scala
interface Greet { def sayHello(): Unit }

def helloWorld() = try {
  sayHello()
  // [error] Cannot find a function named `sayHello`.
} with Greet {
  def sayHello() = { println("Hello!"); resume(()) }
}

def main() = {
  helloWorld() // Generic error, not helpful
}
```

### After the Fix  
```scala
interface Greet { def sayHello(): Unit }

def helloWorld() = try {
  sayHello()
  // [error] There is an equally named effect operation `sayHello` of interface `Greet`. Use syntax `do sayHello()` to call it.
} with Greet {
  def sayHello() = { println("Hello!"); resume(()) }
}

def main() = {
  helloWorld() // Specific error with actionable advice
}
```

---

## Testing  
- **Negative Test 1**: Missing `do` for effect operation:
  - Confirms that invoking an effect operation without the `do` syntax triggers the improved error message.
- **Negative Test 2**: Unresolved function call:
  - Ensures that the generic error message appears when no matches (operations, fields, or overloads) are found.
- **Negative Test 3**: Overloaded effect operations:
  - Confirms that overloaded effect operations are all captured by the new foreach