### PR TITLE
Hotfix output forwarding when not capturing output

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -107,7 +107,7 @@ trait Runner[Executable] {
         process.run(new ProcessLogger {
 
           override def out(s: => String): Unit = {
-            C.config.output().emitln(s)
+            out.emitln(s)
           }
 
           override def err(s: => String): Unit = System.err.println(s)

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -103,11 +103,11 @@ trait Runner[Executable] {
     val exitCode = C.config.output() match {
       case _: kiama.util.OutputEmitter =>
         process.!< // we are not capturing the output, so forward directly
-      case out =>
+      case outs =>
         process.run(new ProcessLogger {
 
           override def out(s: => String): Unit = {
-            out.emitln(s)
+            outs.emitln(s)
           }
 
           override def err(s: => String): Unit = System.err.println(s)

--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -99,21 +99,22 @@ trait Runner[Executable] {
     else
       Process(execFile, Context.config.runArgs())
 
-    // Check if the output is a stdout one. TODO use a different method for tests and remove the else case
-    val exitCode = if (C.config.output().isInstanceOf[kiama.util.OutputEmitter]) {
-      process.!< // we are not capturing the output, so forward directly
-    } else {
-      process.run(new ProcessLogger {
+    // Check if the output is a stdout one. TODO use a different method for tests and remove the default case
+    val exitCode = C.config.output() match {
+      case _: kiama.util.OutputEmitter =>
+        process.!< // we are not capturing the output, so forward directly
+      case out =>
+        process.run(new ProcessLogger {
 
-        override def out(s: => String): Unit = {
-          C.config.output().emitln(s)
-        }
+          override def out(s: => String): Unit = {
+            C.config.output().emitln(s)
+          }
 
-        override def err(s: => String): Unit = System.err.println(s)
+          override def err(s: => String): Unit = System.err.println(s)
 
-        override def buffer[T](f: => T): T = f
+          override def buffer[T](f: => T): T = f
 
-      }, connectInput = true).exitValue()
+        }, connectInput = true).exitValue()
     }
 
     if (exitCode != 0) {


### PR DESCRIPTION
Hotfix to order input/output correctly when running programs via Effekt.
This checks if the kiama output was changed from its default via a `isInstanceOf`, which we should get rid of at some point, if we decide to use this.