### PR TITLE
Add inlay hints for showing omitted function return types

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -407,14 +407,14 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
               pos = fun.ret.span.range.from
             } yield {
               val prettyType = pp": ${tpe.result} / ${tpe.effects}"
-              val inlayHint = new InlayHint(convertPosition(pos), messages.Either.forLeft(pp": ${tpe.result} / ${tpe.effects}"))
+              val inlayHint = new InlayHint(convertPosition(pos), messages.Either.forLeft(prettyType))
               inlayHint.setKind(InlayHintKind.Type)
               val markup = new MarkupContent()
               markup.setValue(s"return type${prettyType}")
               markup.setKind("markdown")
               inlayHint.setTooltip(markup)
               inlayHint.setPaddingLeft(true)
-              inlayHint.setData("omitted-type-annotation")
+              inlayHint.setData("return-type-annotation")
               val textEdit = new TextEdit(convertRange(fun.ret.span.range), prettyType)
               inlayHint.setTextEdits(Collections.seqToJavaList(List(textEdit)))
               inlayHint

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -8,7 +8,7 @@ import effekt.source.{Span, Tree}
 import effekt.symbols.Binder.{ValBinder, VarBinder}
 import effekt.symbols.BlockTypeConstructor.{ExternInterface, Interface}
 import effekt.symbols.TypeConstructor.{DataType, ExternType}
-import effekt.symbols.{Anon, Binder, Callable, Effects, Module, Param, Symbol, TypeAlias, TypePrinter, UserFunction, ValueType, isSynthetic}
+import effekt.symbols.{Anon, Binder, Callable, Effects, ErrorMessageInterpolator, Module, Param, Symbol, TypeAlias, TypePrinter, UserFunction, ValueType, isSynthetic}
 import effekt.util.messages.EffektError
 import effekt.util.{PlainMessaging, PrettyPrinter}
 import kiama.util.Collections.{mapToJavaMap, seqToJavaList}
@@ -384,7 +384,7 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
       source <- sources.get(params.getTextDocument.getUri)
       hints = {
         val range = fromLSPRange(params.getRange, source)
-        getInferredCaptures(range)(using context).map {
+        val captures = getInferredCaptures(range)(using context).map {
           case (p, c) =>
             val prettyCaptures = TypePrinter.show(c)
             val inlayHint = new InlayHint(convertPosition(p), messages.Either.forLeft(prettyCaptures))
@@ -397,6 +397,32 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
             inlayHint.setData("capture")
             inlayHint
         }.toVector
+
+        val unannotated = getTreesInRange(range)(using context).map { trees =>
+          trees.collect {
+            // Functions without an annotated type:
+            case fun: FunDef if fun.ret.isEmpty => for {
+              sym <- context.symbolOption(fun.id)
+              tpe <- context.functionTypeOption(sym)
+              pos = fun.ret.span.range.from
+            } yield {
+              val prettyType = pp": ${tpe.result} / ${tpe.effects}"
+              val inlayHint = new InlayHint(convertPosition(pos), messages.Either.forLeft(pp": ${tpe.result} / ${tpe.effects}"))
+              inlayHint.setKind(InlayHintKind.Type)
+              val markup = new MarkupContent()
+              markup.setValue(s"return type${prettyType}")
+              markup.setKind("markdown")
+              inlayHint.setTooltip(markup)
+              inlayHint.setPaddingLeft(true)
+              inlayHint.setData("omitted-type-annotation")
+              val textEdit = new TextEdit(convertRange(fun.ret.span.range), prettyType)
+              inlayHint.setTextEdits(Collections.seqToJavaList(List(textEdit)))
+              inlayHint
+            }
+          }.flatten
+        }.getOrElse(Vector())
+
+        captures ++ unannotated
       }
     } yield hints
 

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -632,7 +632,7 @@ class LSPTests extends FunSuite {
       omittedHint.setKind(InlayHintKind.Type)
       omittedHint.setPosition(positions(1))
       omittedHint.setLabel(": Int / {}")
-      omittedHint.setData("omitted-type-annotation")
+      omittedHint.setData("return-type-annotation")
       omittedHint.setTextEdits(List(
         new TextEdit(
           new Range(positions(1), positions(1)),

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -298,7 +298,7 @@ case class Maybe[T](unspan: Option[T], span: Span) {
       case None => alternative
     }
 
-  export unspan.{foreach, get, getOrElse}
+  export unspan.{foreach, get, getOrElse, isEmpty}
 }
 
 object Maybe {


### PR DESCRIPTION
Fixes #869. The attached text edits also suffer from #1001.