### PR TITLE
Add support for custom flags based on environment

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -294,7 +294,7 @@ object LLVMRunner extends Runner[String] {
 
   def standardLibraryPath(root: File): File = root / "libraries" / "common"
 
-  val flags = Properties.envOrElse("LLVM_FLAGS", "").split(" ").toSeq
+  val flags = Properties.envOrElse("CFLAGS", "").split(" ").toSeq
 
   override def includes(path: File): List[File] = List(path / ".." / "llvm")
 


### PR DESCRIPTION
Permits a temporary fix for #1026.

We can now do `NODE_FLAGS="--max-old-space-size=8192"` and it will automatically add the flags to the `node` runner flags (in shebang). I also added `VALGRIND_FLAGS`, `CHEZ_FLAGS`, and `CFLAGS` (for historic reasons)