### PR TITLE
Output package.json when generating JavaScript for Node

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -177,6 +177,13 @@ object JSNodeRunner extends Runner[String] {
     // create "executable" using shebang besides the .js file
     val jsScript = s"require('./${jsFileName}').main()"
 
+    // Create a package.json that declares that the generated JavaScript files are CommonJS modules (rather than ES modules).
+    // This is needed in case the user has set the global default to ES modules, for instance with a default ~/package.json file.
+    // See https://github.com/effekt-lang/effekt/issues/834 for more details
+    val packageJson = """{ "type": "commonjs" }"""
+    val packageJsonFilePath = (out / "package.json").canonicalPath.escape
+    IO.createFile(packageJsonFilePath, packageJson)
+
     os match {
       case OS.POSIX =>
         val shebang = "#!/usr/bin/env node"


### PR DESCRIPTION
Fixes #834.

Manually tested on Ubuntu 24.04.

Adding a default `~/package.json` before the changes:

```console
tim@ub0 ~/D/e/playground> effekt helloworld.effekt 
file:///home/tim/Dev/effekt-lang/playground/out/helloworld:2
require('./helloworld.js').main()
^

ReferenceError: require is not defined in ES module scope, you can use import instead
    at file:///home/tim/Dev/effekt-lang/playground/out/helloworld:2:1
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:336:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12)

Node.js v18.19.1
[error] Process exited with non-zero exit code 1.
```

After these changes:

```console
tim@ub0 ~/D/e/playground [1]> effekt helloworld.effekt
Hello
```

It also continues to work without a default `~/package.json`.
Do you want an automated test case for this? 

* [x] Test on Ubuntu
* [x] Test on Windows
* [x] Test on WSL
* [x] Test on macOS