### PR TITLE
Fix generic equals on Chez (#429)

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/ChezSchemeTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ChezSchemeTests.scala
@@ -60,9 +60,6 @@ abstract class ChezSchemeTests extends EffektTests {
 
     examplesDir / "pos" / "io", // async io is only implemented for monadic JS
 
-
-    examplesDir / "pos" / "issue429.effekt",
-
     // Generic comparison
     examplesDir / "pos" / "genericcompare.effekt",
     examplesDir / "pos" / "issue733.effekt",

--- a/examples/pos/issue429.check
+++ b/examples/pos/issue429.check
@@ -1,5 +1,29 @@
+=== Basic equality tests ===
 true
 true
 true
 true
 true
+
+=== Record equality tests ===
+true
+false
+true
+
+=== Nested structure tests ===
+true
+false
+true
+false
+
+=== Tree equality tests ===
+true
+false
+false
+true
+
+=== Complex nested structure tests ===
+true
+false
+true
+false

--- a/examples/pos/issue429.effekt
+++ b/examples/pos/issue429.effekt
@@ -1,15 +1,89 @@
+// Test generic equality implementation
 type MyType {
   MySingleCase()
 }
 
 record EmptyRecord()
 
+record Person(name: String, age: Int)
+
+// Binary tree with values in nodes
+type Tree[T] {
+  Leaf();
+  Node(value: T, left: Tree[T], right: Tree[T])
+}
+
+// Create a simple tree for testing
+def createTree[T](depth: Int, value: T): Tree[T] = {
+  if (depth <= 0) {
+    Leaf()
+  } else {
+    Node(value, createTree(depth - 1, value), createTree(depth - 1, value))
+  }
+}
+
+// Create a more complex tree with different values
+def createMixedTree(): Tree[Int] = {
+  Node(1, 
+    Node(2, Leaf(), Leaf()),
+    Node(3, 
+      Node(4, Leaf(), Leaf()),
+      Leaf()
+    )
+  )
+}
+
 def main() = {
+  // Original tests
+  println("=== Basic equality tests ===")
   println(MySingleCase().equals(MySingleCase()))   // ~> true
   println(EmptyRecord().equals(EmptyRecord()))    // ~> true
-
   println(Some(MySingleCase()).equals(Some(MySingleCase()))) // ~> true
   println(Some(EmptyRecord()).equals(Some(EmptyRecord())))   // ~> true
-
   println([Some(EmptyRecord()), Some(EmptyRecord()), None()].equals([Some(EmptyRecord()), Some(EmptyRecord()), None()]))
+
+  // Enhanced tests with records and nested structures
+  println("\n=== Record equality tests ===")
+  val person1 = Person("Alice", 30)
+  val person2 = Person("Alice", 30)
+  val person3 = Person("Bob", 25)
+  println(person1.equals(person2))  // ~> true
+  println(person1.equals(person3))  // ~> false
+  println(Person("Alice", 30).equals(Person("Alice", 30)))  // ~> true
+  
+  // Test nested records
+  println("\n=== Nested structure tests ===")
+  println(Some(person1).equals(Some(person2)))  // ~> true
+  println(Some(person1).equals(Some(person3)))  // ~> false
+  println([person1, person2].equals([person1, person2]))  // ~> true
+  println([person1, person3].equals([person1, person2]))  // ~> false
+  
+  // Tree equality tests
+  println("\n=== Tree equality tests ===")
+  val tree1 = createTree(3, 42)
+  val tree2 = createTree(3, 42)
+  val tree3 = createTree(2, 42)
+  val tree4 = createTree(3, 100)
+  
+  println(tree1.equals(tree2))  // ~> true
+  println(tree1.equals(tree3))  // ~> false
+  println(tree1.equals(tree4))  // ~> false
+  
+  val mixedTree1 = createMixedTree()
+  val mixedTree2 = createMixedTree()
+  println(mixedTree1.equals(mixedTree2))  // ~> true
+  
+  // Even more complex nested structures
+  println("\n=== Complex nested structure tests ===")
+  val nestedList1 = [Some(tree1), None(), Some(mixedTree1)]
+  val nestedList2 = [Some(tree2), None(), Some(mixedTree2)]
+  val nestedList3 = [Some(tree3), None(), Some(mixedTree1)]
+  
+  println(nestedList1.equals(nestedList2))  // ~> true
+  println(nestedList1.equals(nestedList3))  // ~> false
+  
+  val complexRecord = Person("Charlie", 35)
+  val recordWithTree = [complexRecord, Person("Dave", 40), Person("Charlie", 35)]
+  println(recordWithTree.equals([complexRecord, Person("Dave", 40), Person("Charlie", 35)]))  // ~> true
+  println(recordWithTree.equals([complexRecord, Person("Dave", 40), Person("Charlie", 36)]))  // ~> false
 }

--- a/libraries/chez/common/effekt_primitives.ss
+++ b/libraries/chez/common/effekt_primitives.ss
@@ -84,7 +84,7 @@
                (let ([field1 ((record-accessor rtd1 i) obj1)]
                      [field2 ((record-accessor rtd2 i) obj2)])
                  (if (not (equal_impl field1 field2))
-                     (set! result #f))))
+                     (set! result #f)))))
            #f))]
     
     ; For lists, compare elements recursively

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -203,7 +203,7 @@ def println(o: Ordering): Unit = println(o.show)
 /// Structural equality: Not available in the LLVM backend
 extern pure def equals[R](x: R, y: R): Bool =
   js "$effekt.equals(${x}, ${y})"
-  chez "(equal? ${x} ${y})"
+  chez "(equal_impl ${x} ${y})"
 
 def differsFrom[R](x: R, y: R): Bool =
   not(equals(x, y))


### PR DESCRIPTION
Resolves #429.

Experiment made using the Copilot Agent Code button, because I'm curious if it can do basic stuff like this :)
Seems like the perfect use case: Claude 3.7 -- unlike me -- probably knows enough Chez to fix `equals`...
<img width="274" alt="Screenshot 2025-05-01 at 14 07 59" src="https://github.com/user-attachments/assets/eaa1572d-106a-4c00-8ff1-2c5977f82dfc" />
