### PR TITLE
Add wellformedness check for type of `var ... in ...`

### DIFF
--- a/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
@@ -315,6 +315,10 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
       val boundTypes = tps.map(_.symbol.asTypeParam).toSet[TypeVar]
       val boundCapts = bps.map(_.id.symbol.asBlockParam.capture).toSet
       binding(types = boundTypes, captures = boundCapts) { bodies.foreach(query) }
+
+    case tree @ source.RegDef(id, annot, region, init) =>
+      wellformed(Context.typeOf(id.symbol), tree, pp" inferred as type of region-allocated variable")
+      query(init)
   }
 
   // Can only compute free capture on concrete sets

--- a/examples/neg/issue919.effekt
+++ b/examples/neg/issue919.effekt
@@ -2,10 +2,10 @@ effect tick(): Unit
 
 def main() = {
   region r {
-    var k in r = box { () }
+    var k in r = box { () } // ERROR tick escapes
     try {
       k = box { do tick() }
     } with tick { () => () }
-    k() // ERROR tick escapes
+    k()
   } 
 }

--- a/examples/neg/issue919.effekt
+++ b/examples/neg/issue919.effekt
@@ -1,0 +1,11 @@
+effect tick(): Unit
+
+def main() = {
+  region r {
+    var k in r = box { () }
+    try {
+      k = box { do tick() }
+    } with tick { () => () }
+    k() // ERROR tick escapes
+  } 
+}


### PR DESCRIPTION
Fixes #919 by adding a wellformedness check as suggested [here](https://github.com/effekt-lang/effekt/issues/919#issuecomment-2769562532).

Resulting error message:
<img width="1272" alt="Screenshot 2025-04-25 at 14 27 57" src="https://github.com/user-attachments/assets/e81597a0-602e-4868-a5fd-7ecc1e4e3562" />

