### PR TITLE
Add trailing unit to stmts on unexpected end

### DIFF
--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -186,6 +186,9 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
           val result = `return` ~> Return(expr())
           maybeSemi()
           result
+        case `}` => // Unexpected end of <STMTS> =>
+          // insert a synthetic `return ()` into the block
+          Return(UnitLit())
         case _ =>
           val e = expr()
           semi()


### PR DESCRIPTION
Currently, the following (half-finished) program
```scala
def main() = {
  val foo = 42
}
```
fails in the _parser_ with "Expected variables, literals, tuples, lists, holes or group".
Unfortunately, this happens a lot to me when writing a program during a demo, which then forces me to add a hole / unit literal there.

Instead, if we're parsing `<STMTS>` and encounter "an unexpected" `}`, we can just insert `return ()`.
This means that we still have a working program when writing (a tiny bit of extra resilience).

No idea what the downsides are in practice, maybe unexpected type errors stemming from this?
<img width="585" alt="Screenshot 2025-05-23 at 11 11 32" src="https://github.com/user-attachments/assets/2193e4f9-6fbe-4cc9-80a5-2dd2cc705da9" />
where previously this would fail the parser:
<img width="737" alt="Screenshot 2025-05-23 at 11 12 55" src="https://github.com/user-attachments/assets/816cd36e-21a5-4c61-97f8-53ac665b5479" />


In order to provide a better message here, we'd probably need to remember that the unit literal was synthesised?
We could also produce a tiny warning here with "I, the Effekt compiler, assume you meant to put something here, so I put a `()` here for the time being".

---

This would also (hopefully?) deprecate the need for the idiom:
```
{
  val/def ...;
  ()
}
```
that we seem to employ _a lot_: in `examples/`, it's 74 matches in 63 files (though some are spurious, I used `rg --multiline --stats ";?\n\s*\(\);?\n\s*}"` to check).

---

### Alternatives

- **keep it as-is**
- **insert a hole** (or a special hole), but here we'd probably still want to emit a warning or something?
- ???