### PR TITLE
Implement hole hover for website playground

### DIFF
--- a/effekt/js/src/main/scala/effekt/LanguageServer.scala
+++ b/effekt/js/src/main/scala/effekt/LanguageServer.scala
@@ -72,11 +72,9 @@ class LanguageServer extends Intelligence {
   @JSExport
   def infoAt(path: String, pos: lsp.Position): String = {
     val p = fromLSPPosition(pos, VirtualFileSource(path))
-    for {
-      (tree, sym) <- getSymbolAt(p)
-      info <- getInfoOf(sym)
-    } yield info.fullDescription
-  }.orNull
+    val hover = getSymbolHover(p)(using context) orElse getHoleHover(p)(using context)
+    hover.orNull
+  }
 
   @JSExport
   def typecheck(path: String): js.Array[lsp.Diagnostic] = {

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -264,24 +264,13 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
     }
     position match
       case Some(position) => {
-        val hover = getSymbolHover(position) orElse getHoleHover(position)
+        val hover = getSymbolHover(position, settingBool("showExplanations"))(using context) orElse getHoleHover(position)(using context)
         val markup = new MarkupContent("markdown", hover.getOrElse(""))
         val result = new Hover(markup, new LSPRange(params.getPosition, params.getPosition))
         CompletableFuture.completedFuture(result)
       }
       case None => CompletableFuture.completedFuture(new Hover())
   }
-
-  def getSymbolHover(position: Position): Option[String] = for {
-    (tree, sym) <- getSymbolAt(position)(using context)
-    info <- getInfoOf(sym)(using context)
-  } yield if (settingBool("showExplanations")) info.fullDescription else info.shortDescription
-
-  def getHoleHover(position: Position): Option[String] = for {
-    trees <- getTreesAt(position)(using context)
-    tree <- trees.collectFirst { case h: source.Hole => h }
-    info <- getHoleInfo(tree)(using context)
-  } yield info
 
   // LSP Document Symbols
   //

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -116,6 +116,17 @@ trait Intelligence {
     case s             => s
   }
 
+  def getSymbolHover(position: Position, fullDescription: Boolean = true)(using C: Context): Option[String] = for {
+    (tree, sym) <- getSymbolAt(position)
+    info <- getInfoOf(sym)
+  } yield if (fullDescription) info.fullDescription else info.shortDescription
+
+  def getHoleHover(position: Position)(using C: Context): Option[String] = for {
+    trees <- getTreesAt(position)
+    tree <- trees.collectFirst { case h: source.Hole => h }
+    info <- getHoleInfo(tree)
+  } yield info
+
   def getHoleInfo(hole: source.Hole)(using C: Context): Option[String] = for {
     (outerTpe, outerEff) <- C.inferredTypeAndEffectOption(hole)
     (innerTpe, innerEff) <- C.inferredTypeAndEffectOption(hole.stmts)


### PR DESCRIPTION
Fixes https://github.com/effekt-lang/effekt-website/issues/3.
The info shown still can be improved, of course, but when we do that, it will happen for both the JVM language server and the website because `getHoleHover` is now implemented on `Intelligence`.

Tested locally for the website playground:

![Screenshot from 2025-05-21 16-14-04](https://github.com/user-attachments/assets/c2bc7d55-318a-41b4-a514-2a7151387e02)
