### PR TITLE
Make the language server accept config nested under the "effekt" key

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -504,7 +504,7 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
   def didChangeConfiguration(params: DidChangeConfigurationParams): Unit = {
     // The configuration can be sent as a flat JSON object `{ "showIR": "core", ... }` or
     // nested under an "effekt" key `{ "effekt": { "showIR": "core", ... } }`
-    // The former is sent by previous versions of the VSCode extension for `initializationOptions`,
+    // The former is sent by the VSCode extension for `initializationOptions`,
     // the latter by newer extension versions for `workspace/didChangeConfiguration`.
     val newSettings = params.getSettings.asInstanceOf[JsonElement].getAsJsonObject
     this.settings = newSettings;

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -502,7 +502,17 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
   //
 
   def didChangeConfiguration(params: DidChangeConfigurationParams): Unit = {
-    this.settings = params.getSettings.asInstanceOf[JsonElement].getAsJsonObject
+    // The configuration can be sent as a flat JSON object `{ "showIR": "core", ... }` or
+    // nested under an "effekt" key `{ "effekt": { "showIR": "core", ... } }`
+    // The former is sent by previous versions of the VSCode extension for `initializationOptions`,
+    // the latter by newer extension versions for `workspace/didChangeConfiguration`.
+    val newSettings = params.getSettings.asInstanceOf[JsonElement].getAsJsonObject
+    this.settings = newSettings;
+    if (newSettings == null) return
+    val effektSection = newSettings.get("effekt")
+    if (effektSection != null) {
+      this.settings = effektSection
+    }
   }
 
   def didChangeWatchedFiles(params: DidChangeWatchedFilesParams): Unit = {}

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -768,6 +768,57 @@ class LSPTests extends FunSuite {
     }
   }
 
+  test("When configuration changes, server should publish requested IR") {
+    withClientAndServer { (client, server) =>
+      val source =
+        raw"""
+             |val foo = 42
+             |"""
+      val textDoc = new TextDocumentItem("file://path/to/test.effekt", "effekt", 0, source.stripMargin)
+      val initializeParams = new InitializeParams()
+      val initializationOptions = """{"showIR": "source"}"""
+      initializeParams.setInitializationOptions(JsonParser.parseString(initializationOptions))
+      server.initialize(initializeParams).get()
+
+      val didOpenParams = new DidOpenTextDocumentParams()
+      didOpenParams.setTextDocument(helloWorld)
+      server.getTextDocumentService().didOpen(didOpenParams)
+
+      // Receive the initial IR
+      assertEquals(client.receivedIR().length, 1)
+
+      val configParams = new DidChangeConfigurationParams()
+      // When configuring the VSCode language client with `synchronize: { configurationSection: 'effekt' }`,
+      // we get a `DidChangeConfigurationParams` with the configuration nested under the "effekt" key.
+      val settings: JsonElement = JsonParser.parseString("""{"effekt": {"showIR": "core", "showTree": true}}""")
+      configParams.setSettings(settings)
+      server.getWorkspaceService().didChangeConfiguration(configParams)
+
+      // Send a didSave event to trigger recompilation and IR publication
+      val didSaveParams = new DidSaveTextDocumentParams()
+      didSaveParams.setTextDocument(textDoc.versionedTextDocumentIdentifier)
+      didSaveParams.setText(textDoc.getText)
+      server.getTextDocumentService().didSave(didSaveParams)
+
+      val expectedIRContents =
+        raw"""ModuleDecl(
+             |  test,
+             |  List(effekt, option, list, result, exception, array, string, ref),
+             |  Nil,
+             |  Nil,
+             |  List(
+             |    Val(foo_whatever, Data(Int_whatever, Nil), Return(Literal(42, Data(Int_whatever, Nil))))
+             |  ),
+             |  List(foo_whatever)
+             |)""".stripMargin
+
+      val receivedIRContent = client.receivedIR()
+      assertEquals(receivedIRContent.length, 1)
+      val fixedReceivedIR = receivedIRContent.head.content.replaceAll("Int_\\d+", "Int_whatever").replaceAll("foo_\\d+", "foo_whatever")
+      assertEquals(fixedReceivedIR, expectedIRContents)
+    }
+  }
+
   // Text document DSL
   //
   //


### PR DESCRIPTION
Server-side support for https://github.com/effekt-lang/effekt-vscode/pull/71.