### PR TITLE
Use a ArrayBuffer in Lexer, pre-reserving space for tokens

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -245,10 +245,10 @@ class RecursiveDescentTests extends munit.FunSuite {
 
   test("Peeking") {
     implicit def toToken(t: TokenKind): Token = Token(0, 0, t)
-    def peek(tokens: IndexedSeq[Token], offset: Int): Token =
+    def peek(tokens: Array[Token], offset: Int): Token =
       new RecursiveDescent(new Positions, tokens, StringSource("", "test")).peek(offset)
 
-    val tokens = Vector[Token](`(`, Space, Newline, `)`, Space, `=>`, EOF)
+    val tokens = Vector[Token](`(`, Space, Newline, `)`, Space, `=>`, EOF).toArray
     assertEquals(peek(tokens, 0).kind, `(`)
     assertEquals(peek(tokens, 1).kind, `)`)
     assertEquals(peek(tokens, 2).kind, `=>`)

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -248,7 +248,7 @@ class RecursiveDescentTests extends munit.FunSuite {
     def peek(tokens: Array[Token], offset: Int): Token =
       new RecursiveDescent(new Positions, tokens, StringSource("", "test")).peek(offset)
 
-    val tokens = Vector[Token](`(`, Space, Newline, `)`, Space, `=>`, EOF).toArray
+    val tokens = Array[Token](`(`, Space, Newline, `)`, Space, `=>`, EOF)
     assertEquals(peek(tokens, 0).kind, `(`)
     assertEquals(peek(tokens, 1).kind, `)`)
     assertEquals(peek(tokens, 2).kind, `=>`)

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -245,10 +245,10 @@ class RecursiveDescentTests extends munit.FunSuite {
 
   test("Peeking") {
     implicit def toToken(t: TokenKind): Token = Token(0, 0, t)
-    def peek(tokens: Array[Token], offset: Int): Token =
+    def peek(tokens: IndexedSeq[Token], offset: Int): Token =
       new RecursiveDescent(new Positions, tokens, StringSource("", "test")).peek(offset)
 
-    val tokens = List[Token](`(`, Space, Newline, `)`, Space, `=>`, EOF).toArray
+    val tokens = Vector[Token](`(`, Space, Newline, `)`, Space, `=>`, EOF)
     assertEquals(peek(tokens, 0).kind, `(`)
     assertEquals(peek(tokens, 1).kind, `)`)
     assertEquals(peek(tokens, 2).kind, `=>`)

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -245,10 +245,10 @@ class RecursiveDescentTests extends munit.FunSuite {
 
   test("Peeking") {
     implicit def toToken(t: TokenKind): Token = Token(0, 0, t)
-    def peek(tokens: Seq[Token], offset: Int): Token =
+    def peek(tokens: Array[Token], offset: Int): Token =
       new RecursiveDescent(new Positions, tokens, StringSource("", "test")).peek(offset)
 
-    val tokens = List[Token](`(`, Space, Newline, `)`, Space, `=>`, EOF)
+    val tokens = List[Token](`(`, Space, Newline, `)`, Space, `=>`, EOF).toArray
     assertEquals(peek(tokens, 0).kind, `(`)
     assertEquals(peek(tokens, 1).kind, `)`)
     assertEquals(peek(tokens, 2).kind, `=>`)

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -169,7 +169,7 @@ class Lexer(source: Source) {
    */
   var current: Int = 0
   /** The sequence of tokens the source strings contains. Returned as the result by [[Lexer.run()]] */
-  val tokens: mutable.ArrayBuffer[Token] = new mutable.ArrayBuffer(initialSize = 256)
+  val tokens: mutable.ArrayBuffer[Token] = new mutable.ArrayBuffer(initialSize = 128)
   // For future improvement, this is probably more performant than using substring on the source
   // val currLexeme: mutable.StringBuilder = mutable.StringBuilder()
   /** A peekable iterator of the source string. This is used instead of directly indexing the source string.
@@ -273,7 +273,7 @@ class Lexer(source: Source) {
     r.matches(candidate)
   }
 
-  def lex()(using ctx: Context): IArray[Token] =
+  def lex()(using ctx: Context): Array[Token] =
     try {
       run()
     } catch {
@@ -289,7 +289,7 @@ class Lexer(source: Source) {
    * If an error is encountered, all successfully scanned tokens this far will returned,
    * including the error.
    */
-  def run(): IArray[Token] = {
+  def run(): Array[Token] = {
     var eof = false
     while (!eof) {
       val kind =
@@ -320,7 +320,7 @@ class Lexer(source: Source) {
       }
       start = current
     }
-    IArray.from(tokens)
+    tokens.toArray
   }
 
   // --- Literal and comment matchers ---

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -273,7 +273,7 @@ class Lexer(source: Source) {
     r.matches(candidate)
   }
 
-  def lex()(using ctx: Context): Array[Token] =
+  def lex()(using ctx: Context): IArray[Token] =
     try {
       run()
     } catch {
@@ -289,7 +289,7 @@ class Lexer(source: Source) {
    * If an error is encountered, all successfully scanned tokens this far will returned,
    * including the error.
    */
-  def run(): Array[Token] = {
+  def run(): IArray[Token] = {
     var eof = false
     while (!eof) {
       val kind =
@@ -320,7 +320,7 @@ class Lexer(source: Source) {
       }
       start = current
     }
-    tokens.toArray
+    IArray.from(tokens)
   }
 
   // --- Literal and comment matchers ---

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -169,7 +169,7 @@ class Lexer(source: Source) {
    */
   var current: Int = 0
   /** The sequence of tokens the source strings contains. Returned as the result by [[Lexer.run()]] */
-  val tokens: mutable.ListBuffer[Token] = mutable.ListBuffer.empty
+  val tokens: mutable.ArrayBuffer[Token] = new mutable.ArrayBuffer(initialSize = 256)
   // For future improvement, this is probably more performant than using substring on the source
   // val currLexeme: mutable.StringBuilder = mutable.StringBuilder()
   /** A peekable iterator of the source string. This is used instead of directly indexing the source string.
@@ -273,7 +273,7 @@ class Lexer(source: Source) {
     r.matches(candidate)
   }
 
-  def lex()(using ctx: Context): Vector[Token] =
+  def lex()(using ctx: Context): Array[Token] =
     try {
       run()
     } catch {
@@ -289,7 +289,7 @@ class Lexer(source: Source) {
    * If an error is encountered, all successfully scanned tokens this far will returned,
    * including the error.
    */
-  def run(): Vector[Token] = {
+  def run(): Array[Token] = {
     var eof = false
     while (!eof) {
       val kind =
@@ -320,7 +320,7 @@ class Lexer(source: Source) {
       }
       start = current
     }
-    tokens.toVector
+    tokens.toArray
   }
 
   // --- Literal and comment matchers ---

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -18,7 +18,7 @@ import scala.util.boundary.break
 case class Fail(message: String, position: Int) extends Throwable(null, null, false, false)
 case class SoftFail(message: String, positionStart: Int, positionEnd: Int)
 
-class RecursiveDescent(positions: Positions, tokens: IArray[Token], source: Source) {
+class RecursiveDescent(positions: Positions, tokens: IndexedSeq[Token], source: Source) {
 
   import scala.collection.mutable.ListBuffer
 

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -18,7 +18,7 @@ import scala.util.boundary.break
 case class Fail(message: String, position: Int) extends Throwable(null, null, false, false)
 case class SoftFail(message: String, positionStart: Int, positionEnd: Int)
 
-class RecursiveDescent(positions: Positions, tokens: IndexedSeq[Token], source: Source) {
+class RecursiveDescent(positions: Positions, tokens: Array[Token], source: Source) {
 
   import scala.collection.mutable.ListBuffer
 

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -18,7 +18,7 @@ import scala.util.boundary.break
 case class Fail(message: String, position: Int) extends Throwable(null, null, false, false)
 case class SoftFail(message: String, positionStart: Int, positionEnd: Int)
 
-class RecursiveDescent(positions: Positions, tokens: Array[Token], source: Source) {
+class RecursiveDescent(positions: Positions, tokens: IArray[Token], source: Source) {
 
   import scala.collection.mutable.ListBuffer
 

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -18,7 +18,7 @@ import scala.util.boundary.break
 case class Fail(message: String, position: Int) extends Throwable(null, null, false, false)
 case class SoftFail(message: String, positionStart: Int, positionEnd: Int)
 
-class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source) {
+class RecursiveDescent(positions: Positions, tokens: Array[Token], source: Source) {
 
   import scala.collection.mutable.ListBuffer
 


### PR DESCRIPTION
I tried benchmarking this change and the lexer part went from ~200 ms total on JS on case studies and benchmarks to ~160 ms total.

Could somebody double-check that this actually helps?