### PR TITLE
Report wrong logical 'and', 'or'

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -117,6 +117,7 @@ object TokenKind {
   val `resume` = TokenKind.Ident("resume")
   val `in` = TokenKind.Ident("in")
   val `at` = TokenKind.Ident("at")
+  val `or` = TokenKind.Ident("or") // unused!
   val `__` = Ident("_")
 
   def explain(kind: TokenKind): String = kind match {


### PR DESCRIPTION
Is there a way to make the code not horrible?

Additionally, one common mistake people make is writing:
```effekt
case Foo(x) if x > 5
```
instead of `and`.

But specialising for that is even worse, it's usually in:
```scala
manyWhile(`and` ~> matchGuard(), `and`)
```

So we'd need something like
```scala
`and` 🙁 `if` ~> softFail("We use 'if' around here")
```

as in:
"try to parse this terminal, then try to recover with this other terminal, reporting a soft fail"

Then even the code included here would not be that horrible...