### PR TITLE
Add a simple `readln` function to the standard library

### DIFF
--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -47,10 +47,12 @@ extern def println(value: String): Unit =
   """
   vm "effekt::println(String)"
 
-extern def readln(): String =
+extern async def readln(): String =
+  js "$effekt.capture(callback => $effekt.readln(callback))"
   llvm """
     %result = call %Pos @c_io_readln()
-    ret %Pos %result
+    tail call void @resume_Pos(%Stack %stack, %Pos %result)
+    ret void
   """
 
 def println(value: Int): Unit = println(value.show)

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -47,6 +47,12 @@ extern def println(value: String): Unit =
   """
   vm "effekt::println(String)"
 
+extern def readln(): String =
+  llvm """
+    %result = call %Pos @c_io_readln()
+    ret %Pos %result
+  """
+
 def println(value: Int): Unit = println(value.show)
 def println(value: Unit): Unit = println(value.show)
 def println(value: Double): Unit = println(value.show)

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -42,7 +42,7 @@ extern def println(value: String): Unit =
   js "$effekt.println(${value})"
   chez "(println_impl ${value})"
   llvm """
-    call void @c_io_println_String(%Pos ${value})
+    call void @c_io_println(%Pos ${value})
     ret %Pos zeroinitializer ; Unit
   """
   vm "effekt::println(String)"

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -47,8 +47,21 @@ extern def println(value: String): Unit =
   """
   vm "effekt::println(String)"
 
+extern jsNode """
+$effekt.readln = function readln$impl(callback) {
+  const readline = require('node:readline').createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  readline.question('', (answer) => {
+    readline.close();
+    callback(answer);
+  });
+}
+"""
+
 extern async def readln(): String =
-  js "$effekt.capture(callback => $effekt.readln(callback))"
+  jsNode "$effekt.capture(callback => $effekt.readln(callback))"
   llvm """
     %result = call %Pos @c_io_readln()
     tail call void @resume_Pos(%Stack %stack, %Pos %result)

--- a/libraries/common/exception.effekt
+++ b/libraries/common/exception.effekt
@@ -54,7 +54,7 @@ extern io def panic(msg: String): Nothing =
   js "(function() { throw ${msg} })()"
   chez "(raise ${msg})"
   llvm """
-    call void @c_io_println_String(%Pos ${msg})
+    call void @c_io_println(%Pos ${msg})
     call void @exit(i32 1)
     ret %Pos zeroinitializer ; Unit
   """

--- a/libraries/js/effekt_builtins.js
+++ b/libraries/js/effekt_builtins.js
@@ -54,6 +54,17 @@ $effekt.println = function println$impl(str) {
   console.log(str); return $effekt.unit;
 }
 
+$effekt.readln = function readln$impl(callback) {
+  const readline = require('node:readline').createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  readline.question('', (answer) => {
+    readline.close();
+    callback(answer);
+  });
+}
+
 $effekt.unit = { __unit: true }
 
 $effekt.emptyMatch = function() { throw "empty match" }

--- a/libraries/js/effekt_builtins.js
+++ b/libraries/js/effekt_builtins.js
@@ -54,17 +54,6 @@ $effekt.println = function println$impl(str) {
   console.log(str); return $effekt.unit;
 }
 
-$effekt.readln = function readln$impl(callback) {
-  const readline = require('node:readline').createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  readline.question('', (answer) => {
-    readline.close();
-    callback(answer);
-  });
-}
-
 $effekt.unit = { __unit: true }
 
 $effekt.emptyMatch = function() { throw "empty match" }

--- a/libraries/llvm/bytearray.c
+++ b/libraries/llvm/bytearray.c
@@ -72,7 +72,7 @@ struct Pos c_bytearray_from_nullterminated_string(const char *data) {
 char* c_bytearray_into_nullterminated_string(const struct Pos arr) {
     uint64_t size = arr.tag;
 
-    char* result = (char*)malloc(size + 1);
+    char* result = malloc(size + 1);
 
     memcpy(result, c_bytearray_data(arr), size);
 

--- a/libraries/llvm/forward-declare-c.ll
+++ b/libraries/llvm/forward-declare-c.ll
@@ -3,10 +3,7 @@
 declare i64 @c_get_argc()
 declare %Pos @c_get_arg(i64)
 
-declare void @c_io_println_Boolean(%Pos)
-declare void @c_io_println_Int(%Int)
-declare void @c_io_println_Double(%Double)
-declare void @c_io_println_String(%Pos)
+declare void @c_io_println(%Pos)
 
 declare void @hole()
 declare void @duplicated_prompt()

--- a/libraries/llvm/forward-declare-c.ll
+++ b/libraries/llvm/forward-declare-c.ll
@@ -4,6 +4,7 @@ declare i64 @c_get_argc()
 declare %Pos @c_get_arg(i64)
 
 declare void @c_io_println(%Pos)
+declare %Pos @c_io_readln()
 
 declare void @hole()
 declare void @duplicated_prompt()

--- a/libraries/llvm/io.c
+++ b/libraries/llvm/io.c
@@ -7,19 +7,7 @@
 // Println
 // -------
 
-void c_io_println_Int(const Int n) {
-    printf("%" PRId64 "\n", n);
-}
-
-void c_io_println_Boolean(const struct Pos p) {
-    printf("%s\n", p.tag ? "true" : "false");
-}
-
-void c_io_println_Double(const Double x) {
-    printf("%g\n", x);
-}
-
-void c_io_println_String(String text) {
+void c_io_println(String text) {
     for (uint64_t j = 0; j < text.tag; ++j)
         putchar(c_bytearray_data(text)[j]);
     erasePositive(text);

--- a/libraries/llvm/io.c
+++ b/libraries/llvm/io.c
@@ -4,16 +4,35 @@
 #include <uv.h>
 #include <string.h> // to compare flag names
 
-// Println
-// -------
+// Println and Readln
+// ------------------
 
 void c_io_println(String text) {
-    for (uint64_t j = 0; j < text.tag; ++j)
+    for (uint64_t j = 0; j < text.tag; ++j) {
         putchar(c_bytearray_data(text)[j]);
+    };
     erasePositive(text);
     putchar('\n');
 }
 
+String c_io_readln() {
+    uint64_t capacity = 64;
+    uint64_t length = 0;
+    char* buffer = malloc(capacity * sizeof(char));
+
+    for (int c = getchar(); c != '\n' && c != EOF; c = getchar()) {
+        if (length >= capacity) {
+            capacity *= 2;
+            buffer = realloc(buffer, capacity * sizeof(char));
+        }
+        buffer[length] = (char)c;
+        length++;
+    }
+
+    String result = c_bytearray_construct(length, (const uint8_t*)buffer);
+    free(buffer);
+    return result;
+}
 
 // Lib UV Bindings
 // ---------------


### PR DESCRIPTION
For advanced console input and output, in the future, we will bind to `tty` in `libuv`.

How to do it for the Web?
How to do it for the VM?