### PR TITLE
Fix serialization of hole info

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/GsonUtil.scala
+++ b/effekt/jvm/src/main/scala/effekt/GsonUtil.scala
@@ -43,20 +43,18 @@ class ScalaListTypeAdapter extends JsonSerializer[scala.collection.immutable.Lis
   }
 }
 
-implicit class GsonBuilderScalaOps(val builder: GsonBuilder) extends AnyVal {
-  /**
-   * Make the Scala Option[_] and List[_] types (de)serialize correctly with Gson.
-   *
-   * As a Java library, Gson does not special case any Scala types. This leads to unexpected (de)serialization by default.
-   * By default, Some(x) serializes to {"value":x} and None serializes to {}.
-   * List serializes to nested JSON objects.
-   *
-   * This method adds custom (de)serializers such that
-   * - Some(x) serializes to x and None serializes to null
-   * - List serializes to a flat JSON array.
-   */
-  def withScalaSupport: GsonBuilder =
-    builder
-      .registerTypeHierarchyAdapter(classOf[Option[_]], new ScalaOptionTypeAdapter)
-      .registerTypeHierarchyAdapter(classOf[List[_]],   new ScalaListTypeAdapter)
-}
+/**
+ * Make the Scala Option[_] and List[_] types (de)serialize correctly with Gson.
+ *
+ * As a Java library, Gson does not special case any Scala types. This leads to unexpected (de)serialization by default.
+ * By default, Some(x) serializes to {"value":x} and None serializes to {}.
+ * List serializes to nested JSON objects.
+ *
+ * This method adds custom (de)serializers such that
+ * - Some(x) serializes to x and None serializes to null
+ * - List serializes to a flat JSON array.
+ */
+extension (builder: GsonBuilder) def withScalaSupport: GsonBuilder =
+  builder
+    .registerTypeHierarchyAdapter(classOf[Option[_]], new ScalaOptionTypeAdapter)
+    .registerTypeHierarchyAdapter(classOf[List[_]], new ScalaListTypeAdapter)

--- a/effekt/jvm/src/main/scala/effekt/GsonUtil.scala
+++ b/effekt/jvm/src/main/scala/effekt/GsonUtil.scala
@@ -1,0 +1,62 @@
+package effekt
+
+import com.google.gson._
+import com.google.gson.reflect.TypeToken
+import java.lang.reflect.{ParameterizedType, Type}
+import scala.jdk.CollectionConverters._
+
+class ScalaOptionTypeAdapter extends JsonSerializer[Option[Any]] with JsonDeserializer[Option[Any]] {
+  override def serialize(src: Option[Any], typeOfSrc: Type, context: JsonSerializationContext): JsonElement = {
+    src match {
+      case Some(value) => context.serialize(value)
+      case None        => JsonNull.INSTANCE
+    }
+  }
+
+  override def deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Option[Any] = {
+    val innerType = typeOfT match {
+      case pt: ParameterizedType => pt.getActualTypeArguments.head
+      case _                     => classOf[Object]
+    }
+
+    if (json.isJsonNull) None
+    else Some(context.deserialize(json, innerType))
+  }
+}
+
+class ScalaListTypeAdapter extends JsonSerializer[scala.collection.immutable.List[Any]] with JsonDeserializer[scala.collection.immutable.List[Any]] {
+  override def serialize(src: scala.collection.immutable.List[Any], typeOfSrc: Type, context: JsonSerializationContext): JsonElement = {
+    val javaList: java.util.List[Any] = src.asJava
+    context.serialize(javaList)
+  }
+
+  override def deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): scala.collection.immutable.List[Any] = {
+    val elemType = typeOfT match {
+      case pt: ParameterizedType => pt.getActualTypeArguments.head
+      case _                     => classOf[Object]
+    }
+
+    val listType = TypeToken.getParameterized(classOf[java.util.List[_]], elemType).getType
+    val javaList = context.deserialize[java.util.List[Any]](json, listType)
+
+    javaList.asScala.toList
+  }
+}
+
+implicit class GsonBuilderScalaOps(val builder: GsonBuilder) extends AnyVal {
+  /**
+   * Make the Scala Option[_] and List[_] types (de)serialize correctly with Gson.
+   *
+   * As a Java library, Gson does not special case any Scala types. This leads to unexpected (de)serialization by default.
+   * By default, Some(x) serializes to {"value":x} and None serializes to {}.
+   * List serializes to nested JSON objects.
+   *
+   * This method adds custom (de)serializers such that
+   * - Some(x) serializes to x and None serializes to null
+   * - List serializes to a flat JSON array.
+   */
+  def withScalaSupport: GsonBuilder =
+    builder
+      .registerTypeHierarchyAdapter(classOf[Option[_]], new ScalaOptionTypeAdapter)
+      .registerTypeHierarchyAdapter(classOf[List[_]],   new ScalaListTypeAdapter)
+}

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -180,7 +180,7 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
    */
   def publishHoles(source: Source, config: EffektConfig)(implicit C: Context): Unit = {
     if (!workspaceService.settingBool("showHoles")) return
-    val holes = getHoles(source).toArray
+    val holes = getHoles(source)
     if (holes.isEmpty) return
     client.publishHoles(EffektPublishHolesParams(source.name, holes.map(EffektHoleInfo.fromHoleInfo)))
   }
@@ -596,7 +596,7 @@ case class EffektPublishIRParams(filename: String,
  * @param uri The URI of the source file
  * @param holes The holes in the source file
  */
-case class EffektPublishHolesParams(uri: String, holes: Array[EffektHoleInfo])
+case class EffektPublishHolesParams(uri: String, holes: List[EffektHoleInfo])
 
 /**
  * Information about a typed hole

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -180,7 +180,7 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
    */
   def publishHoles(source: Source, config: EffektConfig)(implicit C: Context): Unit = {
     if (!workspaceService.settingBool("showHoles")) return
-    val holes = getHoles(source)
+    val holes = getHoles(source).toArray
     if (holes.isEmpty) return
     client.publishHoles(EffektPublishHolesParams(source.name, holes.map(EffektHoleInfo.fromHoleInfo)))
   }
@@ -220,25 +220,6 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
 
   def connect(client: EffektLanguageClient): Unit = {
     this.client = client
-  }
-
-  /**
-   * Launch a language server using provided input/output streams.
-   * This allows tests to connect via in-memory pipes.
-   */
-  def launch(client: EffektLanguageClient, in: InputStream, out: OutputStream): Launcher[EffektLanguageClient] = {
-    val executor = Executors.newSingleThreadExecutor()
-    val launcher =
-      new LSPLauncher.Builder()
-        .setLocalService(this)
-        .setRemoteInterface(classOf[EffektLanguageClient])
-        .setInput(in)
-        .setOutput(out)
-        .setExecutorService(executor)
-        .create()
-    this.connect(client)
-    launcher.startListening()
-    launcher
   }
 
   // LSP Document Lifecycle
@@ -539,6 +520,34 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
   }
 
   /**
+   * Launch a language server using provided input/output streams.
+   * This allows tests to connect via in-memory pipes.
+   */
+  def launch(getClient: Launcher[EffektLanguageClient] => EffektLanguageClient, in: InputStream, out: OutputStream, trace: Boolean = false): Launcher[EffektLanguageClient] = {
+    // Create a single-threaded executor to serialize all requests.
+    val executor: ExecutorService = Executors.newSingleThreadExecutor()
+
+    val builder =
+      new LSPLauncher.Builder()
+        .setLocalService(this)
+        .setRemoteInterface(classOf[EffektLanguageClient])
+        .setInput(in)
+        .setOutput(out)
+        .setExecutorService(executor)
+        // This line makes sure that the List and Option Scala types serialize correctly
+        .configureGson(_.withScalaSupport)
+
+    if (trace) {
+      builder.traceMessages(new PrintWriter(System.err, true))
+    }
+
+    val launcher = builder.create()
+    this.connect(getClient(launcher))
+    launcher.startListening()
+    launcher
+  }
+
+  /**
    * Launch a language server with a given `ServerConfig`
    */
   def launch(config: ServerConfig): Unit = {
@@ -549,32 +558,9 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
       val serverSocket = new ServerSocket(config.debugPort)
       System.err.println(s"Starting language server in debug mode on port ${config.debugPort}")
       val socket = serverSocket.accept()
-
-      val launcher =
-        new LSPLauncher.Builder()
-          .setLocalService(this)
-          .setRemoteInterface(classOf[EffektLanguageClient])
-          .setInput(socket.getInputStream)
-          .setOutput(socket.getOutputStream)
-          .setExecutorService(executor)
-          .traceMessages(new PrintWriter(System.err, true))
-          .create()
-      val client = launcher.getRemoteProxy
-      this.connect(client)
-      launcher.startListening()
+      launch(_.getRemoteProxy, socket.getInputStream, socket.getOutputStream, trace = true)
     } else {
-      val launcher =
-        new LSPLauncher.Builder()
-          .setLocalService(this)
-          .setRemoteInterface(classOf[EffektLanguageClient])
-          .setInput(System.in)
-          .setOutput(System.out)
-          .setExecutorService(executor)
-          .create()
-
-      val client = launcher.getRemoteProxy
-      this.connect(client)
-      launcher.startListening()
+      launch(_.getRemoteProxy, System.in, System.out)
     }
   }
 }
@@ -610,7 +596,7 @@ case class EffektPublishIRParams(filename: String,
  * @param uri The URI of the source file
  * @param holes The holes in the source file
  */
-case class EffektPublishHolesParams(uri: String, holes: List[EffektHoleInfo])
+case class EffektPublishHolesParams(uri: String, holes: Array[EffektHoleInfo])
 
 /**
  * Information about a typed hole
@@ -621,8 +607,8 @@ case class EffektHoleInfo(id: String,
                     range: LSPRange,
                     innerType: Option[String],
                     expectedType: Option[String],
-                    importedTerms: Seq[Intelligence.TermBinding], importedTypes: Seq[Intelligence.TypeBinding],
-                    terms: Seq[Intelligence.TermBinding], types: Seq[Intelligence.TypeBinding])
+                    importedTerms: List[Intelligence.TermBinding], importedTypes: List[Intelligence.TypeBinding],
+                    terms: List[Intelligence.TermBinding], types: List[Intelligence.TypeBinding])
 
 object EffektHoleInfo {
   def fromHoleInfo(info: Intelligence.HoleInfo): EffektHoleInfo = {
@@ -638,4 +624,3 @@ object EffektHoleInfo {
     )
   }
 }
-

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1185,25 +1185,25 @@ class LSPTests extends FunSuite {
       didOpenParams.setTextDocument(source)
       server.getTextDocumentService().didOpen(didOpenParams)
 
-      val expectedHoles = Array[EffektHoleInfo]()
+      val expectedHoles = List()
 
       val termsFoo = List(
         TermBinding(
-          qualifier = Nil,
+          qualifier = List(),
           name = "x",
           `type` = Some(
             "Int"
           )
         ),
         TermBinding(
-          qualifier = Nil,
+          qualifier = List(),
           name = "bar",
           `type` = Some(
             "String => Int"
           )
         ),
         TermBinding(
-          qualifier = Nil,
+          qualifier = List(),
           name = "foo",
           `type` = Some(
             "Int => Bool"

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1,6 +1,6 @@
 package effekt
 
-import com.google.gson.{JsonElement, JsonParser}
+import com.google.gson.{Gson, GsonBuilder, JsonElement, JsonParser}
 import effekt.Intelligence.{TermBinding, TypeBinding}
 import munit.FunSuite
 import org.eclipse.lsp4j.{CodeAction, CodeActionKind, CodeActionParams, Command, DefinitionParams, Diagnostic, DiagnosticSeverity, DidChangeConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentSymbol, DocumentSymbolParams, Hover, HoverParams, InitializeParams, InitializeResult, InlayHint, InlayHintKind, InlayHintParams, MarkupContent, MessageActionItem, MessageParams, Position, PublishDiagnosticsParams, Range, ReferenceContext, ReferenceParams, SaveOptions, ServerCapabilities, SetTraceParams, ShowMessageRequestParams, SymbolInformation, SymbolKind, TextDocumentContentChangeEvent, TextDocumentItem, TextDocumentSyncKind, TextDocumentSyncOptions, TextEdit, VersionedTextDocumentIdentifier, WorkspaceEdit}
@@ -40,7 +40,7 @@ class LSPTests extends FunSuite {
     val mockClient = new MockLanguageClient()
     server.connect(mockClient)
 
-    val launcher = server.launch(mockClient, serverIn, serverOut)
+    val launcher = server.launch(_ => mockClient, serverIn, serverOut)
 
     testBlock(mockClient, server)
   }
@@ -1185,28 +1185,28 @@ class LSPTests extends FunSuite {
       didOpenParams.setTextDocument(source)
       server.getTextDocumentService().didOpen(didOpenParams)
 
-      val expectedHoles = List()
+      val expectedHoles = Array[EffektHoleInfo]()
 
       val termsFoo = List(
         TermBinding(
-          qualifier = List(),
+          qualifier = Nil,
           name = "x",
           `type` = Some(
-            value = "Int"
+            "Int"
           )
         ),
         TermBinding(
-          qualifier = List(),
+          qualifier = Nil,
           name = "bar",
           `type` = Some(
-            value = "String => Int"
+            "String => Int"
           )
         ),
         TermBinding(
-          qualifier = List(),
+          qualifier = Nil,
           name = "foo",
           `type` = Some(
-            value = "Int => Bool"
+            "Int => Bool"
           )
         )
       )
@@ -1217,7 +1217,7 @@ class LSPTests extends FunSuite {
       assertEquals(receivedHoles.head.holes(0).id, "foo0")
       assertEquals(receivedHoles.head.holes(0).innerType, Some("Int"))
       assertEquals(receivedHoles.head.holes(0).expectedType, Some("Bool"))
-      assertEquals(receivedHoles.head.holes(0).terms.toList, termsFoo.toList)
+      assertEquals(receivedHoles.head.holes(0).terms, termsFoo)
       assertEquals(receivedHoles.head.holes(0).types, List(
         TypeBinding(
           qualifier = Nil,
@@ -1260,6 +1260,50 @@ class LSPTests extends FunSuite {
       assertEquals(receivedHoles.head.holes.head.id, "foo_bar0")
     }
   }
+
+  /**
+   * By default, Scala types such as List and Option show pathological (de)serialization behavior with Gson.
+   * We use a custom extension method `withScalaSupport` which adds support for Scala collections, fixing serialization.
+   */
+  test("Hole info serializes to expected JSON") {
+    val holeInfo = EffektHoleInfo(
+      id = "foo_bar0",
+      range = new Range(
+        new Position(0, 0),
+        new Position(0, 0)
+      ),
+      innerType = None,
+      expectedType = Some("Bool"),
+      importedTerms = Nil,
+      importedTypes = Nil,
+      terms = List(
+        TermBinding(
+          qualifier = Nil,
+          name = "x",
+          `type` = Some("Int")
+        )
+      ),
+      types = List(
+        TypeBinding(
+          qualifier = Nil,
+          name = "MyInt",
+          definition = "type MyInt = Int"
+        )
+      )
+    )
+
+    val expectedJsonStr =
+      """{"id":"foo_bar0","range":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}},"expectedType":"Bool","importedTerms":[],"importedTypes":[],"terms":[{"qualifier":[],"name":"x","type":"Int"}],"types":[{"qualifier":[],"name":"MyInt","definition":"type MyInt = Int"}]}""".stripMargin
+
+    val expectedJson: JsonElement = JsonParser.parseString(expectedJsonStr)
+
+    val gson: Gson = new GsonBuilder().withScalaSupport.create()
+
+    val actualJson: JsonElement = gson.toJsonTree(holeInfo)
+
+    assertEquals(actualJson, expectedJson)
+  }
+
 
   // Text document DSL
   //

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -321,13 +321,13 @@ object Intelligence {
      span: Span,
      innerType: Option[String],
      expectedType: Option[String],
-     importedTerms: Seq[TermBinding], importedTypes: Seq[TypeBinding],
-     terms: Seq[TermBinding], types: Seq[TypeBinding]
+     importedTerms: List[TermBinding], importedTypes: List[TypeBinding],
+     terms: List[TermBinding], types: List[TypeBinding]
   )
 
-  case class TermBinding(qualifier: Seq[String], name: String, `type`: Option[String])
+  case class TermBinding(qualifier: List[String], name: String, `type`: Option[String])
 
-  case class TypeBinding(qualifier: Seq[String], name: String, definition: String)
+  case class TypeBinding(qualifier: List[String], name: String, definition: String)
 
   case class BindingInfo(
     importedTerms: Iterable[TermBinding],


### PR DESCRIPTION
LSP4j uses the Gson Java library to (de)serialize JSON as part of the language server protocol. As a Java library, Gson doesn't special-case the Scala types Option and List (or any other Scala types for that matter), leading to undesirable output for these based on the default runtime-reflection based (de)serialization logic.

This PR fixes it by registering custom type adapters for scala `List` and `Option` with Gson.