### PR TITLE
Show type of region-allocated variables on hover

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -292,14 +292,15 @@ trait Intelligence {
       SymbolInfo(c, "Mutable variable binder", signature, Some(ex))
 
     case s: RegBinder =>
+      val signature = C.blockTypeOption(s).map(TState.extractType).orElse(s.tpe).map { tpe => pp"${s.name}: ${tpe}" }
 
       val ex =
-        pp"""|The region a variable is allocated into (${s.region}) not only affects its lifetime, but
-             |also its backtracking behavior in combination with continuation capture and
-             |resumption.
-             |""".stripMargin
+        s"""|The region `${s.region.name}` the variable `${s.name}` is allocated into
+            |not only affects its lifetime, but also its backtracking behavior
+            |in combination with continuation capture and resumption.
+            |""".stripMargin
 
-      SymbolInfo(s, "Variable in region", None, Some(ex))
+      SymbolInfo(s, "Variable in region", signature, Some(ex))
 
     case c: ValueParam =>
       val signature = C.valueTypeOption(c).orElse(c.tpe).map { tpe => pp"${c.name}: ${tpe}" }


### PR DESCRIPTION
Resolves #924

Before (screenshot from #924):
![image](https://github.com/user-attachments/assets/c1d4fb9d-bc5e-40b9-8ac1-68d6148aff40)

After this PR:
<img width="804" alt="Screenshot 2025-05-18 at 15 51 00" src="https://github.com/user-attachments/assets/208e317e-8c7a-4b79-9bcd-678defae2ffe" />

More complicated example (Scheduler case study):
<img width="844" alt="Screenshot 2025-05-18 at 15 53 32" src="https://github.com/user-attachments/assets/731f8abe-6cd6-4cff-98d0-489d3b5d679c" />

I haven't really changed the text, but we can do so if needed.