### PR TITLE
Fix normalizing IR strings in LSP tests

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -52,7 +52,7 @@ class LSPTests extends FunSuite {
    */
   def normalizeIRString(ir: String): String = {
     ir.replaceAll("_\\d+", "_whatever")
-      .replaceAll("\\s+", " ")
+      .replaceAll("\\s+", "")
   }
   
   def assertIREquals(ir: String, expected: String): Unit = {


### PR DESCRIPTION
Replacing all occurrences of whitespace by a single space is not a valid approach since expected and actual output can differ in whitespace (e.g. newlines).