### PR TITLE
Recursive check: Compare modules by path

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -49,8 +49,8 @@ object Namer extends Phase[Parsed, NameResolved] {
    * Produces a cyclic import error when this is already the case
    */
   private def recursiveProtect[R](mod: ModuleDecl)(body: => R)(using Context): R = {
-    if (currentlyNaming.value.exists { m => m.path == mod.path }) {
-      val cycle = mod :: currentlyNaming.value.takeWhile{ m => m.path != mod.path }.reverse
+    if (currentlyNaming.value.exists { m => m.span.source == mod.span.source }) {
+      val cycle = mod :: currentlyNaming.value.takeWhile{ m => m.span.source != mod.span.source }.reverse
       Context.abort(
         pretty"""Cyclic import: ${mod.path} depends on itself, via:\n\t${cycle.map(_.path).mkString(" -> ")} -> ${mod.path}""")
     } else {

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -49,8 +49,8 @@ object Namer extends Phase[Parsed, NameResolved] {
    * Produces a cyclic import error when this is already the case
    */
   private def recursiveProtect[R](mod: ModuleDecl)(body: => R)(using Context): R = {
-    if (currentlyNaming.value.contains(mod)) {
-      val cycle = mod :: currentlyNaming.value.takeWhile(_ != mod).reverse
+    if (currentlyNaming.value.exists(_.path == mod.path)) {
+      val cycle = mod :: currentlyNaming.value.takeWhile(_.path != mod.path).reverse
       Context.abort(
         pretty"""Cyclic import: ${mod.path} depends on itself, via:\n\t${cycle.map(_.path).mkString(" -> ")} -> ${mod.path}""")
     } else {

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -49,8 +49,8 @@ object Namer extends Phase[Parsed, NameResolved] {
    * Produces a cyclic import error when this is already the case
    */
   private def recursiveProtect[R](mod: ModuleDecl)(body: => R)(using Context): R = {
-    if (currentlyNaming.value.exists(_.path == mod.path)) {
-      val cycle = mod :: currentlyNaming.value.takeWhile(_.path != mod.path).reverse
+    if (currentlyNaming.value.exists { m => m.path == mod.path }) {
+      val cycle = mod :: currentlyNaming.value.takeWhile{ m => m.path != mod.path }.reverse
       Context.abort(
         pretty"""Cyclic import: ${mod.path} depends on itself, via:\n\t${cycle.map(_.path).mkString(" -> ")} -> ${mod.path}""")
     } else {


### PR DESCRIPTION
As noted in https://github.com/effekt-lang/kiama/pull/11, we compare by structural equality on the `ModuleDecl` currently.
This changes it to the path (which should be enough, faster, and more robust w.r.t. #957 and follow-up PRs).

---
Note: Based on #957 .