### PR TITLE
Set locale when handrolling JSON

### DIFF
--- a/effekt/shared/src/main/scala/effekt/util/Timer.scala
+++ b/effekt/shared/src/main/scala/effekt/util/Timer.scala
@@ -68,7 +68,15 @@ trait Timers {
     }.mkString("")
   }
 
-  def timesToJSON(): String = {
+  private def withENLocale[T](p: => T): T = {
+    val locale = java.util.Locale.getDefault
+    java.util.Locale.setDefault(java.util.Locale.US)
+    val result = p
+    java.util.Locale.setDefault(locale)
+    result
+  }
+
+  def timesToJSON(): String = withENLocale {
     val spacetab = " ".repeat(4)
     val entries = times.map { (name, ts) =>
       val subs = ts.map { case Timed(subname, time) =>


### PR DESCRIPTION
IDK why, but on my machine, the output of `--time=json` uses decimal commas instead decimal points, so `"lexer": { "my/awesome/file.effekt": 14,15 }, ...`
Let's not do that. :)

We should also think about using a proper JSON library, esp. if we use it in both documentation (#930) and here, it might just be worth to import [`uJson`](http://www.lihaoyi.com/post/uJsonfastflexibleandintuitiveJSONforScala.html) or something...