### PR TITLE
Preserve orders of symbols in scope

### DIFF
--- a/effekt/js/src/main/scala/effekt/context/VirtualModuleDB.scala
+++ b/effekt/js/src/main/scala/effekt/context/VirtualModuleDB.scala
@@ -1,8 +1,7 @@
 package effekt
 package context
 
-import effekt.util.
-Resources
+import effekt.util.Resources
 import effekt.util.paths._
 
 import kiama.util.Source

--- a/effekt/js/src/main/scala/effekt/context/VirtualModuleDB.scala
+++ b/effekt/js/src/main/scala/effekt/context/VirtualModuleDB.scala
@@ -1,7 +1,8 @@
 package effekt
 package context
 
-import effekt.util.Resources
+import effekt.util.
+Resources
 import effekt.util.paths._
 
 import kiama.util.Source

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1750,17 +1750,16 @@ class LSPTests extends FunSuite {
     }
   }
 
-  test("Server correctly publishes different constructor fields with same name") {
+  test("Server correctly publishes overloaded field accessors") {
     withClientAndServer { (client, server) =>
       val source =
         raw"""namespace N {
-             |  type Foo {
-             |    MkFoo(theField: String)
-             |  }
+             |  // Accessor functions are generated for all record fields
+             |  record Foo1(theField: String)
+             |  record Foo2(theField: String)
              |
-             |  type Bar {
-             |    MkBar(theField: Int)
-             |  }
+             |  // There are no accessor functions for data type constructor fields
+             |  type Bar { Bar(theField: Int) }
              |
              |  def main() = <>
              |}
@@ -1778,19 +1777,19 @@ class LSPTests extends FunSuite {
       val expectedBindings = List(
         TypeBinding(
           qualifier = Nil,
-          name = "Foo",
+          name = "Foo1",
           origin = "Defined",
-          definition = """type Foo {
-  def MkFoo(theField: String): Foo / {}
+          definition = """type Foo1 {
+  def Foo1(theField: String): Foo1 / {}
 }""",
           kind = "Type"
         ),
         TermBinding(
           qualifier = Nil,
-          name = "MkFoo",
+          name = "Foo1",
           origin = "Defined",
           `type` = Some(
-            value = "String => Foo"
+            value = "String => Foo1"
           ),
           kind = "Term"
         ),
@@ -1798,7 +1797,36 @@ class LSPTests extends FunSuite {
           qualifier = Nil,
           name = "theField",
           origin = "Defined",
-          `type` = None,
+          `type` = Some(
+            value = "Foo1 => String"
+          ),
+          kind = "Term"
+        ),
+        TypeBinding(
+          qualifier = Nil,
+          name = "Foo2",
+          origin = "Defined",
+          definition = """type Foo2 {
+  def Foo2(theField: String): Foo2 / {}
+}""",
+          kind = "Type"
+        ),
+        TermBinding(
+          qualifier = Nil,
+          name = "Foo2",
+          origin = "Defined",
+          `type` = Some(
+            value = "String => Foo2"
+          ),
+          kind = "Term"
+        ),
+        TermBinding(
+          qualifier = Nil,
+          name = "theField",
+          origin = "Defined",
+          `type` = Some(
+            value = "Foo2 => String"
+          ),
           kind = "Term"
         ),
         TypeBinding(
@@ -1806,24 +1834,17 @@ class LSPTests extends FunSuite {
           name = "Bar",
           origin = "Defined",
           definition = """type Bar {
-  def MkBar(theField: Int): Bar / {}
+  def Bar(theField: Int): Bar / {}
 }""",
           kind = "Type"
         ),
         TermBinding(
           qualifier = Nil,
-          name = "MkBar",
+          name = "Bar",
           origin = "Defined",
           `type` = Some(
             value = "Int => Bar"
           ),
-          kind = "Term"
-        ),
-        TermBinding(
-          qualifier = Nil,
-          name = "theField",
-          origin = "Defined",
-          `type` = None,
           kind = "Term"
         ),
         TermBinding(

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1711,7 +1711,7 @@ class LSPTests extends FunSuite {
       val source =
         raw"""namespace Foo {
              |  effect e1: Int
-             |  def foo(z: Int, y: Int, x: Int): Int = <>
+             |  def foo(z: Int, y: Int, x: Int){b1: => Int}{b2: => Bool}: Int = <>
              |  effect e2: Int
              |}
              |""".textDocument
@@ -1734,10 +1734,12 @@ class LSPTests extends FunSuite {
 
       val innerBindings = hole.scope.bindings
 
-      assertEquals(innerBindings.length, 3)
+      assertEquals(innerBindings.length, 5)
       assertEquals(innerBindings(0).name, "z")
       assertEquals(innerBindings(1).name, "y")
       assertEquals(innerBindings(2).name, "x")
+      assertEquals(innerBindings(3).name, "b1")
+      assertEquals(innerBindings(4).name, "b2")
 
       val outerBindings = hole.scope.outer.get.bindings
 

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -197,15 +197,10 @@ trait Intelligence {
       })
     }
 
-    sorted.flatMap((name, sym) => sym match {
-      case sym: TypeSymbol =>
-        // TODO this is extremely hacky, printing is not defined for all types at the moment
-        try { Some(TypeBinding(path, name, origin, DeclPrinter(sym))) } catch { case e => None }
-      case sym: TermSymbol =>
-        sym match {
-          case sym: ValueSymbol => Some(TermBinding(path, name, origin, C.valueTypeOption(sym).map(t => pp"${t}")))
-          case sym: BlockSymbol => Some(TermBinding(path, name, origin, C.blockTypeOption(sym).map(t => pp"${t}")))
-        }
+    sorted.map((name, sym) => sym match {
+      case sym: TypeSymbol => TypeBinding(path, name, origin, DeclPrinter(sym))
+      case sym: ValueSymbol => TermBinding(path, name, origin, C.valueTypeOption(sym).map(t => pp"${t}"))
+      case sym: BlockSymbol => TermBinding(path, name, origin, C.blockTypeOption(sym).map(t => pp"${t}"))
     }).toList
 
   def allSymbols(origin: String, bindings: Namespace, path: List[String] = Nil)(using C: Context): Array[(String, TypeSymbol | TermSymbol)] = {

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -185,23 +185,34 @@ trait Intelligence {
         ScopeInfo(name, ScopeKind.Local, bindingsOut.toList, Some(allBindings(outer)))
     }
 
-  def allBindings(origin: String, bindings: Namespace, path: List[String] = Nil)(using C: Context): Iterable[BindingInfo] =
-    val types = bindings.types.flatMap {
-      case (name, sym) =>
-        // TODO this is extremely hacky, printing is not defined for all types at the moment
-        try { Some(TypeBinding(path, name, origin, DeclPrinter(sym))) } catch { case e => None }
-    }
-    val terms = bindings.terms.flatMap { case (name, syms) =>
-      syms.collect {
-        case sym: ValueSymbol => TermBinding(path, name, origin, C.valueTypeOption(sym).map(t => pp"${t}"))
-        case sym: BlockSymbol => TermBinding(path, name, origin, C.blockTypeOption(sym).map(t => pp"${t}"))
-      }
-    }
-    val nestedBindings = bindings.namespaces.flatMap {
-      case (name, namespace) => allBindings(origin, namespace, path :+ name)
+  def allBindings(origin: String, bindings: Namespace, path: List[String] = Nil)(using C: Context): List[BindingInfo] =
+    val symbols = allSymbols(origin, bindings, path).toArray
+
+    val sorted = if (origin == BindingOrigin.Imported) {
+      symbols.sortBy(_._1.toLowerCase())
+    } else {
+      symbols.sortBy((name, sym) => sym match {
+        case s: TypeSymbol => s.decl.span
+        case s: TermSymbol => s.decl.span
+      })
     }
 
-    terms ++ types ++ nestedBindings
+    sorted.flatMap((name, sym) => sym match {
+      case sym: TypeSymbol =>
+        // TODO this is extremely hacky, printing is not defined for all types at the moment
+        try { Some(TypeBinding(path, name, origin, DeclPrinter(sym))) } catch { case e => None }
+      case sym: TermSymbol =>
+        sym match {
+          case sym: ValueSymbol => Some(TermBinding(path, name, origin, C.valueTypeOption(sym).map(t => pp"${t}")))
+          case sym: BlockSymbol => Some(TermBinding(path, name, origin, C.blockTypeOption(sym).map(t => pp"${t}")))
+        }
+    }).toList
+
+  def allSymbols(origin: String, bindings: Namespace, path: List[String] = Nil)(using C: Context): Iterable[(String, TypeSymbol | TermSymbol)] = {
+    bindings.types ++ bindings.terms.flatMap((name, syms) => syms.map((name, _))) ++ bindings.namespaces.flatMap {
+      case (name, namespace) => allSymbols(origin, namespace, path :+ name)
+    }
+  }
 
   def holeBody(template: Template[source.Stmt], argTypes: List[Option[ValueType]])(using C: Context): List[HoleItem] = {
     val Template(strings, args) = template

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -186,7 +186,7 @@ trait Intelligence {
     }
 
   def allBindings(origin: String, bindings: Namespace, path: List[String] = Nil)(using C: Context): List[BindingInfo] =
-    val symbols = allSymbols(origin, bindings, path).toArray
+    val symbols = allSymbols(origin, bindings, path)
 
     val sorted = if (origin == BindingOrigin.Imported) {
       symbols.sortBy(_._1.toLowerCase())
@@ -208,8 +208,8 @@ trait Intelligence {
         }
     }).toList
 
-  def allSymbols(origin: String, bindings: Namespace, path: List[String] = Nil)(using C: Context): Iterable[(String, TypeSymbol | TermSymbol)] = {
-    bindings.types ++ bindings.terms.flatMap((name, syms) => syms.map((name, _))) ++ bindings.namespaces.flatMap {
+  def allSymbols(origin: String, bindings: Namespace, path: List[String] = Nil)(using C: Context): Array[(String, TypeSymbol | TermSymbol)] = {
+    bindings.types.toArray ++ bindings.terms.toArray.flatMap((name, syms) => syms.map((name, _))) ++ bindings.namespaces.toArray.flatMap {
       case (name, namespace) => allSymbols(origin, namespace, path :+ name)
     }
   }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -173,11 +173,11 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
       Context.define(id, effectSym)
 
-    case source.TypeDef(id, tparams, tpe, doc, span) =>
+    case d @ source.TypeDef(id, tparams, tpe, doc, span) =>
       val tps = Context scoped { tparams map resolve }
       val alias = Context scoped {
         tps.foreach { t => Context.bind(t) }
-        TypeAlias(Context.nameFor(id), tps, resolveValueType(tpe))
+        TypeAlias(Context.nameFor(id), tps, resolveValueType(tpe), d)
       }
       Context.define(id, alias)
 
@@ -723,7 +723,7 @@ object Namer extends Phase[Parsed, NameResolved] {
           Context.abort(pretty"Type variables cannot be applied, but received ${args.size} arguments.")
         }
         ValueTypeRef(id)
-      case TypeAlias(name, tparams, tpe) =>
+      case TypeAlias(name, tparams, tpe, _) =>
         val targs = args.map(resolveValueType)
         if (tparams.size != targs.size) {
           Context.abort(pretty"Type alias ${name} expects ${tparams.size} type arguments, but got ${targs.size}.")

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -386,11 +386,11 @@ object Namer extends Phase[Parsed, NameResolved] {
     case d @ source.DataDef(id, tparams, ctors, doc, span) =>
       val data = d.symbol
       data.constructors = ctors map {
-        case source.Constructor(id, tparams, ps, doc, span) =>
+        case c @ source.Constructor(id, tparams, ps, doc, span) =>
           val constructor = Context scoped {
             val name = Context.nameFor(id)
             val tps = tparams map resolve
-            Constructor(name, data.tparams ++ tps.unspan, Nil, data)
+            Constructor(name, data.tparams ++ tps.unspan, Nil, data, c)
           }
           Context.define(id, constructor)
           constructor.fields = resolveFields(ps.unspan, constructor)
@@ -401,7 +401,7 @@ object Namer extends Phase[Parsed, NameResolved] {
     case d @ source.RecordDef(id, tparams, fs, doc, span) =>
       val record = d.symbol
       val name = Context.nameFor(id)
-      val constructor = Constructor(name, record.tparams, Nil, record)
+      val constructor = Constructor(name, record.tparams, Nil, record, d)
       // we define the constructor on a copy to avoid confusion with symbols
       Context.define(id.clone, constructor)
       record.constructor = constructor

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -181,11 +181,11 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
       Context.define(id, alias)
 
-    case source.EffectDef(id, tparams, effs, doc, span) =>
+    case d @ source.EffectDef(id, tparams, effs, doc, span) =>
       val tps = Context scoped { tparams map resolve }
       val alias = Context scoped {
         tps.foreach { t => Context.bind(t) }
-        EffectAlias(Context.nameFor(id), tps, resolve(effs))
+        EffectAlias(Context.nameFor(id), tps, resolve(effs), d)
       }
       Context.define(id, alias)
 
@@ -837,7 +837,7 @@ object Namer extends Phase[Parsed, NameResolved] {
   def resolveWithAliases(tpe: source.TypeRef)(using Context): List[InterfaceType] = Context.at(tpe) {
     val resolved: List[InterfaceType] = tpe match {
       case source.TypeRef(id, args, span) => Context.resolveType(id) match {
-        case EffectAlias(name, tparams, effs) =>
+        case EffectAlias(name, tparams, effs, _) =>
           if (tparams.size != args.size) {
             Context.abort(pretty"Effect alias ${name} expects ${tparams.size} type arguments, but got ${args.size}.")
           }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -236,10 +236,10 @@ object Namer extends Phase[Parsed, NameResolved] {
       })
     }
 
-    case source.ExternResource(id, tpe, doc, span) =>
+    case d @ source.ExternResource(id, tpe, doc, span) =>
       val name = Context.nameFor(id)
       val btpe = resolveBlockType(tpe)
-      val sym = ExternResource(name, btpe)
+      val sym = ExternResource(name, btpe, d)
       Context.define(id, sym)
       Context.bindBlock(sym)
 

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -570,7 +570,7 @@ object Namer extends Phase[Parsed, NameResolved] {
       case (paramSym, paramTree) =>
         val fieldId = paramTree.id.clone
         val name = Context.nameFor(fieldId)
-        val fieldSym = Field(name, paramSym, constructor)
+        val fieldSym = Field(name, paramSym, constructor, paramTree)
         Context.define(fieldId, fieldSym)
         fieldSym
     }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -162,14 +162,14 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
       Context.define(id, sym)
 
-    case source.InterfaceDef(id, tparams, ops, doc, span) =>
+    case decl @ source.InterfaceDef(id, tparams, ops, doc, span) =>
       val effectName = Context.nameFor(id)
       // we use the localName for effects, since they will be bound as capabilities
       val effectSym = Context scoped {
         val tps = tparams map resolve
         // we do not resolve the effect operations here to allow them to refer to types that are defined
         // later in the file
-        Interface(effectName, tps.unspan)
+        Interface(effectName, tps.unspan, List(), decl)
       }
       Context.define(id, effectSym)
 
@@ -213,10 +213,10 @@ object Namer extends Phase[Parsed, NameResolved] {
         ExternType(Context.nameFor(id), tps.unspan)
       })
 
-    case source.ExternInterface(id, tparams, doc, span) =>
+    case decl @ source.ExternInterface(id, tparams, doc, span) =>
       Context.define(id, Context scoped {
         val tps = tparams map resolve
-        ExternInterface(Context.nameFor(id), tps)
+        ExternInterface(Context.nameFor(id), tps, decl)
       })
 
     case source.ExternDef(capture, id, tparams, vparams, bparams, ret, bodies, doc, span) => {
@@ -370,9 +370,9 @@ object Namer extends Phase[Parsed, NameResolved] {
             //   2) the annotated type parameters on the concrete operation
             val (result, effects) = resolve(ret)
 
-            val op = Operation(name, interface.tparams ++ tps.unspan, resVparams, resBparams, result, effects, interface)
-            Context.define(id, op)
-            op
+            val opSym = Operation(name, interface.tparams ++ tps.unspan, resVparams, resBparams, result, effects, interface, op)
+            Context.define(id, opSym)
+            opSym
           }
         }
       }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -189,28 +189,28 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
       Context.define(id, alias)
 
-    case source.DataDef(id, tparams, ctors, doc, span) =>
+    case d @ source.DataDef(id, tparams, ctors, doc, span) =>
       val typ = Context scoped {
         val tps = tparams map resolve
         // we do not resolve the constructors here to allow them to refer to types that are defined
         // later in the file
-        DataType(Context.nameFor(id), tps.unspan)
+        DataType(Context.nameFor(id), tps.unspan, List(), d)
       }
       Context.define(id, typ)
 
-    case source.RecordDef(id, tparams, fields, doc, span) =>
+    case d @ source.RecordDef(id, tparams, fields, doc, span) =>
       lazy val sym: Record = {
         val tps = Context scoped { tparams map resolve }
         // we do not resolve the fields here to allow them to refer to types that are defined
         // later in the file
-        Record(Context.nameFor(id), tps.unspan, null)
+        Record(Context.nameFor(id), tps.unspan, null, d)
       }
       Context.define(id, sym)
 
-    case source.ExternType(id, tparams, doc, span) =>
+    case d @source.ExternType(id, tparams, doc, span) =>
       Context.define(id, Context scoped {
         val tps = tparams map resolve
-        ExternType(Context.nameFor(id), tps.unspan)
+        ExternType(Context.nameFor(id), tps.unspan, d)
       })
 
     case decl @ source.ExternInterface(id, tparams, doc, span) =>

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -219,7 +219,7 @@ object Namer extends Phase[Parsed, NameResolved] {
         ExternInterface(Context.nameFor(id), tps, decl)
       })
 
-    case source.ExternDef(capture, id, tparams, vparams, bparams, ret, bodies, doc, span) => {
+    case d @ source.ExternDef(capture, id, tparams, vparams, bparams, ret, bodies, doc, span) => {
       val name = Context.nameFor(id)
       val capt = resolve(capture)
       Context.define(id, Context scoped {
@@ -232,7 +232,7 @@ object Namer extends Phase[Parsed, NameResolved] {
           resolve(ret)
         }
 
-        ExternFunction(name, tps.unspan, vps.unspan, bps.unspan, tpe, eff, capt, bodies)
+        ExternFunction(name, tps.unspan, vps.unspan, bps.unspan, tpe, eff, capt, bodies, d)
       })
     }
 

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -460,7 +460,7 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
 
     case tree @ source.Region(name, body, _) =>
-      val reg = BlockParam(Name.local(name.name), Some(builtins.TRegion))
+      val reg = BlockParam(Name.local(name.name), Some(builtins.TRegion), tree)
       Context.define(name, reg)
       Context scoped {
         Context.bindBlock(reg)
@@ -642,7 +642,7 @@ object Namer extends Phase[Parsed, NameResolved] {
     sym
   }
   def resolve(p: source.BlockParam)(using Context): BlockParam = {
-    val sym: BlockParam = BlockParam(Name.local(p.id), p.tpe.map { tpe => resolveBlockType(tpe, isParam = true) })
+    val sym: BlockParam = BlockParam(Name.local(p.id), p.tpe.map { tpe => resolveBlockType(tpe, isParam = true) }, p)
     Context.assignSymbol(p.id, sym)
     sym
   }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -631,13 +631,13 @@ object Namer extends Phase[Parsed, NameResolved] {
    * Used for fields where "please wrap this in braces" is not good advice to be told by [[resolveValueType]].
    */
   def resolveNonfunctionValueParam(p: source.ValueParam)(using Context): ValueParam = {
-    val sym = ValueParam(Name.local(p.id), p.tpe.map(tpe => resolveValueType(tpe, isParam = false)))
+    val sym = ValueParam(Name.local(p.id), p.tpe.map(tpe => resolveValueType(tpe, isParam = false)), decl = p)
     Context.assignSymbol(p.id, sym)
     sym
   }
 
   def resolve(p: source.ValueParam)(using Context): ValueParam = {
-    val sym = ValueParam(Name.local(p.id), p.tpe.map(tpe => resolveValueType(tpe, isParam = true)))
+    val sym = ValueParam(Name.local(p.id), p.tpe.map(tpe => resolveValueType(tpe, isParam = true)), decl = p)
     Context.assignSymbol(p.id, sym)
     sym
   }
@@ -683,7 +683,7 @@ object Namer extends Phase[Parsed, NameResolved] {
     case source.IgnorePattern(_)     => Nil
     case source.LiteralPattern(lit, _) => Nil
     case source.AnyPattern(id, _) =>
-      val p = ValueParam(Name.local(id), None)
+      val p = ValueParam(Name.local(id), None, decl = id)
       Context.assignSymbol(id, p)
       List(p)
     case source.TagPattern(id, patterns, _) =>

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -1637,7 +1637,7 @@ trait TyperOps extends ContextOps { self: Context =>
 
   private[typer] def bind(p: TrackedParam): Unit = p match {
     case s @ BlockParam(name, tpe, _) => bind(s, tpe.get, CaptureSet(p.capture))
-    case s @ ExternResource(name, tpe) => bind(s, tpe, CaptureSet(p.capture))
+    case s @ ExternResource(name, tpe, _) => bind(s, tpe, CaptureSet(p.capture))
     case s : VarBinder => bind(s, CaptureSet(s.capture))
     case r : ResumeParam => panic("Cannot bind resume")
   }

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -1631,7 +1631,7 @@ trait TyperOps extends ContextOps { self: Context =>
     }
 
   private[typer] def bind(p: ValueParam): Unit = p match {
-    case s @ ValueParam(name, Some(tpe)) => bind(s, tpe)
+    case s @ ValueParam(name, Some(tpe), _) => bind(s, tpe)
     case s => panic(pretty"Internal Error: Cannot add $s to typing context.")
   }
 

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -6,7 +6,7 @@ package typer
  */
 import effekt.context.{Annotation, Annotations, Context, ContextOps}
 import effekt.context.assertions.*
-import effekt.source.{AnyPattern, Def, Effectful, IgnorePattern, Many, MatchGuard, MatchPattern, Maybe, ModuleDecl, OpClause, Stmt, TagPattern, Term, Tree, resolve, resolveBlockRef, resolveBlockType, resolveValueType, symbol}
+import effekt.source.{AnyPattern, Def, Effectful, IgnorePattern, Many, MatchGuard, MatchPattern, Maybe, ModuleDecl, NoSource, OpClause, Stmt, TagPattern, Term, Tree, resolve, resolveBlockRef, resolveBlockType, resolveValueType, symbol}
 import effekt.source.Term.BlockLiteral
 import effekt.symbols.*
 import effekt.symbols.builtins.*
@@ -1548,7 +1548,7 @@ trait TyperOps extends ContextOps { self: Context =>
     cap
 
   private [typer] def freshCapabilityFor(tpe: InterfaceType): symbols.BlockParam =
-    val param: BlockParam = BlockParam(tpe.name, Some(tpe))
+    val param: BlockParam = BlockParam(tpe.name, Some(tpe), NoSource)
     // TODO FIXME -- generated capabilities need to be ignored in LSP!
 //     {
 //      override def synthetic = true
@@ -1636,7 +1636,7 @@ trait TyperOps extends ContextOps { self: Context =>
   }
 
   private[typer] def bind(p: TrackedParam): Unit = p match {
-    case s @ BlockParam(name, tpe) => bind(s, tpe.get, CaptureSet(p.capture))
+    case s @ BlockParam(name, tpe, _) => bind(s, tpe.get, CaptureSet(p.capture))
     case s @ ExternResource(name, tpe) => bind(s, tpe, CaptureSet(p.capture))
     case s : VarBinder => bind(s, CaptureSet(s.capture))
     case r : ResumeParam => panic("Cannot bind resume")

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -31,7 +31,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     case Pure, Direct, Control
   }
   def callingConvention(callable: Callable)(using Context): CallingConvention = callable match {
-    case f @ ExternFunction(name, _, _, _, _, _, capture, bodies) =>
+    case f @ ExternFunction(name, _, _, _, _, _, capture, bodies, _) =>
       // resolve the preferred body again and hope it's the same
       val body = ResolveExternDefs.findPreferred(bodies)
       body match {
@@ -105,7 +105,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
         interface.operations.map { op => core.Property(op, operationAtDeclaration(interface.tparams, op)) }))
 
     case f @ source.ExternDef(pure, id, _, vps, bps, _, bodies, doc, span) =>
-      val sym@ExternFunction(name, tps, _, _, ret, effects, capt, _) = f.symbol
+      val sym@ExternFunction(name, tps, _, _, ret, effects, capt, _, _) = f.symbol
       assert(effects.isEmpty)
       val cps = bps.map(b => b.symbol.capture)
       val tBody = bodies match {

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -753,7 +753,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
   def operationAtCallsite(receiver: symbols.BlockType, member: symbols.Operation)(using Context): BlockType = receiver.asInterfaceType match {
     case InterfaceType(i: Interface, targs) => member match {
       // For operations, we substitute the first type parameters by concrete type args.
-      case Operation(name, tparams, vparams, bparams, resultType, effects, _) =>
+      case Operation(name, tparams, vparams, bparams, resultType, effects, _, _) =>
         val substitution = Substitutions((tparams zip targs).toMap, Map.empty)
         val remainingTypeParams = tparams.drop(targs.size)
         // TODO this is exactly like in [[Callable.toType]] -- TODO repeated here:
@@ -778,7 +778,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
   }
 
   def operationAtDeclaration(tparamsInterface: List[Id], op: symbols.Operation)(using Context): core.BlockType = op match {
-    case symbols.Operation(name, tps, vps, bps, resultType, effects, interface) =>
+    case symbols.Operation(name, tps, vps, bps, resultType, effects, interface, _) =>
       // like in asSeenFrom we need to make up cparams, they cannot occur free in the result type
       val capabilities = CanonicalOrdering(effects.toList)
       val tparams = tps.drop(tparamsInterface.size)

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -127,7 +127,7 @@ enum Origin {
   case Real, Synthesized, Missing
 }
 
-case class Span(source: kiama.util.Source, from: Int, to: Int, origin: Origin = Origin.Real) {
+case class Span(source: kiama.util.Source, from: Int, to: Int, origin: Origin = Origin.Real) extends Ordered[Span] {
   /**
    * creates a fake empty Span immediately after this one
    * Example:
@@ -142,6 +142,16 @@ case class Span(source: kiama.util.Source, from: Int, to: Int, origin: Origin = 
   def synthesized: Span = Span(source, from, to, origin = Origin.Synthesized)
 
   def range: kiama.util.Range = kiama.util.Range(source.offsetToPosition(from), source.offsetToPosition(to))
+
+  override def compare(that: Span): Int = {
+    val nameCmp = this.source.name compareTo that.source.name
+    if (nameCmp != 0) nameCmp
+    else {
+      val startCmp = this.from compareTo that.from
+      if (startCmp != 0) startCmp
+      else this.to compareTo that.to
+    }
+  }
 }
 
 object Span {

--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -63,7 +63,7 @@ object DeclPrinter extends ParenPrettyPrinter {
     case ExternInterface(name, tparams, _) =>
       pp"extern interface ${name}${show(tparams)}"
 
-    case ExternResource(name, tpe) =>
+    case ExternResource(name, tpe, _) =>
       pp"extern resource ${name}: ${tpe}"
 
     case c: Callable =>

--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -37,7 +37,7 @@ object DeclPrinter extends ParenPrettyPrinter {
       val tps = show(tparams)
       "type" <+> name.toString <> tps <+> "=" <+> pp"$tpe"
 
-    case EffectAlias(name, tparams, eff) =>
+    case EffectAlias(name, tparams, eff, _) =>
       val tps = show(tparams)
       "effect" <+> name.toString <> tps <+> "=" <+> pp"${eff}"
 

--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -41,14 +41,14 @@ object DeclPrinter extends ParenPrettyPrinter {
       val tps = show(tparams)
       "effect" <+> name.toString <> tps <+> "=" <+> pp"${eff}"
 
-    case DataType(name, tparams, ctors) =>
+    case DataType(name, tparams, ctors, _) =>
       val tps = show(tparams)
       val ctrs = ctors map { ctor =>
         format("def", ctor, ctor.annotatedResult, ctor.annotatedEffects)
       }
       "type" <+> name.toString <> tps <+> braces(nest(line <> vsep(ctrs)) <> line)
 
-    case Record(name, tparams, ctor) =>
+    case Record(name, tparams, ctor, _) =>
       val tps = show(tparams)
       val ctrs = format("def", ctor, ctor.annotatedResult, ctor.annotatedEffects)
       "type" <+> name.toString <> tps <+> braces(nest(line <> ctrs) <> line)
@@ -56,7 +56,7 @@ object DeclPrinter extends ParenPrettyPrinter {
     case f: ExternFunction =>
       format("extern def", f, f.annotatedResult, f.annotatedEffects)
 
-    case ExternType(name, tparams) =>
+    case ExternType(name, tparams, _) =>
       val tps = show(tparams)
       pp"extern type ${name}$tps"
 

--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -33,7 +33,7 @@ object DeclPrinter extends ParenPrettyPrinter {
       val tpe = context.valueTypeOption(b).getOrElse { b.tpe.get }
       pp"var ${b.name}: ${tpe}"
 
-    case TypeAlias(name, tparams, tpe) =>
+    case TypeAlias(name, tparams, tpe, _) =>
       val tps = show(tparams)
       "type" <+> name.toString <> tps <+> "=" <+> pp"$tpe"
 

--- a/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/DeclPrinter.scala
@@ -17,10 +17,10 @@ object DeclPrinter extends ParenPrettyPrinter {
 
   def toDoc(t: Symbol, context: Context): Doc = t match {
 
-    case e @ Interface(name, tparams, List(op)) =>
+    case e @ Interface(name, tparams, List(op), _) =>
       format("effect", op, op.annotatedResult, op.annotatedEffects)
 
-    case e @ Interface(name, tparams, ops) =>
+    case e @ Interface(name, tparams, ops, _) =>
       val tps = show(tparams)
       val effs = ops.map { op => format("def", op, op.annotatedResult, op.annotatedEffects) }
       "effect" <+> name.toString <> tps <+> braces(nest(line <> vsep(effs)) <> line)
@@ -60,7 +60,7 @@ object DeclPrinter extends ParenPrettyPrinter {
       val tps = show(tparams)
       pp"extern type ${name}$tps"
 
-    case ExternInterface(name, tparams) =>
+    case ExternInterface(name, tparams, _) =>
       pp"extern interface ${name}${show(tparams)}"
 
     case ExternResource(name, tpe) =>

--- a/effekt/shared/src/main/scala/effekt/symbols/Scope.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/Scope.scala
@@ -51,7 +51,7 @@ class Namespace(
 
   def operations: Map[String, Set[Operation]] =
     types.values.toSet.flatMap {
-      case BlockTypeConstructor.Interface(_, _, operations) => operations.toSet
+      case BlockTypeConstructor.Interface(_, _, operations, _) => operations.toSet
       case _ => Set.empty
     }.groupMap(_.name.name)(op => op)
 

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -85,8 +85,8 @@ object TypePrinter extends ParenPrettyPrinter {
   }
 
   def toDoc(t: BlockTypeConstructor): Doc = t match {
-    case Interface(name, tparams, ops) => name
-    case ExternInterface(name, tparams) => name
+    case Interface(name, tparams, ops, _) => name
+    case ExternInterface(name, tparams, _) => name
     case ErrorBlockType(name, tparams) => "?"
   }
 

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -91,9 +91,9 @@ object TypePrinter extends ParenPrettyPrinter {
   }
 
   def toDoc(t: TypeConstructor): Doc = t match {
-    case DataType(name, tparams, constructors)  => name <> typeParams(tparams)
-    case Record(name, tparams, constructor) => name <> typeParams(tparams)
-    case ExternType(name, tparams) => name
+    case DataType(name, tparams, constructors, _)  => name <> typeParams(tparams)
+    case Record(name, tparams, constructor, _) => name <> typeParams(tparams)
+    case ExternType(name, tparams, _) => name
     case ErrorValueType(name, tparams) => "?"
   }
 

--- a/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/TypePrinter.scala
@@ -87,14 +87,14 @@ object TypePrinter extends ParenPrettyPrinter {
   def toDoc(t: BlockTypeConstructor): Doc = t match {
     case Interface(name, tparams, ops, _) => name
     case ExternInterface(name, tparams, _) => name
-    case ErrorBlockType(name, tparams) => "?"
+    case ErrorBlockType(name, tparams, _) => "?"
   }
 
   def toDoc(t: TypeConstructor): Doc = t match {
     case DataType(name, tparams, constructors, _)  => name <> typeParams(tparams)
     case Record(name, tparams, constructor, _) => name <> typeParams(tparams)
     case ExternType(name, tparams, _) => name
-    case ErrorValueType(name, tparams) => "?"
+    case ErrorValueType(name, tparams, _) => "?"
   }
 
   def toDoc(eff: Effects): Doc =

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -48,13 +48,13 @@ object builtins {
   val TBottom = ValueTypeApp(BottomSymbol, Nil)
 
   val IOSymbol = Interface(Name.local("IO"), Nil, Nil, decl = NoSource)
-  val IOCapability = ExternResource(name("io"), InterfaceType(IOSymbol, Nil))
+  val IOCapability = ExternResource(name("io"), InterfaceType(IOSymbol, Nil), decl = NoSource)
 
   val AsyncSymbol = Interface(Name.local("Async"), Nil, Nil, decl = NoSource)
-  val AsyncCapability = ExternResource(name("async"), InterfaceType(AsyncSymbol, Nil))
+  val AsyncCapability = ExternResource(name("async"), InterfaceType(AsyncSymbol, Nil), decl = NoSource)
 
   val GlobalSymbol = Interface(Name.local("Global"), Nil, Nil, decl = NoSource)
-  val GlobalCapability = ExternResource(name("global"), InterfaceType(GlobalSymbol, Nil))
+  val GlobalCapability = ExternResource(name("global"), InterfaceType(GlobalSymbol, Nil), decl = NoSource)
 
   object TState {
     val S: TypeParam = TypeParam(Name.local("S"))

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -1,7 +1,7 @@
 package effekt
 package symbols
 
-import effekt.source.{Many, ModuleDecl, Span}
+import effekt.source.{Many, ModuleDecl, NoSource, Span}
 import effekt.context.Context
 import effekt.symbols.ErrorMessageInterpolator
 import effekt.util.messages.ErrorMessageReifier
@@ -60,7 +60,7 @@ object builtins {
     val S: TypeParam = TypeParam(Name.local("S"))
     val interface: Interface = Interface(Name.local("Ref"), List(S), Nil)
     val get = Operation(name("get"), List(S), Nil, Nil, ValueTypeRef(S), Effects.Pure, interface)
-    val put = Operation(name("put"), List(S), List(ValueParam(Name.local("s"), Some(ValueTypeRef(S)))), Nil, TUnit, Effects.Pure, interface)
+    val put = Operation(name("put"), List(S), List(ValueParam(Name.local("s"), Some(ValueTypeRef(S)), decl = NoSource)), Nil, TUnit, Effects.Pure, interface)
     interface.operations = List(get, put)
 
     def apply(stateType: ValueType) = InterfaceType(interface, List(stateType))

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -19,32 +19,32 @@ object builtins {
 
   private def name(s: String) = QualifiedName(List("effekt"), s)
 
-  val UnitSymbol = ExternType(name("Unit"), Nil)
+  val UnitSymbol = ExternType(name("Unit"), Nil, NoSource)
   val TUnit = ValueTypeApp(UnitSymbol, Nil)
 
-  val BooleanSymbol = ExternType(name("Bool"), Nil)
+  val BooleanSymbol = ExternType(name("Bool"), Nil, NoSource)
   val TBoolean = ValueTypeApp(BooleanSymbol, Nil)
 
-  val IntSymbol = ExternType(name("Int"), Nil)
+  val IntSymbol = ExternType(name("Int"), Nil, NoSource)
   val TInt = ValueTypeApp(IntSymbol, Nil)
 
-  val DoubleSymbol = ExternType(name("Double"), Nil)
+  val DoubleSymbol = ExternType(name("Double"), Nil, NoSource)
   val TDouble = ValueTypeApp(DoubleSymbol, Nil)
 
-  val StringSymbol = ExternType(name("String"), Nil)
+  val StringSymbol = ExternType(name("String"), Nil, NoSource)
   val TString = ValueTypeApp(StringSymbol, Nil)
 
-  val CharSymbol = ExternType(name("Char"), Nil)
+  val CharSymbol = ExternType(name("Char"), Nil, NoSource)
   val TChar = ValueTypeApp(CharSymbol, Nil)
 
-  val ByteSymbol = ExternType(name("Byte"), Nil)
+  val ByteSymbol = ExternType(name("Byte"), Nil, NoSource)
   val TByte = ValueTypeApp(ByteSymbol, Nil)
 
-  val TopSymbol = ExternType(name("Any"), Nil)
+  val TopSymbol = ExternType(name("Any"), Nil, NoSource)
   val TTop = ValueTypeApp(TopSymbol, Nil)
 
   // should this be a datatype, not an extern type?
-  val BottomSymbol = ExternType(name("Nothing"), Nil)
+  val BottomSymbol = ExternType(name("Nothing"), Nil, NoSource)
   val TBottom = ValueTypeApp(BottomSymbol, Nil)
 
   val IOSymbol = Interface(Name.local("IO"), Nil, Nil, decl = NoSource)

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -47,20 +47,20 @@ object builtins {
   val BottomSymbol = ExternType(name("Nothing"), Nil)
   val TBottom = ValueTypeApp(BottomSymbol, Nil)
 
-  val IOSymbol = Interface(Name.local("IO"), Nil, Nil)
+  val IOSymbol = Interface(Name.local("IO"), Nil, Nil, decl = NoSource)
   val IOCapability = ExternResource(name("io"), InterfaceType(IOSymbol, Nil))
 
-  val AsyncSymbol = Interface(Name.local("Async"), Nil, Nil)
+  val AsyncSymbol = Interface(Name.local("Async"), Nil, Nil, decl = NoSource)
   val AsyncCapability = ExternResource(name("async"), InterfaceType(AsyncSymbol, Nil))
 
-  val GlobalSymbol = Interface(Name.local("Global"), Nil, Nil)
+  val GlobalSymbol = Interface(Name.local("Global"), Nil, Nil, decl = NoSource)
   val GlobalCapability = ExternResource(name("global"), InterfaceType(GlobalSymbol, Nil))
 
   object TState {
     val S: TypeParam = TypeParam(Name.local("S"))
-    val interface: Interface = Interface(Name.local("Ref"), List(S), Nil)
-    val get = Operation(name("get"), List(S), Nil, Nil, ValueTypeRef(S), Effects.Pure, interface)
-    val put = Operation(name("put"), List(S), List(ValueParam(Name.local("s"), Some(ValueTypeRef(S)), decl = NoSource)), Nil, TUnit, Effects.Pure, interface)
+    val interface: Interface = Interface(Name.local("Ref"), List(S), Nil, decl = NoSource)
+    val get = Operation(name("get"), List(S), Nil, Nil, ValueTypeRef(S), Effects.Pure, interface, decl = NoSource)
+    val put = Operation(name("put"), List(S), List(ValueParam(Name.local("s"), Some(ValueTypeRef(S)), decl = NoSource)), Nil, TUnit, Effects.Pure, interface, decl = NoSource)
     interface.operations = List(get, put)
 
     def apply(stateType: ValueType) = InterfaceType(interface, List(stateType))
@@ -72,7 +72,7 @@ object builtins {
       }
   }
 
-  val RegionSymbol = Interface(Name.local("Region"), Nil, Nil)
+  val RegionSymbol = Interface(Name.local("Region"), Nil, Nil, decl = NoSource)
   val TRegion = InterfaceType(RegionSymbol, Nil)
 
   val rootTypes: Map[String, TypeSymbol] = Map(

--- a/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
@@ -54,9 +54,9 @@ package object kinds {
   }
 
   private def wellformedTypeConstructor(tpe: TypeConstructor)(using C: Context): Kind.Fun = tpe match {
-    case DataType(_, tparams, _)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
-    case Record(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
-    case ExternType(_, tparams)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
+    case DataType(_, tparams, _, _)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
+    case Record(_, tparams, _, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
+    case ExternType(_, tparams, _)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
     case ErrorValueType(_, tparams) => Kind.Fun(tparams map { p => Kind.VType}, Kind.VType)
   }
 

--- a/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
@@ -57,7 +57,7 @@ package object kinds {
     case DataType(_, tparams, _, _)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
     case Record(_, tparams, _, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
     case ExternType(_, tparams, _)  => Kind.Fun(tparams map { p => Kind.VType }, Kind.VType)
-    case ErrorValueType(_, tparams) => Kind.Fun(tparams map { p => Kind.VType}, Kind.VType)
+    case ErrorValueType(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType}, Kind.VType)
   }
 
   private def wellformedType(tpe: ValueType)(using C: Context): Kind = tpe match {
@@ -89,6 +89,6 @@ package object kinds {
   private def wellformedBlockTypeConstructor(e: BlockTypeConstructor)(using Context): Kind.Fun = e match {
     case Interface(_, tparams, _, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
     case ExternInterface(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
-    case ErrorBlockType(_, tparams) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
+    case ErrorBlockType(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
   }
 }

--- a/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/kinds.scala
@@ -87,8 +87,8 @@ package object kinds {
   }
 
   private def wellformedBlockTypeConstructor(e: BlockTypeConstructor)(using Context): Kind.Fun = e match {
-    case Interface(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
-    case ExternInterface(_, tparams) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
+    case Interface(_, tparams, _, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
+    case ExternInterface(_, tparams, _) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
     case ErrorBlockType(_, tparams) => Kind.Fun(tparams map { p => Kind.VType }, Kind.BType)
   }
 }

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -285,7 +285,7 @@ case class Constructor(name: Name, tparams: List[TypeParam], var fields: List[Fi
 }
 
 // TODO maybe split into Field (the symbol) and Selector (the synthetic function)
-case class Field(name: Name, param: ValueParam, constructor: Constructor) extends Callable {
+case class Field(name: Name, param: ValueParam, constructor: Constructor, override val decl: source.Tree) extends Callable {
   val tparams: List[TypeParam] = constructor.tparams
   val vparams = List(ValueParam(constructor.name, Some(constructor.appliedDatatype), decl = NoSource))
   val bparams = List.empty[BlockParam]

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -274,7 +274,7 @@ enum TypeConstructor extends TypeSymbol {
 export TypeConstructor.*
 
 
-case class Constructor(name: Name, tparams: List[TypeParam], var fields: List[Field], tpe: TypeConstructor) extends Callable {
+case class Constructor(name: Name, tparams: List[TypeParam], var fields: List[Field], tpe: TypeConstructor, override val decl: source.Tree) extends Callable {
   // Parameters and return type of the constructor
   lazy val vparams: List[ValueParam] = fields.map { f => f.param }
   val bparams: List[BlockParam] = Nil

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -299,14 +299,14 @@ case class Field(name: Name, param: ValueParam, constructor: Constructor) extend
 enum BlockTypeConstructor extends BlockTypeSymbol {
   def tparams: List[TypeParam]
 
-  case Interface(name: Name, tparams: List[TypeParam], var operations: List[Operation] = Nil)
-  case ExternInterface(name: Name, tparams: List[TypeParam])
+  case Interface(name: Name, tparams: List[TypeParam], var operations: List[Operation] = Nil, override val decl: source.Tree)
+  case ExternInterface(name: Name, tparams: List[TypeParam], override val decl: source.Tree)
   case ErrorBlockType(name: Name = NoName, tparams: List[TypeParam] = Nil)
 }
 export BlockTypeConstructor.*
 
 
-case class Operation(name: Name, tparams: List[TypeParam], vparams: List[ValueParam], bparams: List[BlockParam], resultType: ValueType, effects: Effects, interface: BlockTypeConstructor.Interface) extends Callable {
+case class Operation(name: Name, tparams: List[TypeParam], vparams: List[ValueParam], bparams: List[BlockParam], resultType: ValueType, effects: Effects, interface: BlockTypeConstructor.Interface, override val decl: source.Tree) extends Callable {
   def annotatedResult: Option[ValueType] = Some(resultType)
   def annotatedEffects: Option[Effects] = Some(Effects(effects.toList))
   def appliedInterface: InterfaceType = InterfaceType(interface, interface.tparams map ValueTypeRef.apply)

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -123,7 +123,7 @@ sealed trait TrackedParam extends Param, BlockSymbol {
   }
 }
 object TrackedParam {
-  case class BlockParam(name: Name, tpe: Option[BlockType]) extends TrackedParam
+  case class BlockParam(name: Name, tpe: Option[BlockType], override val decl: source.Tree) extends TrackedParam
   case class ResumeParam(module: Module) extends TrackedParam { val name = Name.local("resume") }
   case class ExternResource(name: Name, tpe: BlockType) extends TrackedParam
 }

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -415,7 +415,8 @@ case class ExternFunction(
   result: ValueType,
   effects: Effects,
   capture: CaptureSet,
-  bodies: List[source.ExternBody]
+  bodies: List[source.ExternBody],
+  override val decl: source.Tree
 ) extends Callable {
   def annotatedResult = Some(result)
   def annotatedEffects = Some(effects)

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -316,7 +316,7 @@ case class Operation(name: Name, tparams: List[TypeParam], vparams: List[ValuePa
  * Effect aliases are *not* block types, or block type constructors. They have to be dealiased by [[Namer]]
  * before usage.
  */
-case class EffectAlias(name: Name, tparams: List[TypeParam], effs: Effects) extends BlockTypeSymbol
+case class EffectAlias(name: Name, tparams: List[TypeParam], effs: Effects, override val decl: source.Tree) extends BlockTypeSymbol
 
 
 /**

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -266,9 +266,9 @@ case class TypeAlias(name: Name, tparams: List[TypeParam], tpe: ValueType, overr
 enum TypeConstructor extends TypeSymbol {
   def tparams: List[TypeParam]
 
-  case DataType(name: Name, tparams: List[TypeParam], var constructors: List[Constructor] = Nil)
-  case Record(name: Name, tparams: List[TypeParam], var constructor: Constructor)
-  case ExternType(name: Name, tparams: List[TypeParam])
+  case DataType(name: Name, tparams: List[TypeParam], var constructors: List[Constructor] = Nil, override val decl: source.Tree)
+  case Record(name: Name, tparams: List[TypeParam], var constructor: Constructor, override val decl: source.Tree)
+  case ExternType(name: Name, tparams: List[TypeParam], override val decl: source.Tree)
   case ErrorValueType(name: Name = NoName, tparams: List[TypeParam] = Nil)
 }
 export TypeConstructor.*

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -125,7 +125,7 @@ sealed trait TrackedParam extends Param, BlockSymbol {
 object TrackedParam {
   case class BlockParam(name: Name, tpe: Option[BlockType], override val decl: source.Tree) extends TrackedParam
   case class ResumeParam(module: Module) extends TrackedParam { val name = Name.local("resume") }
-  case class ExternResource(name: Name, tpe: BlockType) extends TrackedParam
+  case class ExternResource(name: Name, tpe: BlockType, override val decl: source.Tree) extends TrackedParam
 }
 export TrackedParam.*
 

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -253,7 +253,7 @@ enum TypeVar(val name: Name) extends ValueTypeSymbol {
 }
 export TypeVar.*
 
-case class TypeAlias(name: Name, tparams: List[TypeParam], tpe: ValueType) extends ValueTypeSymbol
+case class TypeAlias(name: Name, tparams: List[TypeParam], tpe: ValueType, override val decl: source.Tree) extends ValueTypeSymbol
 
 /**
  * Types that _can_ be used in type constructor position. e.g. >>>List<<<[T]

--- a/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
@@ -298,8 +298,8 @@ object ExhaustivityChecker {
     }
 
     tpe match {
-      case ValueType.ValueTypeApp(DataType(_, _, ctors), _) => checkDatatype(ctors)
-      case ValueType.ValueTypeApp(Record(_, _, ctor), _)    => checkDatatype(List(ctor))
+      case ValueType.ValueTypeApp(DataType(_, _, ctors, _), _) => checkDatatype(ctors)
+      case ValueType.ValueTypeApp(Record(_, _, ctor, _), _)    => checkDatatype(List(ctor))
       case tpe @ (builtins.TInt | builtins.TDouble | builtins.TString | builtins.TBoolean | builtins.TUnit | builtins.TBottom | builtins.TChar | builtins.TByte) =>
         checkLiteral(tpe)
 

--- a/examples/neg/selecting_from_datatype.check
+++ b/examples/neg/selecting_from_datatype.check
@@ -1,3 +1,3 @@
-[error] examples/neg/selecting_from_datatype.effekt:8:22: Cannot find type for myHead -- forward uses and recursive functions need annotated return types.
+[error] examples/neg/selecting_from_datatype.effekt:8:22: Cannot find a function named `myHead`.
 def foo(l: MyList) = myHead(l)
-                     ^^^^^^^^^
+                     ^^^^^^


### PR DESCRIPTION
For the holes panel, based on our own experiments and feedback from @jiribenes, I propose to display the bound names in the order they were defined in.
I.e., if you have the program

```scala
def foo(x: Int, y: Int, z: Int) = {
  val boo = "whatever"

  def bar(a: Int, b: Int) = <>

  val quack = "whatever"
}
```

with this PR, the context displays as follows:

![image](https://github.com/user-attachments/assets/75e9e38a-b337-4a6e-a077-4b61456d90d6)

In particular, within a scope, the variables are ordered as they were defined, rather than displayed in an arbitrary order (as they are now).

This is implemented by sorting symbols by the span of their declarations. To realize this, we had to add many more `decl` back-references to symbols.

Alternatives considered relied on the insertion order in `Namer`, which we cannot rely on as some symbols are added in `resolve`, some in `preresolve`.