### PR TITLE
Improve compiler debugging by adding show method to most core trees/types

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -108,7 +108,9 @@ case class ModuleDecl(
   externs: List[Extern],
   definitions: List[Toplevel],
   exports: List[Id]
-) extends Tree
+) extends Tree {
+  def show: String = util.show(this)
+}
 
 /**
  * Toplevel data and interface declarations
@@ -157,6 +159,8 @@ enum Toplevel {
 sealed trait Expr extends Tree {
   val tpe: ValueType = Type.inferType(this)
   val capt: Captures = Type.inferCapt(this)
+
+  def show: String = util.show(this)
 }
 
 // invariant, block b is {io}.
@@ -219,6 +223,8 @@ enum Block extends Tree {
 
   val tpe: BlockType = Type.inferType(this)
   val capt: Captures = Type.inferCapt(this)
+
+  def show: String = util.show(this)
 }
 export Block.*
 
@@ -301,6 +307,8 @@ enum Stmt extends Tree {
 
   val tpe: ValueType = Type.inferType(this)
   val capt: Captures = Type.inferCapt(this)
+
+  def show: String = util.show(this)
 }
 export Stmt.*
 

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -29,7 +29,9 @@ type Captures = Set[Capture]
  *
  * -------------------------------------------
  */
-sealed trait Type
+sealed trait Type {
+  def show: String = util.show(this)
+}
 
 enum ValueType extends Type {
   case Var(name: Id)


### PR DESCRIPTION
When debugging with IntelliJ it can be very helpful to use custom renderers.  As far as I managed to use them, they require `show` to be a method on the object, hence this PR.

In order to use them, in the debugger window, right click and select: "Custom DataViews" 

<img width="273" alt="image" src="https://github.com/user-attachments/assets/3c862c20-8595-443d-8c20-45f3ba341110" />

Then add a new one (for instance for `core.Type`) and enter `show` as Scala expression
<img width="773" alt="image" src="https://github.com/user-attachments/assets/f5af0be9-df0f-4b5a-a1fe-60ba47148521" />

IntelliJ then uses `show` to render core types when debugging:

<img width="751" alt="image" src="https://github.com/user-attachments/assets/a4fac76d-3b8b-436f-beb2-39f3c0b8df9a" />
