### PR TITLE
Publish holes info via custom LSP notification

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -203,8 +203,7 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
     }
     try {
       publishHoles(source, config)
-    }
-    catch {
+    } catch {
       case e => client.logMessage(new MessageParams(MessageType.Error, e.toString + ":" + e.getMessage))
     }
   }

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -175,6 +175,16 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
     }
   }
 
+  /**
+   * Publish holes in the given source file
+   */
+  def publishHoles(source: Source, config: EffektConfig)(implicit C: Context): Unit = {
+    if (!workspaceService.settingBool("showHoles")) return
+    val holes = getHoles(source)
+    if (holes.isEmpty) return
+    client.publishHoles(EffektPublishHolesParams(source.name, holes.map(EffektHoleInfo.fromHoleInfo)))
+  }
+
   // Driver methods
   //
   //
@@ -189,6 +199,12 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
     try {
       publishIR(source, config)
     } catch {
+      case e => client.logMessage(new MessageParams(MessageType.Error, e.toString + ":" + e.getMessage))
+    }
+    try {
+      publishHoles(source, config)
+    }
+    catch {
       case e => client.logMessage(new MessageParams(MessageType.Error, e.toString + ":" + e.getMessage))
     }
   }
@@ -464,12 +480,12 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
     contentTpe <- C.inferredTypeOption(hole.stmts)
     if holeTpe == contentTpe
     res <- hole match {
-      case Hole(source.Return(exp), span) => for {
+      case Hole(id, source.Return(exp), span) => for {
         text <- positions.textOf(exp)
       } yield EffektCodeAction("Close hole", span, text)
 
       // <{ s1 ; s2; ... }>
-      case Hole(stmts, span) => for {
+      case Hole(id, stmts, span) => for {
         text <- positions.textOf(stmts)
       } yield EffektCodeAction("Close hole", span, s"locally { ${text} }")
     }
@@ -574,6 +590,9 @@ trait EffektLanguageClient extends LanguageClient {
    */
   @JsonNotification("$/effekt/publishIR")
   def publishIR(params: EffektPublishIRParams): Unit
+
+  @JsonNotification("$/effekt/publishHoles")
+  def publishHoles(params: EffektPublishHolesParams): Unit
 }
 
 /**
@@ -585,3 +604,39 @@ trait EffektLanguageClient extends LanguageClient {
 case class EffektPublishIRParams(filename: String,
                                  content: String
 )
+
+/**
+ * Custom LSP notification to publish Effekt holes
+ *
+ * @param uri The URI of the source file
+ * @param holes The holes in the source file
+ */
+case class EffektPublishHolesParams(uri: String, holes: List[EffektHoleInfo])
+
+/**
+ * Information about a typed hole
+ *
+ * The difference to Intelligence.HoleInfo is that it uses the appropriate LSP type for the range
+ */
+case class EffektHoleInfo(id: String,
+                    range: LSPRange,
+                    innerType: Option[String],
+                    expectedType: Option[String],
+                    importedTerms: Seq[Intelligence.TermBinding], importedTypes: Seq[Intelligence.TypeBinding],
+                    terms: Seq[Intelligence.TermBinding], types: Seq[Intelligence.TypeBinding])
+
+object EffektHoleInfo {
+  def fromHoleInfo(info: Intelligence.HoleInfo): EffektHoleInfo = {
+    EffektHoleInfo(
+      info.id,
+      convertRange(info.span.range),
+      info.innerType,
+      info.expectedType,
+      info.importedTerms,
+      info.importedTypes,
+      info.terms,
+      info.types
+    )
+  }
+}
+

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1089,7 +1089,16 @@ class LSPTests extends FunSuite {
              |      ),
              |      Return(
              |        Hole(
-             |          Return(Literal((), ValueTypeApp(Unit_whatever, Nil))),
+             |          IdDef(
+             |            hole,
+             |            Span(
+             |              StringSource(def main() = <>, file://test.effekt),
+             |              13,
+             |              15,
+             |              Synthesized()
+             |            )
+             |          ),
+             |          Return(Literal((), ValueTypeApp(Unit_405, Nil))),
              |          Span(StringSource(def main() = <>, file://test.effekt), 13, 15, Real())
              |        )
              |      ),

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1165,7 +1165,7 @@ class LSPTests extends FunSuite {
         raw"""
              |type MyInt = Int
              |def foo(x: Int): Bool = <{ x }>
-             |def bar(x: String): Int = <>
+             |def bar(x: String): Int = <{ <> }> // a hole within a hole
              |""".textDocument
       val initializeParams = new InitializeParams()
       val initializationOptions = """{"showHoles": true}"""
@@ -1179,11 +1179,6 @@ class LSPTests extends FunSuite {
       val expectedHoles = List()
 
       val termsFoo = List(
-        TermBinding(
-          qualifier = List(),
-          name = "hole",
-          `type` = None
-        ),
         TermBinding(
           qualifier = List(),
           name = "x",
@@ -1209,8 +1204,8 @@ class LSPTests extends FunSuite {
 
       val receivedHoles = client.receivedHoles()
       assertEquals(receivedHoles.length, 1)
-      assertEquals(receivedHoles.head.holes.length, 2)
-      assertEquals(receivedHoles.head.holes(0).id, "hole")
+      assertEquals(receivedHoles.head.holes.length, 3)
+      assertEquals(receivedHoles.head.holes(0).id, "foo0")
       assertEquals(receivedHoles.head.holes(0).innerType, Some("Int"))
       assertEquals(receivedHoles.head.holes(0).expectedType, Some("Bool"))
       assertEquals(receivedHoles.head.holes(0).terms.toList, termsFoo.toList)
@@ -1221,9 +1216,13 @@ class LSPTests extends FunSuite {
           definition = "type MyInt = Int"
         )
       ))
-      assertEquals(receivedHoles.head.holes(1).id, "hole")
-      assertEquals(receivedHoles.head.holes(1).innerType, Some("Unit"))
+      assertEquals(receivedHoles.head.holes(1).id, "bar0")
+      assertEquals(receivedHoles.head.holes(1).innerType, Some("Nothing"))
       assertEquals(receivedHoles.head.holes(1).expectedType, Some("Int"))
+
+      assertEquals(receivedHoles.head.holes(2).id, "bar1")
+      assertEquals(receivedHoles.head.holes(2).innerType, Some("Unit"))
+      assertEquals(receivedHoles.head.holes(2).expectedType, None)
     }
   }
 

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1,6 +1,7 @@
 package effekt
 
 import com.google.gson.{JsonElement, JsonParser}
+import effekt.Intelligence.{TermBinding, TypeBinding}
 import munit.FunSuite
 import org.eclipse.lsp4j.{CodeAction, CodeActionKind, CodeActionParams, Command, DefinitionParams, Diagnostic, DiagnosticSeverity, DidChangeConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentSymbol, DocumentSymbolParams, Hover, HoverParams, InitializeParams, InitializeResult, InlayHint, InlayHintKind, InlayHintParams, MarkupContent, MessageActionItem, MessageParams, Position, PublishDiagnosticsParams, Range, ReferenceContext, ReferenceParams, SaveOptions, ServerCapabilities, SetTraceParams, ShowMessageRequestParams, SymbolInformation, SymbolKind, TextDocumentContentChangeEvent, TextDocumentItem, TextDocumentSyncKind, TextDocumentSyncOptions, TextEdit, VersionedTextDocumentIdentifier, WorkspaceEdit}
 import org.eclipse.lsp4j.jsonrpc.messages
@@ -1154,6 +1155,78 @@ class LSPTests extends FunSuite {
     }
   }
 
+  // Effekt: Publish holes
+  //
+  //
+
+  test("Server publishes list of holes in file") {
+    withClientAndServer { (client, server) =>
+      val source =
+        raw"""
+             |type MyInt = Int
+             |def foo(x: Int): Bool = <{ x }>
+             |def bar(x: String): Int = <>
+             |""".textDocument
+      val initializeParams = new InitializeParams()
+      val initializationOptions = """{"showHoles": true}"""
+      initializeParams.setInitializationOptions(JsonParser.parseString(initializationOptions))
+      server.initialize(initializeParams).get()
+
+      val didOpenParams = new DidOpenTextDocumentParams()
+      didOpenParams.setTextDocument(source)
+      server.getTextDocumentService().didOpen(didOpenParams)
+
+      val expectedHoles = List()
+
+      val termsFoo = List(
+        TermBinding(
+          qualifier = List(),
+          name = "hole",
+          `type` = None
+        ),
+        TermBinding(
+          qualifier = List(),
+          name = "x",
+          `type` = Some(
+            value = "Int"
+          )
+        ),
+        TermBinding(
+          qualifier = List(),
+          name = "bar",
+          `type` = Some(
+            value = "String => Int"
+          )
+        ),
+        TermBinding(
+          qualifier = List(),
+          name = "foo",
+          `type` = Some(
+            value = "Int => Bool"
+          )
+        )
+      )
+
+      val receivedHoles = client.receivedHoles()
+      assertEquals(receivedHoles.length, 1)
+      assertEquals(receivedHoles.head.holes.length, 2)
+      assertEquals(receivedHoles.head.holes(0).id, "hole")
+      assertEquals(receivedHoles.head.holes(0).innerType, Some("Int"))
+      assertEquals(receivedHoles.head.holes(0).expectedType, Some("Bool"))
+      assertEquals(receivedHoles.head.holes(0).terms.toList, termsFoo.toList)
+      assertEquals(receivedHoles.head.holes(0).types, List(
+        TypeBinding(
+          qualifier = Nil,
+          name = "MyInt",
+          definition = "type MyInt = Int"
+        )
+      ))
+      assertEquals(receivedHoles.head.holes(1).id, "hole")
+      assertEquals(receivedHoles.head.holes(1).innerType, Some("Unit"))
+      assertEquals(receivedHoles.head.holes(1).expectedType, Some("Int"))
+    }
+  }
+
   // Text document DSL
   //
   //
@@ -1196,6 +1269,7 @@ class LSPTests extends FunSuite {
 class MockLanguageClient extends EffektLanguageClient {
   private val diagnosticQueue: mutable.Queue[PublishDiagnosticsParams] = mutable.Queue.empty
   private val publishIRQueue: mutable.Queue[EffektPublishIRParams] = mutable.Queue.empty
+  private val publishHolesQueue: mutable.Queue[EffektPublishHolesParams] = mutable.Queue.empty
 
   /**
    * Pops all diagnostics received since the last call to this method.
@@ -1213,6 +1287,12 @@ class MockLanguageClient extends EffektLanguageClient {
     val irs = publishIRQueue.toSeq
     publishIRQueue.clear()
     irs
+  }
+
+  def receivedHoles(): Seq[EffektPublishHolesParams] = {
+    val holes = publishHolesQueue.toSeq
+    publishHolesQueue.clear()
+    holes
   }
 
   override def telemetryEvent(`object`: Any): Unit = {
@@ -1238,6 +1318,10 @@ class MockLanguageClient extends EffektLanguageClient {
 
   override def publishIR(params: EffektPublishIRParams): Unit = {
     publishIRQueue.enqueue(params)
+  }
+
+  override def publishHoles(params: EffektPublishHolesParams): Unit = {
+    publishHolesQueue.enqueue(params)
   }
 }
 

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -316,23 +316,25 @@ trait Intelligence {
 }
 
 object Intelligence {
-  case class HoleInfo(id: String,
-                      span: Span,
-                      innerType: Option[String],
-                      expectedType: Option[String],
-                      importedTerms: Seq[TermBinding], importedTypes: Seq[TypeBinding],
-                      terms: Seq[TermBinding], types: Seq[TypeBinding])
+  case class HoleInfo(
+     id: String,
+     span: Span,
+     innerType: Option[String],
+     expectedType: Option[String],
+     importedTerms: Seq[TermBinding], importedTypes: Seq[TypeBinding],
+     terms: Seq[TermBinding], types: Seq[TypeBinding]
+  )
 
   case class TermBinding(qualifier: Seq[String], name: String, `type`: Option[String])
 
   case class TypeBinding(qualifier: Seq[String], name: String, definition: String)
 
   case class BindingInfo(
-                          importedTerms: Iterable[TermBinding],
-                          importedTypes: Iterable[TypeBinding],
-                          terms: Iterable[TermBinding],
-                          types: Iterable[TypeBinding]) {
-
+    importedTerms: Iterable[TermBinding],
+    importedTypes: Iterable[TypeBinding],
+    terms: Iterable[TermBinding],
+    types: Iterable[TypeBinding]
+  ) {
     def ++(other: BindingInfo): BindingInfo =
       BindingInfo(
         importedTerms ++ other.importedTerms,

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -1,13 +1,16 @@
 package effekt
 
-import effekt.context.{ Annotations, Context }
-import effekt.source.{ FunDef, ModuleDecl, Tree, Include }
-import kiama.util.{ Position, Source }
+import effekt.context.{Annotations, Context}
+import effekt.source.{FunDef, Include, ModuleDecl, Span, Tree}
+import effekt.symbols.Hole
+import kiama.util.{Position, Source}
+import effekt.symbols.scopes.Scope
 
 trait Intelligence {
 
   import effekt.symbols._
   import builtins.TState
+  import Intelligence._
 
   type EffektTree = kiama.relation.Tree[AnyRef & Product, ModuleDecl]
 
@@ -120,6 +123,49 @@ trait Intelligence {
                | |:------------- |:------------- |
                | | `${outerTpe}` | `${innerTpe}` |
                |""".stripMargin
+
+  def getHoles(src: Source)(using C: Context): List[HoleInfo] = for {
+    (hole, scope) <- C.annotationOption(Annotations.HolesForFile, src).getOrElse(Nil)
+    innerType = hole.innerType.map { t => pp"${t}" }
+    expectedType = hole.expectedType.map { t => pp"${t}" }
+  } yield {
+    val BindingInfo(importedTerms, importedTypes, terms, types) = allBindings(scope)
+    HoleInfo(hole.decl.id.name, hole.decl.span, innerType, expectedType, importedTerms.toList.distinct, importedTypes.toList.distinct, terms.toList.distinct, types.toList.distinct)
+  }
+
+  def allBindings(scope: Scope)(using C: Context): BindingInfo =
+    scope match {
+      case Scope.Global(imports, bindings) =>
+        val (te1, ty1) = allBindings(imports)
+        val (te2, ty2) = allBindings(bindings)
+        BindingInfo(te1, ty1, te2, ty2)
+      case Scope.Named(name, bindings, outer) =>
+        val (te, ty) = allBindings(bindings)
+        BindingInfo(Seq.empty, Seq.empty, te, ty) ++ allBindings(outer)
+      case Scope.Local(imports, bindings, outer) =>
+        val outerBindings = allBindings(outer)
+        val (te1, ty1) = allBindings(imports)
+        val (te2, ty2) = allBindings(bindings)
+        BindingInfo(te1, ty1, te2, ty2) ++ allBindings(outer)
+    }
+
+  def allBindings(bindings: Namespace, path: List[String] = Nil)(using C: Context): (Iterable[TermBinding], Iterable[TypeBinding]) =
+    val types = bindings.types.flatMap {
+      case (name, sym) =>
+        // TODO this is extremely hacky, printing is not defined for all types at the moment
+        try { Some(TypeBinding(path, name, DeclPrinter(sym))) } catch { case e => None }
+    }
+    val terms = bindings.terms.flatMap { case (name, syms) =>
+      syms.collect {
+        case sym: ValueSymbol => TermBinding(path, name, C.valueTypeOption(sym).map(t => pp"${t}"))
+        case sym: BlockSymbol => TermBinding(path, name, C.blockTypeOption(sym).map(t => pp"${t}"))
+      }
+    }
+    val (nestedTerms, nestedTypes) = bindings.namespaces.map {
+      case (name, namespace) => allBindings(namespace, path :+ name)
+    }.unzip
+
+    (terms ++ nestedTerms.flatten, types ++ nestedTypes.flatten)
 
   def allCaptures(src: Source)(using C: Context): List[(Tree, CaptureSet)] =
     C.annotationOption(Annotations.CaptureForFile, src).getOrElse(Nil)
@@ -266,5 +312,32 @@ trait Intelligence {
     case c: DefBinder =>
       val signature = C.blockTypeOption(c).orElse(c.tpe).map { tpe => pp"${c.name}: ${tpe}" }
       SymbolInfo(c, "Block binder", signature, None)
+  }
+}
+
+object Intelligence {
+  case class HoleInfo(id: String,
+                      span: Span,
+                      innerType: Option[String],
+                      expectedType: Option[String],
+                      importedTerms: Seq[TermBinding], importedTypes: Seq[TypeBinding],
+                      terms: Seq[TermBinding], types: Seq[TypeBinding])
+
+  case class TermBinding(qualifier: Seq[String], name: String, `type`: Option[String])
+
+  case class TypeBinding(qualifier: Seq[String], name: String, definition: String)
+
+  case class BindingInfo(
+                          importedTerms: Iterable[TermBinding],
+                          importedTypes: Iterable[TypeBinding],
+                          terms: Iterable[TermBinding],
+                          types: Iterable[TypeBinding]) {
+
+    def ++(other: BindingInfo): BindingInfo =
+      BindingInfo(
+        importedTerms ++ other.importedTerms,
+        importedTypes ++ other.importedTypes,
+        terms ++ other.terms,
+        types ++ other.types)
   }
 }

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -130,7 +130,7 @@ trait Intelligence {
     expectedType = hole.expectedType.map { t => pp"${t}" }
   } yield {
     val BindingInfo(importedTerms, importedTypes, terms, types) = allBindings(scope)
-    HoleInfo(hole.decl.id.name, hole.decl.span, innerType, expectedType, importedTerms.toList.distinct, importedTypes.toList.distinct, terms.toList.distinct, types.toList.distinct)
+    HoleInfo(hole.name.name, hole.decl.span, innerType, expectedType, importedTerms.toList.distinct, importedTypes.toList.distinct, terms.toList.distinct, types.toList.distinct)
   }
 
   def allBindings(scope: Scope)(using C: Context): BindingInfo =

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -419,6 +419,12 @@ object Namer extends Phase[Parsed, NameResolved] {
     case source.BlockStmt(block) =>
       Context scoped { resolveGeneric(block) }
 
+    case hole @ source.Hole(id, stmts, span) =>
+      val h = Hole(Name.local(id), hole)
+      Context.addHole(h)
+      Context.define(id, h)
+      Context scoped { resolveGeneric(stmts) }
+
     case tree @ source.TryHandle(body, handlers) =>
       resolveAll(handlers)
 
@@ -889,7 +895,10 @@ trait NamerOps extends ContextOps { Context: Context =>
    */
   private var scope: Scoping = _
 
-  private[namer] def initNamerstate(s: Scoping): Unit = scope = s
+  private[namer] def initNamerstate(s: Scoping): Unit = {
+    annotate(Annotations.HolesForFile, module.source, Nil)
+    scope = s
+  }
 
   /**
    * Override the dynamically scoped `in` to also reset namer state.
@@ -962,6 +971,11 @@ trait NamerOps extends ContextOps { Context: Context =>
     assignSymbol(id, sym)
     sym
   }
+
+  private[namer] def addHole(h: Hole): Unit =
+    val src = module.source
+    val holesSoFar = annotationOption(Annotations.HolesForFile, src).getOrElse(Nil)
+    annotate(Annotations.HolesForFile, src, holesSoFar :+ (h, scope.scope))
 
   private[namer] def allConstructorsFor(name: Name): Set[Constructor] = name match {
     case NoName => panic("Constructor needs to be named")

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -47,7 +47,7 @@ object Namer extends Phase[Parsed, NameResolved] {
   /** Current parent top-level definition (if any) */
   private val currentDefinition: DynamicVariable[Option[Def]] = DynamicVariable(None)
   /** Counter to disambiguate hole identifiers */
-  private var holeCount: mutable.HashMap[String, Int] = mutable.HashMap[String, Int]()
+  private val holeCount: mutable.HashMap[String, Int] = mutable.HashMap[String, Int]()
 
   /**
    * Run body in a context where we are currently naming `mod`.
@@ -104,7 +104,7 @@ object Namer extends Phase[Parsed, NameResolved] {
         mod
     }
 
-    holeCount = mutable.HashMap()
+    holeCount.clear()
 
     Context.timed(phaseName, src.name) { resolveGeneric(decl) }
 

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -47,7 +47,7 @@ object Namer extends Phase[Parsed, NameResolved] {
   /** Current parent top-level definition (if any) */
   private val currentDefinition: DynamicVariable[Option[Def]] = DynamicVariable(None)
   /** Counter to disambiguate hole identifiers */
-  private val holeCount: mutable.HashMap[String, Int] = mutable.HashMap[String, Int]()
+  private var holeCount: mutable.HashMap[String, Int] = mutable.HashMap[String, Int]()
 
   /**
    * Run body in a context where we are currently naming `mod`.
@@ -103,6 +103,8 @@ object Namer extends Phase[Parsed, NameResolved] {
         Context.annotate(Annotations.IncludedSymbols, im, mod)
         mod
     }
+
+    holeCount = mutable.HashMap()
 
     Context.timed(phaseName, src.name) { resolveGeneric(decl) }
 

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -4,16 +4,16 @@ package namer
 /**
  * In this file we fully qualify source types, but use symbols directly
  */
-import effekt.context.{ Annotations, Context, ContextOps }
+import effekt.context.{Annotations, Context, ContextOps}
 import effekt.context.assertions.*
 import effekt.typer.Substitutions
-import effekt.source.{ Def, Id, IdDef, IdRef, Many, MatchGuard, ModuleDecl, Tree, sourceOf }
+import effekt.source.{Def, Id, IdDef, IdRef, Many, MatchGuard, ModuleDecl, Tree, sourceOf}
 import effekt.symbols.*
 import effekt.util.messages.ErrorMessageReifier
 import effekt.symbols.scopes.*
-import effekt.source.FeatureFlag.supportedByFeatureFlags
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 import scala.util.DynamicVariable
 
 /**
@@ -44,6 +44,11 @@ object Namer extends Phase[Parsed, NameResolved] {
 
   /** Shadow stack of modules currently named, for detection of cyclic imports */
   private val currentlyNaming: DynamicVariable[List[ModuleDecl]] = DynamicVariable(List())
+  /** Current parent top-level definition (if any) */
+  private val currentDefinition: DynamicVariable[Option[Def]] = DynamicVariable(None)
+  /** Counter to disambiguate hole identifiers */
+  private val holeCount: mutable.HashMap[String, Int] = mutable.HashMap[String, Int]()
+
   /**
    * Run body in a context where we are currently naming `mod`.
    * Produces a cyclic import error when this is already the case
@@ -256,7 +261,7 @@ object Namer extends Phase[Parsed, NameResolved] {
    * 1) the passed environment is enriched with definitions
    * 2) names are resolved using the environment and written to the table
    */
-  def resolveGeneric(tree: Tree)(using Context): Unit = Context.focusing(tree) {
+  def resolveGeneric(tree: Tree)(using Context): Unit = withDefinition(tree) {
 
     // (1) === Binding Occurrences ===
     case source.ModuleDecl(path, includes, definitions, span) =>
@@ -420,9 +425,9 @@ object Namer extends Phase[Parsed, NameResolved] {
       Context scoped { resolveGeneric(block) }
 
     case hole @ source.Hole(id, stmts, span) =>
-      val h = Hole(Name.local(id), hole)
+      val h = Hole(Name.local(freshHoleId), hole)
       Context.addHole(h)
-      Context.define(id, h)
+      Context.assignSymbol(id, h)
       Context scoped { resolveGeneric(stmts) }
 
     case tree @ source.TryHandle(body, handlers) =>
@@ -589,6 +594,18 @@ object Namer extends Phase[Parsed, NameResolved] {
     case id: IdRef                => Context.resolveTerm(id)
 
     case other                    => resolveAll(other)
+  }
+
+  /**
+   * Track the current top-level definition (if any)
+   */
+  def withDefinition[T](tree: Tree)(block: Tree => T)(using Context): T = {
+    tree match {
+      case d: Def => currentDefinition.withValue(Some(d)) {
+        Context.focusing(tree)(block)
+      }
+      case _ => Context.focusing(tree)(block)
+    }
   }
 
   // TODO move away
@@ -883,6 +900,19 @@ object Namer extends Phase[Parsed, NameResolved] {
       case Nil => "{}"
       case many => many.mkString("{", ", ", "}")
     }
+
+  /**
+   * Generate a fresh hole id that is unique in the current module.
+   * Ideally, this id should be somewhat stable wrt. edits to the source code.
+   * For this, we use the name of the current top-level definition, disambiguated by a counter that increments in
+   * depth-first order as Namer traverses the syntax tree.
+   */
+  private def freshHoleId: String = {
+    val prefix = currentDefinition.value.map(_.id.name).getOrElse("hole")
+    val count = holeCount.getOrElseUpdate(prefix, 0)
+    holeCount(prefix) = count + 1
+    s"${prefix}${count}"
+  }
 }
 
 /**

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -1029,8 +1029,10 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
   def hole(): Term = {
     nonterminal:
       peek.kind match {
-        case `<>` => `<>` ~> Hole(Return(UnitLit()), span())
-        case `<{` => Hole(`<{` ~> stmts() <~ `}>`, span())
+        case `<>` => `<>` ~> Hole(IdDef("hole", span().synthesized), Return(UnitLit()), span())
+        case `<{` =>
+          val s = `<{` ~> stmts() <~ `}>`
+          Hole(IdDef("hole", span().synthesized), s, span())
         case _ => fail("Expected hole")
       }
     }

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -327,8 +327,13 @@ object Typer extends Phase[NameResolved, Typechecked] {
         // we can unify with everything.
         Result(Context.join(tpes: _*), resEff)
 
-      case source.Hole(stmt, span) =>
+      case source.Hole(id, stmt, span) =>
         val Result(tpe, effs) = checkStmt(stmt, None)
+        val h = id.symbol.asHole
+
+        h.expectedType = expected
+        h.innerType = Some(tpe)
+
         Result(expected.getOrElse(TBottom), Pure)
 
       case tree : source.New => Context.abort("Expected an expression, but got an object implementation (which is a block).")

--- a/effekt/shared/src/main/scala/effekt/context/Annotations.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Annotations.scala
@@ -180,6 +180,14 @@ object Annotations {
   )
 
   /**
+   * Used by LSP to list all holes
+   */
+  val HolesForFile = SourceAnnotation[kiama.util.Source, List[(symbols.Hole, symbols.scopes.Scope)]](
+    "HolesForFile",
+    "All holes with information about the names in scope"
+  )
+  
+  /**
    * The module a given symbol is defined in
    *
    * @deprecated

--- a/effekt/shared/src/main/scala/effekt/context/Assertions.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Assertions.scala
@@ -85,6 +85,10 @@ object assertions {
       case t: BlockSymbol => t
       case _ => reporter.panic("Expected a block symbol")
     }
+    def asHole: Hole = s match {
+      case t: Hole => t
+      case _ => reporter.abort("Expected a hole symbol")
+    }
   }
 
   extension(t: symbols.Type)(using reporter: ErrorReporter) {

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -469,8 +469,8 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       val cap: core.BlockParam = core.BlockParam(region, transform(tpe), Set(region.capture))
       Context.bind(Region(BlockLit(Nil, List(region.capture), Nil, List(cap), transform(body))))
 
-    case source.Hole(stmts, span) =>
-      Context.bind(Hole())
+    case source.Hole(id, stmts, span) =>
+      Context.bind(core.Hole())
 
     case a @ source.Assign(id, expr) =>
       val sym = a.definition

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -451,7 +451,7 @@ enum Term extends Tree {
   case Assign(id: IdRef, expr: Term) extends Term, Reference
 
   case Literal(value: Any, tpe: symbols.ValueType)
-  case Hole(stmts: Stmt, span: Span)
+  case Hole(id: IdDef, stmts: Stmt, span: Span)
 
   // Boxing and unboxing to represent first-class values
   case Box(capt: Option[CaptureSet], block: Term)
@@ -733,6 +733,7 @@ object Named {
     case Constructor => symbols.Constructor
     case Region      => symbols.TrackedParam
     case AnyPattern  => symbols.ValueParam
+    case Hole        => symbols.Hole
   }
 
   type ResolvedReferences[T <: References] = T match {

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -183,6 +183,8 @@ case class Lambda(vparams: List[ValueParam], bparams: List[BlockParam], decl: so
   def tparams = Nil
 }
 
+case class Hole(name: Name = NoName, decl: source.Hole, var expectedType: Option[ValueType] = None, var innerType: Option[ValueType] = None) extends ValueSymbol
+
 /**
  * Binders represent local value and variable binders
  *

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -183,7 +183,7 @@ case class Lambda(vparams: List[ValueParam], bparams: List[BlockParam], decl: so
   def tparams = Nil
 }
 
-case class Hole(name: Name = NoName, decl: source.Hole, var expectedType: Option[ValueType] = None, var innerType: Option[ValueType] = None) extends ValueSymbol
+case class Hole(name: Name, decl: source.Hole, var expectedType: Option[ValueType] = None, var innerType: Option[ValueType] = None) extends ValueSymbol
 
 /**
  * Binders represent local value and variable binders

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -106,8 +106,8 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
     case Region(name, body) =>
       Region(name, rewrite(body))
 
-    case Hole(stmts, span) =>
-      Hole(rewrite(stmts), span)
+    case Hole(id, stmts, span) =>
+      Hole(id, rewrite(stmts), span)
 
     case Box(c, b) =>
       Box(c, rewriteAsBlock(b))


### PR DESCRIPTION
Porting the [`feature/llm` branch](https://github.com/effekt-lang/effekt/compare/master...feature/llm) to the current state of the Effekt compiler.

Adds a custom LSP notification `$/effekt/publishHoles` that publishes a list of holes with type and binder information.

Currently, it doesn't support user-annotated names on holes but `Namer` generates a fresh identifier for each hole based on the surrounding top-level declaration, disambiguated by a simple counter. This name should be unique wrt. to the current module and is somewhat stable to changes. It breaks when the user changes the order of holes within definitions of the same name or within the same definition. It also breaks when the user changes the name of the surrounding definition.