### PR TITLE
Improve the context info sent for holes

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -622,12 +622,13 @@ case class EffektPublishHolesParams(uri: String, holes: List[EffektHoleInfo])
  *
  * The difference to Intelligence.HoleInfo is that it uses the appropriate LSP type for the range
  */
-case class EffektHoleInfo(id: String,
-                    range: LSPRange,
-                    innerType: Option[String],
-                    expectedType: Option[String],
-                    importedTerms: List[Intelligence.TermBinding], importedTypes: List[Intelligence.TypeBinding],
-                    terms: List[Intelligence.TermBinding], types: List[Intelligence.TypeBinding])
+case class EffektHoleInfo(
+  id: String,
+  range: LSPRange,
+  innerType: Option[String],
+  expectedType: Option[String],
+  scope: Intelligence.ScopeInfo
+ )
 
 object EffektHoleInfo {
   def fromHoleInfo(info: Intelligence.HoleInfo): EffektHoleInfo = {
@@ -636,10 +637,7 @@ object EffektHoleInfo {
       convertRange(info.span.range),
       info.innerType,
       info.expectedType,
-      info.importedTerms,
-      info.importedTypes,
-      info.terms,
-      info.types
+      info.scope
     )
   }
 }

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -140,43 +140,49 @@ trait Intelligence {
     innerType = hole.innerType.map { t => pp"${t}" }
     expectedType = hole.expectedType.map { t => pp"${t}" }
   } yield {
-    val BindingInfo(importedTerms, importedTypes, terms, types) = allBindings(scope)
-    HoleInfo(hole.name.name, hole.decl.span, innerType, expectedType, importedTerms.toList.distinct, importedTypes.toList.distinct, terms.toList.distinct, types.toList.distinct)
+    val scopeInfo = allBindings(scope)
+    HoleInfo(
+      hole.name.name,
+      hole.decl.span,
+      innerType,
+      expectedType,
+      scopeInfo
+    )
   }
 
-  def allBindings(scope: Scope)(using C: Context): BindingInfo =
+  def allBindings(scope: Scope)(using C: Context): ScopeInfo =
     scope match {
       case Scope.Global(imports, bindings) =>
-        val (te1, ty1) = allBindings(imports)
-        val (te2, ty2) = allBindings(bindings)
-        BindingInfo(te1, ty1, te2, ty2)
+        val bindingsOut = allBindings(BindingOrigin.Imported, imports)
+          ++ allBindings(BindingOrigin.Defined, bindings)
+        ScopeInfo(None, ScopeKind.Global, bindingsOut.toList, None)
       case Scope.Named(name, bindings, outer) =>
-        val (te, ty) = allBindings(bindings)
-        BindingInfo(Seq.empty, Seq.empty, te, ty) ++ allBindings(outer)
+        val bindingsOut = allBindings(BindingOrigin.Defined, bindings)
+        ScopeInfo(Some(name), ScopeKind.Namespace, bindingsOut.toList, Some(allBindings(outer)))
       case Scope.Local(imports, bindings, outer) =>
         val outerBindings = allBindings(outer)
-        val (te1, ty1) = allBindings(imports)
-        val (te2, ty2) = allBindings(bindings)
-        BindingInfo(te1, ty1, te2, ty2) ++ allBindings(outer)
+        val bindingsOut = allBindings(BindingOrigin.Imported, imports)
+          ++ allBindings(BindingOrigin.Defined, bindings)
+        ScopeInfo(None, ScopeKind.Local, bindingsOut.toList, Some(allBindings(outer)))
     }
 
-  def allBindings(bindings: Namespace, path: List[String] = Nil)(using C: Context): (Iterable[TermBinding], Iterable[TypeBinding]) =
+  def allBindings(origin: String, bindings: Namespace, path: List[String] = Nil)(using C: Context): Iterable[BindingInfo] =
     val types = bindings.types.flatMap {
       case (name, sym) =>
         // TODO this is extremely hacky, printing is not defined for all types at the moment
-        try { Some(TypeBinding(path, name, DeclPrinter(sym))) } catch { case e => None }
+        try { Some(TypeBinding(path, name, origin, DeclPrinter(sym))) } catch { case e => None }
     }
     val terms = bindings.terms.flatMap { case (name, syms) =>
       syms.collect {
-        case sym: ValueSymbol => TermBinding(path, name, C.valueTypeOption(sym).map(t => pp"${t}"))
-        case sym: BlockSymbol => TermBinding(path, name, C.blockTypeOption(sym).map(t => pp"${t}"))
+        case sym: ValueSymbol => TermBinding(path, name, origin, C.valueTypeOption(sym).map(t => pp"${t}"))
+        case sym: BlockSymbol => TermBinding(path, name, origin, C.blockTypeOption(sym).map(t => pp"${t}"))
       }
     }
-    val (nestedTerms, nestedTypes) = bindings.namespaces.map {
-      case (name, namespace) => allBindings(namespace, path :+ name)
-    }.unzip
+    val nestedBindings = bindings.namespaces.flatMap {
+      case (name, namespace) => allBindings(origin, namespace, path :+ name)
+    }
 
-    (terms ++ nestedTerms.flatten, types ++ nestedTypes.flatten)
+    terms ++ types ++ nestedBindings
 
   def allCaptures(src: Source)(using C: Context): List[(Tree, CaptureSet)] =
     C.annotationOption(Annotations.CaptureForFile, src).getOrElse(Nil)
@@ -332,27 +338,43 @@ object Intelligence {
      span: Span,
      innerType: Option[String],
      expectedType: Option[String],
-     importedTerms: List[TermBinding], importedTypes: List[TypeBinding],
-     terms: List[TermBinding], types: List[TypeBinding]
+     scope: ScopeInfo,
   )
 
-  case class TermBinding(qualifier: List[String], name: String, `type`: Option[String])
-
-  case class TypeBinding(qualifier: List[String], name: String, definition: String)
-
-  case class BindingInfo(
-    importedTerms: Iterable[TermBinding],
-    importedTypes: Iterable[TypeBinding],
-    terms: Iterable[TermBinding],
-    types: Iterable[TypeBinding]
-  ) {
-    def ++(other: BindingInfo): BindingInfo =
-      BindingInfo(
-        importedTerms ++ other.importedTerms,
-        importedTypes ++ other.importedTypes,
-        terms ++ other.terms,
-        types ++ other.types)
+  // These need to be strings (rather than cases of an enum) so that they get serialized correctly
+  object BindingOrigin {
+    /**
+     * The binding was defined in this scope
+     */
+    final val Defined = "Defined"
+    /**
+     * The binding was imported in this scope
+     */
+    final val Imported = "Imported"
   }
+
+  sealed trait BindingInfo {
+    val qualifier: List[String]
+    val name: String
+    val origin: String
+  }
+
+  case class TermBinding(qualifier: List[String], name: String, origin: String, `type`: Option[String]) extends BindingInfo
+  case class TypeBinding(qualifier: List[String], name: String, origin: String, definition: String) extends BindingInfo
+
+  // These need to be strings (rather than cases of an enum) so that they get serialized correctly
+  object ScopeKind {
+    final val Namespace: String = "Namespace"
+    final val Local: String = "Local"
+    final val Global: String = "Global"
+  }
+
+  case class ScopeInfo(
+      name: Option[String],
+      kind: String,
+      bindings: List[BindingInfo],
+      outer: Option[ScopeInfo]
+  )
 
   case class CaptureInfo(
     position: Position,


### PR DESCRIPTION
This is the first step of improving the information the language server sends about holes and their context. In particular, we now preserve the scope that terms originate from, allowing us to display local variables first.
It does not (yet) order the bindings based on the order they were defined in because they are internally tracked in `HashMap`s which unfortunately also means that we apparently cannot show shadowed  terms at the moment?