### PR TITLE
Add spans to every source tree node

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Repl.scala
+++ b/effekt/jvm/src/main/scala/effekt/Repl.scala
@@ -108,7 +108,7 @@ class Repl(driver: Driver) extends REPL[Tree, EffektConfig, EffektError] {
       }
       output.emitln("")
 
-      runFrontend(StringSource(""), module.make(StringSource(""), UnitLit()), config) { cu =>
+      runFrontend(StringSource(""), module.make(StringSource(""), UnitLit(Span.missing)), config) { cu =>
         module.definitions.foreach {
           case u: Def =>
             outputCode(DeclPrinter(context.symbolOf(u)), config)
@@ -217,7 +217,7 @@ class Repl(driver: Driver) extends REPL[Tree, EffektConfig, EffektError] {
 
     case d: Def =>
       val extendedDefs = module + d
-      val decl = extendedDefs.make(source, UnitLit())
+      val decl = extendedDefs.make(source, UnitLit(Span.missing))
 
       runFrontend(source, decl, config) { cu =>
         module = extendedDefs
@@ -321,7 +321,7 @@ class Repl(driver: Driver) extends REPL[Tree, EffektConfig, EffektError] {
 
     def makeEval(source: Source, expr: Term): ModuleDecl = {
       val fakeSpan = Span(source, 0, 0, origin = Origin.Synthesized)
-      make(source, Call(IdTarget(IdRef(List(), "println", fakeSpan)), Nil, List(expr), Nil))
+      make(source, Call(IdTarget(IdRef(List(), "println", fakeSpan)), Nil, List(expr), Nil, fakeSpan))
     }
   }
   lazy val emptyModule = ReplModule(Nil, Nil)

--- a/effekt/jvm/src/main/scala/effekt/Repl.scala
+++ b/effekt/jvm/src/main/scala/effekt/Repl.scala
@@ -311,7 +311,7 @@ class Repl(driver: Driver) extends REPL[Tree, EffektConfig, EffektError] {
      */
     def make(source: Source, expr: Term): ModuleDecl = {
 
-      val body = Return(expr)
+      val body = Return(expr, expr.span.synthesized)
       val fakeSpan = Span(source, 0, 0, origin = Origin.Synthesized)
       val fullSpan = Span(source, 0, source.content.length, origin = Origin.Synthesized)
       ModuleDecl("interactive", includes,

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -479,7 +479,7 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
     contentTpe <- C.inferredTypeOption(hole.stmts)
     if holeTpe == contentTpe
     res <- hole match {
-      case Hole(id, source.Return(exp), span) => for {
+      case Hole(id, source.Return(exp, _), span) => for {
         text <- positions.textOf(exp)
       } yield EffektCodeAction("Close hole", span, text)
 

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1147,6 +1147,7 @@ class LSPTests extends FunSuite {
       didOpenParams.setTextDocument(source)
       server.getTextDocumentService().didOpen(didOpenParams)
 
+
       val expectedIRContents =
         raw"""ModuleDecl(
              |  test,
@@ -1184,9 +1185,18 @@ class LSPTests extends FunSuite {
              |              Synthesized()
              |            )
              |          ),
-             |          Return(Literal((), ValueTypeApp(Unit_405, Nil))),
+             |          Return(
+             |            Literal((), ValueTypeApp(Unit_whatever, Nil)),
+             |            Span(
+             |              StringSource(def main() = <>, file://test.effekt),
+             |              13,
+             |              15,
+             |              Synthesized()
+             |            )
+             |          ),
              |          Span(StringSource(def main() = <>, file://test.effekt), 13, 15, Real())
-             |        )
+             |        ),
+             |        Span(StringSource(def main() = <>, file://test.effekt), 13, 15, Real())
              |      ),
              |      None(),
              |      Span(StringSource(def main() = <>, file://test.effekt), 0, 15, Real())
@@ -1194,7 +1204,8 @@ class LSPTests extends FunSuite {
              |  ),
              |  None(),
              |  Span(StringSource(def main() = <>, file://test.effekt), 0, 15, Real())
-             |)""".stripMargin
+             |)
+             |""".stripMargin
 
       val receivedIRContent = client.receivedIR()
       assertEquals(receivedIRContent.length, 1)

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1186,7 +1186,16 @@ class LSPTests extends FunSuite {
              |            )
              |          ),
              |          Return(
-             |            Literal((), ValueTypeApp(Unit_whatever, Nil)),
+             |            Literal(
+             |              (),
+             |              ValueTypeApp(Unit_whatever, Nil),
+             |              Span(
+             |                StringSource(def main() = <>, file://test.effekt),
+             |                13,
+             |                15,
+             |                Synthesized()
+             |              )
+             |            ),
              |            Span(
              |              StringSource(def main() = <>, file://test.effekt),
              |              13,

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -672,7 +672,8 @@ class RecursiveDescentTests extends munit.FunSuite {
           ), Span(source, pos(0), pos(5))),
           Many.empty(Span(source, pos(5), pos(5))),
           TypeRef(IdRef(Nil, "Int", Span(source, pos(6), pos(7))), Many.empty(Span(source, pos(7), pos(7))), Span(source, pos(6), pos(7))),
-          Effects(Nil, Span(source, pos.last, pos.last, Synthesized))
+          Effects(Nil, Span(source, pos.last, pos.last, Synthesized)),
+          Span(source, pos(0), pos.last)
         )
       )
     }

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -270,12 +270,20 @@ class RecursiveDescentTests extends munit.FunSuite {
     {
       val (source, pos) =
         raw"""loop { f }
-             |↑   ↑  ↑↑
+             |↑   ↑  ↑↑ ↑
              |""".sourceAndPositions
 
       assertEquals(
         parseExpr(source.content),
-        Call(IdTarget(IdRef(Nil, "loop", Span(source, pos(0), pos(1)))), Nil, Nil, List(Var(IdRef(Nil, "f", Span(source, pos(2), pos(3)))))))
+        Call(
+          IdTarget(IdRef(Nil, "loop", Span(source, pos(0), pos(1)))),
+          Nil, Nil,
+          List(
+            Var(IdRef(Nil, "f", Span(source, pos(2), pos(3))), Span(source, pos(2), pos(3)))
+          ),
+          Span(source, pos(0), pos.last)
+        )
+      )
     }
 
     assertNotEqualModuloSpans(
@@ -294,7 +302,12 @@ class RecursiveDescentTests extends munit.FunSuite {
       assertEquals(
         parseExpr(source.content),
         // At the moment uniform function call syntax is always a method call
-        MethodCall(Var(IdRef(Nil, "foo", Span(source, pos(0), pos(1)))), IdRef(Nil, "bar", Span(source, pos(2), pos(3))), Nil, Nil, Nil))
+        MethodCall(
+          Var(IdRef(Nil, "foo", Span(source, pos(0), pos(1))), Span(source, pos(0), pos(1))),
+          IdRef(Nil, "bar", Span(source, pos(2), pos(3))), Nil, Nil, Nil,
+          Span(source, pos(0), pos.last)
+        )
+      )
     }
 
     parseExpr("resume(42)")
@@ -336,7 +349,7 @@ class RecursiveDescentTests extends munit.FunSuite {
              |""".sourceAndPosition
       val b = parseExpr(source.content)
       b match {
-        case Term.Box(c, _) => assertEquals(c.span, Span(source, pos, pos, Synthesized))
+        case Term.Box(c, _, _) => assertEquals(c.span, Span(source, pos, pos, Synthesized))
         case other =>
           throw new IllegalArgumentException(s"Expected Box but got ${other.getClass.getSimpleName}")
       }
@@ -379,28 +392,28 @@ class RecursiveDescentTests extends munit.FunSuite {
         raw"""map
              |↑ ↑
              |""".sourceAndSpan
-      assertEquals(parseExpr(source.content), Var(IdRef(List(), "map", span)))
+      assertEquals(parseExpr(source.content), Var(IdRef(List(), "map", span), span))
     }
     {
       val (source, span) =
         raw"""list::map
              |↑       ↑
              |""".sourceAndSpan
-      assertEquals(parseExpr(source.content), Var(IdRef(List("list"), "map", span)))
+      assertEquals(parseExpr(source.content), Var(IdRef(List("list"), "map", span), span))
     }
     {
       val (source, span) =
         raw"""list::internal::map
              |↑                 ↑
              |""".sourceAndSpan
-      assertEquals(parseExpr(source.content), Var(IdRef(List("list", "internal"), "map", span)))
+      assertEquals(parseExpr(source.content), Var(IdRef(List("list", "internal"), "map", span), span))
     }
     {
       val (source, span) =
         raw"""list::internal::test
              |↑                  ↑
              |""".sourceAndSpan
-      assertEquals(parseExpr(source.content), Var(IdRef(List("list", "internal"), "test", span)))
+      assertEquals(parseExpr(source.content), Var(IdRef(List("list", "internal"), "test", span), span))
     }
   }
 
@@ -741,7 +754,7 @@ class RecursiveDescentTests extends munit.FunSuite {
         Implementation(
           TypeRef(IdRef(Nil, "Foo", Span(source, pos(0), pos(1))), Many.empty(Span(source, pos(1), pos(1))), Span(source, pos(0), pos(1), Synthesized)),
           List(OpClause(IdRef(Nil, "Foo", Span(source, pos(0), pos(1), Synthesized)), Nil, Nil, Nil, None,
-            Return(Literal(43, symbols.builtins.TInt), Span(source, pos(2), pos(3))), IdDef("resume", Span(source, pos(1), pos(1)))))))
+            Return(Literal(43, symbols.builtins.TInt, Span(source, pos(2), pos(3))), Span(source, pos(2), pos(3))), IdDef("resume", Span(source, pos(1), pos(1)))))))
     }
   }
 
@@ -881,7 +894,11 @@ class RecursiveDescentTests extends munit.FunSuite {
 
       assertEquals(
         parseDefinition(source.content),
-        DefDef(IdDef("foo", Span(source, pos(0), pos(1))), None, Var(IdRef(Nil, "f", Span(source, pos(2), pos(3)))), None, Span(source, 0, pos.last)))
+        DefDef(
+          IdDef("foo", Span(source, pos(0), pos(1))),
+          None,
+          Var(IdRef(Nil, "f", Span(source, pos(2), pos(3))), Span(source, pos(2), pos(3))),
+          None, Span(source, 0, pos.last)))
     }
 
     parseDefinition(

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -505,8 +505,9 @@ class RecursiveDescentTests extends munit.FunSuite {
         MatchClause(
           TagPattern(
             IdRef(List("effekt"),"Tuple2",Span(source,pos(0),pos(5),Synthesized)),
-            List(AnyPattern(IdDef("left", Span(source,pos(1),pos(2)))),
-              AnyPattern(IdDef("right",Span(source,pos(3),pos(4)))))
+            List(AnyPattern(IdDef("left", Span(source,pos(1),pos(2))), Span(source,pos(1),pos(2))),
+              AnyPattern(IdDef("right",Span(source,pos(3),pos(4))), Span(source,pos(3),pos(4)))),
+            Span(source,pos(0),pos(5))
           ),
           List(),
           Return(Var(IdRef(List(),"left",Span(source,pos(9),pos(10))),
@@ -560,23 +561,27 @@ class RecursiveDescentTests extends munit.FunSuite {
     parseMatchPattern("Cons(x, y)")
     assertEqualModuloSpans(
       parseMatchPattern("_"),
-      IgnorePattern())
+      IgnorePattern(Span.missing))
     parseMatchPattern("Cons(x, Cons(x, Nil()))")
 
     {
       val (source, pos) =
         raw"""(left, Cons(x, right))
-             |↑↑   ↑ ↑   ↑↑↑ ↑    ↑ ↑
+             |↑↑   ↑ ↑   ↑↑↑ ↑    ↑↑↑
              |""".sourceAndPositions
       assertEquals(
         parseMatchPattern(source.content),
-        TagPattern(IdRef(List("effekt"), "Tuple2", Span(source, pos(0), pos(9), Synthesized)),
-          List(AnyPattern(IdDef("left", Span(source, pos(1), pos(2)))),
+        TagPattern(IdRef(List("effekt"), "Tuple2", Span(source, pos(0), pos.last, Synthesized)),
+          List(AnyPattern(IdDef("left", Span(source, pos(1), pos(2))), Span(source, pos(1), pos(2))),
             TagPattern(
               IdRef(List(), "Cons", Span(source, pos(3), pos(4))),
-              List(AnyPattern(IdDef("x", Span(source, pos(5), pos(6)))),
-                AnyPattern(IdDef("right", Span(source, pos(7), pos(8)))))
-            ))))
+              List(AnyPattern(IdDef("x", Span(source, pos(5), pos(6))), Span(source, pos(5), pos(6))),
+                AnyPattern(IdDef("right", Span(source, pos(7), pos(8))), Span(source, pos(7), pos(8)))),
+              Span(source, pos(3), pos(9))
+            )),
+          Span(source, pos(0), pos.last)
+        )
+      )
     }
   }
 

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -1260,6 +1260,7 @@ class RecursiveDescentTests extends munit.FunSuite {
         throw new IllegalArgumentException(s"Expected ExternDef but got ${other.getClass.getSimpleName}")
     }
 
+    assertEquals(extDef.bodies.head.span, Span(source, pos(1), pos.last))
     assertEquals(extDef.bodies.head.featureFlag.span, Span(source, pos(1), pos(2)))
     assertEquals(extDef.span, Span(source, pos(0), pos.last))
   }

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -734,14 +734,14 @@ class RecursiveDescentTests extends munit.FunSuite {
     {
       val (source, pos) =
         raw"""Foo { 43 }
-             |↑  ↑
+             |↑  ↑  ↑ ↑
              |""".sourceAndPositions
       assertEquals(
         parseImplementation(source.content),
         Implementation(
           TypeRef(IdRef(Nil, "Foo", Span(source, pos(0), pos(1))), Many.empty(Span(source, pos(1), pos(1))), Span(source, pos(0), pos(1), Synthesized)),
           List(OpClause(IdRef(Nil, "Foo", Span(source, pos(0), pos(1), Synthesized)), Nil, Nil, Nil, None,
-            Return(Literal(43, symbols.builtins.TInt)), IdDef("resume", Span(source, pos(1), pos(1)))))))
+            Return(Literal(43, symbols.builtins.TInt), Span(source, pos(2), pos(3))), IdDef("resume", Span(source, pos(1), pos(1)))))))
     }
   }
 
@@ -1026,7 +1026,7 @@ class RecursiveDescentTests extends munit.FunSuite {
     val definition = parseStmts(source.content)
 
     val regDef = definition match {
-      case DefStmt(rd@RegDef(id, annot, region, binding, doc, span), _) => rd
+      case DefStmt(rd@RegDef(id, annot, region, binding, doc, span), _, _) => rd
       case other =>
         throw new IllegalArgumentException(s"Expected RegDef but got ${other.getClass.getSimpleName}")
     }
@@ -1043,7 +1043,7 @@ class RecursiveDescentTests extends munit.FunSuite {
     val definition = parseStmts(source.content)
 
     val varDef = definition match {
-      case DefStmt(vd@VarDef(id, annot, binding, doc, span), _) => vd
+      case DefStmt(vd@VarDef(id, annot, binding, doc, span), _, _) => vd
       case other =>
         throw new IllegalArgumentException(s"Expected VarDef but got ${other.getClass.getSimpleName}")
     }

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -768,6 +768,21 @@ class RecursiveDescentTests extends munit.FunSuite {
     )
   }
 
+  test("Try handler capability parses with correct span") {
+    val (source, pos) =
+      raw"""try { 42 } with eff: Eff { 42 }
+           |                ↑  ↑
+           |""".sourceAndPositions
+
+    val tryExpr = parseTry(source.content) match {
+      case t: Term.TryHandle => t
+      case other =>
+        throw new IllegalArgumentException(s"Expected Try but got ${other.getClass.getSimpleName}")
+    }
+
+    assertEquals(tryExpr.handlers.head.capability.get.span, Span(source, pos(0), pos(1), Synthesized))
+  }
+
   test("Type definition") {
     parseDefinition("type A = Int")
     parseDefinition("type A[X] = Int")

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -512,7 +512,8 @@ class RecursiveDescentTests extends munit.FunSuite {
           List(),
           Return(Var(IdRef(List(),"left",Span(source,pos(9),pos(10))),
             Span(source,pos(9),pos(10))),
-            Span(source,pos(8),pos(10)))
+            Span(source,pos(8),pos(10))),
+          Span(source,pos(0),pos(7))
         )
       ),
       None,

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -1247,10 +1247,10 @@ class RecursiveDescentTests extends munit.FunSuite {
   }
 
   test("Extern effect‐body parses with correct span") {
-    val (source, span) =
+    val (source, pos) =
       raw"""extern def foo(): Int = default { foo() }
-           |↑                                       ↑
-           |""".sourceAndSpan
+           |↑                       ↑      ↑         ↑
+           |""".sourceAndPositions
 
     val definition = parseToplevel(source.content)
 
@@ -1260,7 +1260,8 @@ class RecursiveDescentTests extends munit.FunSuite {
         throw new IllegalArgumentException(s"Expected ExternDef but got ${other.getClass.getSimpleName}")
     }
 
-    assertEquals(extDef.span, span)
+    assertEquals(extDef.bodies.head.featureFlag.span, Span(source, pos(1), pos(2)))
+    assertEquals(extDef.span, Span(source, pos(0), pos.last))
   }
 
   test("Toplevel definitions") {

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -791,7 +791,9 @@ class RecursiveDescentTests extends munit.FunSuite {
         Implementation(
           TypeRef(IdRef(Nil, "Foo", Span(source, pos(0), pos(1))), Many.empty(Span(source, pos(1), pos(1))), Span(source, pos(0), pos(1), Synthesized)),
           List(OpClause(IdRef(Nil, "Foo", Span(source, pos(0), pos(1), Synthesized)), Nil, Nil, Nil, None,
-            Return(Literal(43, symbols.builtins.TInt, Span(source, pos(2), pos(3))), Span(source, pos(2), pos(3))), IdDef("resume", Span(source, pos(1), pos(1))))),
+            Return(Literal(43, symbols.builtins.TInt, Span(source, pos(2), pos(3))), Span(source, pos(2), pos(3))), IdDef("resume", Span(source, pos(1), pos(1))),
+            Span(source, pos(0), pos(3), Synthesized))
+          ),
           Span(source, pos(0), pos.last)
         ))
     }

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -756,13 +756,17 @@ class RecursiveDescentTests extends munit.FunSuite {
 
   test("Implementations") {
     {
-      val (source, span) =
+      val (source, pos) =
         raw"""Foo {}
-             |↑ ↑
-             |""".sourceAndSpan
+             |↑  ↑  ↑
+             |""".sourceAndPositions
       assertEquals(
         parseImplementation(source.content),
-        Implementation(TypeRef(IdRef(Nil, "Foo", span), Many.empty(Span(source, span.to, span.to)), span), Nil))
+        Implementation(
+          TypeRef(IdRef(Nil, "Foo", Span(source, pos(0), pos(1))), Many.empty(Span(source, pos(1), pos(1))), Span(source, pos(0), pos(1))),
+          Nil,
+          Span(source, pos(0), pos(2)))
+      )
     }
     parseImplementation("Foo[T] {}")
     parseImplementation("Foo[T] { def bar() = 42 }")
@@ -780,14 +784,16 @@ class RecursiveDescentTests extends munit.FunSuite {
     {
       val (source, pos) =
         raw"""Foo { 43 }
-             |↑  ↑  ↑ ↑
+             |↑  ↑  ↑ ↑ ↑
              |""".sourceAndPositions
       assertEquals(
         parseImplementation(source.content),
         Implementation(
           TypeRef(IdRef(Nil, "Foo", Span(source, pos(0), pos(1))), Many.empty(Span(source, pos(1), pos(1))), Span(source, pos(0), pos(1), Synthesized)),
           List(OpClause(IdRef(Nil, "Foo", Span(source, pos(0), pos(1), Synthesized)), Nil, Nil, Nil, None,
-            Return(Literal(43, symbols.builtins.TInt, Span(source, pos(2), pos(3))), Span(source, pos(2), pos(3))), IdDef("resume", Span(source, pos(1), pos(1)))))))
+            Return(Literal(43, symbols.builtins.TInt, Span(source, pos(2), pos(3))), Span(source, pos(2), pos(3))), IdDef("resume", Span(source, pos(1), pos(1))))),
+          Span(source, pos(0), pos.last)
+        ))
     }
   }
 

--- a/effekt/jvm/src/test/scala/effekt/core/PolymorphismBoxingTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/PolymorphismBoxingTests.scala
@@ -4,7 +4,7 @@ package core
 import effekt.{core, source, symbols}
 import effekt.context.Context
 import effekt.core.{Block, DirectApp, PolymorphismBoxing, Pure, Stmt}
-import effekt.source.{IdDef, Include}
+import effekt.source.{IdDef, Include, Span}
 import effekt.util.messages
 import effekt.util.messages.DebugMessaging
 import kiama.parsing.{Failure, NoSuccess, Success}
@@ -27,10 +27,10 @@ abstract class AbstractPolymorphismBoxingTests extends CorePhaseTests(Polymorphi
   val boxExterns = List(
     Extern.Def(defaultNames("boxInt"), Nil, Nil, List(ValueParam(Id("i"), ValueType.Data(defaultNames("Int"), Nil))), Nil,
       ValueType.Data(defaultNames("BoxedInt"), Nil), Set.empty,
-      ExternBody.StringExternBody(source.FeatureFlag.Default, Template(List("<box int>"), Nil))),
+      ExternBody.StringExternBody(source.FeatureFlag.Default(Span.missing), Template(List("<box int>"), Nil))),
     Extern.Def(defaultNames("unboxInt"), Nil, Nil, List(ValueParam(Id("i"), ValueType.Data(defaultNames("BoxedInt"), Nil))), Nil,
       ValueType.Data(defaultNames("Int"), Nil), Set.empty,
-      ExternBody.StringExternBody(source.FeatureFlag.Default, Template(List("<unbox int>"), Nil)))
+      ExternBody.StringExternBody(source.FeatureFlag.Default(Span.missing), Template(List("<unbox int>"), Nil)))
   )
 
   override def transform(input: ModuleDecl): ModuleDecl = input match {

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -92,7 +92,7 @@ trait Intelligence {
 
   def getSymbolOf(tree: Tree)(using C: Context): Option[Symbol] =
     tree match {
-      case i @ Include(path) => C.annotationOption(Annotations.IncludedSymbols, i)
+      case i @ Include(path, span) => C.annotationOption(Annotations.IncludedSymbols, i)
       case _ => None
     }
 

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -196,7 +196,7 @@ trait Intelligence {
       case (t: source.DefDef, c) => for {
         pos <- C.positions.getStart(t)
       } yield CaptureInfo(pos, c)
-      case (source.Box(Maybe(None, span), block), _) if C.inferredCaptureOption(block).isDefined => for {
+      case (source.Box(Maybe(None, span), block, _), _) if C.inferredCaptureOption(block).isDefined => for {
         capt <- C.inferredCaptureOption(block)
       } yield CaptureInfo(span.range.from, capt, true)
     }.flatten

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -575,7 +575,7 @@ object Namer extends Phase[Parsed, NameResolved] {
   }
 
   def resolve(h: source.Handler)(using Context): Unit = h match {
-    case source.Handler(capability, impl) =>
+    case source.Handler(capability, impl, _) =>
       resolve(impl)
       capability.foreach { param =>
         Context.bind(resolve(param))

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -97,7 +97,7 @@ object Namer extends Phase[Parsed, NameResolved] {
 
     // process all includes, updating the terms and types in scope
     val includes = decl.includes collect {
-      case im @ source.Include(path) =>
+      case im @ source.Include(path, span) =>
         // [[recursiveProtect]] is called here so the source position is the recursive import
         val mod = Context.at(im) { recursiveProtect(decl){ importDependency(path) } }
         Context.annotate(Annotations.IncludedSymbols, im, mod)

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -265,21 +265,21 @@ object Namer extends Phase[Parsed, NameResolved] {
 
   def resolve(s: source.Stmt)(using Context): Unit = Context.focusing(s) {
 
-    case source.DefStmt(d, rest) =>
+    case source.DefStmt(d, rest, span) =>
       // resolve declarations but do not resolve bodies
       preresolve(d)
       // resolve bodies
       resolve(d)
       resolve(rest)
 
-    case source.ExprStmt(term, rest) =>
+    case source.ExprStmt(term, rest, span) =>
       resolve(term)
       resolve(rest)
 
-    case source.Return(term) =>
+    case source.Return(term, span) =>
       resolve(term)
 
-    case source.BlockStmt(stmts) =>
+    case source.BlockStmt(stmts, span) =>
       Context scoped { resolve(stmts) }
   }
 

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -135,7 +135,7 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
 
     // allow recursive definitions of objects
-    case d @ source.DefDef(id, annot, source.New(source.Implementation(interface, clauses), _), doc, span) =>
+    case d @ source.DefDef(id, annot, source.New(source.Implementation(interface, clauses, _), _), doc, span) =>
       val tpe = Context.at(interface) { resolveBlockRef(interface) }
       val sym = Binder.DefBinder(Context.nameFor(id), Some(tpe), d)
       Context.define(id, sym)
@@ -583,7 +583,7 @@ object Namer extends Phase[Parsed, NameResolved] {
   }
 
   def resolve(i: source.Implementation)(using Context): Unit = Context.focusing(i) {
-    case source.Implementation(interface, clauses) =>
+    case source.Implementation(interface, clauses, _) =>
       val eff: Interface = Context.at(interface) { resolveBlockRef(interface).typeConstructor.asInterface }
 
       clauses.foreach {

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -340,8 +340,8 @@ object Namer extends Phase[Parsed, NameResolved] {
         Context.bindValues(sym.vparams)
         Context.bindBlocks(sym.bparams)
         bodies.foreach {
-          case source.ExternBody.StringExternBody(ff, body) => body.args.foreach(resolve)
-          case source.ExternBody.EffektExternBody(ff, body) => resolve(body)
+          case source.ExternBody.StringExternBody(ff, body, span) => body.args.foreach(resolve)
+          case source.ExternBody.EffektExternBody(ff, body, span) => resolve(body)
           case u: source.ExternBody.Unsupported => u
         }
       }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -587,7 +587,7 @@ object Namer extends Phase[Parsed, NameResolved] {
       val eff: Interface = Context.at(interface) { resolveBlockRef(interface).typeConstructor.asInterface }
 
       clauses.foreach {
-        case clause @ source.OpClause(op, tparams, vparams, bparams, ret, body, resumeId) => Context.at(clause) {
+        case clause @ source.OpClause(op, tparams, vparams, bparams, ret, body, resumeId, _) => Context.at(clause) {
 
           // try to find the operation in the handled effect:
           eff.operations.find { o => o.name.toString == op.name } map { opSym =>

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -646,7 +646,7 @@ object Namer extends Phase[Parsed, NameResolved] {
   }
 
   def resolve(m: source.MatchClause)(using Context): Unit = Context.focusing(m) {
-    case source.MatchClause(pattern, guards, body) =>
+    case source.MatchClause(pattern, guards, body, _) =>
       val ps = resolve(pattern)
       Context scoped {
         // variables bound by patterns are available in the guards.
@@ -697,8 +697,8 @@ object Namer extends Phase[Parsed, NameResolved] {
   }
 
   def resolve(p: source.MatchGuard)(using Context): Unit = p match {
-    case MatchGuard.BooleanGuard(condition) => resolve(condition)
-    case MatchGuard.PatternGuard(scrutinee, pattern) =>
+    case MatchGuard.BooleanGuard(condition, _) => resolve(condition)
+    case MatchGuard.PatternGuard(scrutinee, pattern, _) =>
       resolve(scrutinee)
       val ps = resolve(pattern)
       ps.foreach { Context.bind }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -678,13 +678,13 @@ object Namer extends Phase[Parsed, NameResolved] {
    * Returns the value params it binds
    */
   def resolve(p: source.MatchPattern)(using Context): List[ValueParam] = p match {
-    case source.IgnorePattern()     => Nil
-    case source.LiteralPattern(lit) => Nil
-    case source.AnyPattern(id) =>
+    case source.IgnorePattern(_)     => Nil
+    case source.LiteralPattern(lit, _) => Nil
+    case source.AnyPattern(id, _) =>
       val p = ValueParam(Name.local(id), None)
       Context.assignSymbol(id, p)
       List(p)
-    case source.TagPattern(id, patterns) =>
+    case source.TagPattern(id, patterns, _) =>
       Context.resolveTerm(id) match {
         case symbol: Constructor => ()
         case _ => Context.at(id) {
@@ -692,7 +692,7 @@ object Namer extends Phase[Parsed, NameResolved] {
         }
       }
       patterns.flatMap { resolve }
-    case source.MultiPattern(patterns) =>
+    case source.MultiPattern(patterns, _) =>
       patterns.flatMap { resolve }
   }
 

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -328,7 +328,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
 
   def includeDecl(): Include =
     nonterminal:
-      Include(`import` ~> moduleName())
+      Include(`import` ~> moduleName(), span())
 
   def moduleName(): String =
     some(ident, `/`).mkString("/") labelled "module name"

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -449,8 +449,8 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
             val default = when(`else`) { Some(stmt()) } { None }
             val body = semi() ~> stmts()
             val clause = MatchClause(p, guards, body).withRangeOf(p, sc)
-            val matching = Match(List(sc), List(clause), default, Span(source, startPos, endPos)).withRangeOf(startMarker, sc)
-            Return(matching, span())
+            val matching = Match(List(sc), List(clause), default, Span(source, startPos, endPos, Synthesized)).withRangeOf(startMarker, sc)
+            Return(matching, span().synthesized)
         }
 
       simpleLhs() getOrElse matchLhs()

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -775,7 +775,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
     nonterminal:
       `with` ~> backtrack(idDef() <~ `:`) ~ implementation() match {
         case capabilityName ~ impl =>
-          val capability = capabilityName map { name => BlockParam(name, Some(impl.interface)): BlockParam }
+          val capability = capabilityName map { name => BlockParam(name, Some(impl.interface), name.span.synthesized): BlockParam }
           Handler(capability.unspan, impl)
       }
 
@@ -1040,7 +1040,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
             val names = List.tabulate(arity){ n => s"__arg${n}" }
             BlockLiteral(
               Nil,
-              names.map { name => ValueParam(IdDef(name, Span.missing(source)), None) },
+              names.map { name => ValueParam(IdDef(name, Span.missing(source)), None, Span.missing(source)) },
               Nil,
               Return(Match(names.map{ name => Var(IdRef(Nil, name, Span.missing(source))) }, cs.unspan, None))) : BlockLiteral
           }
@@ -1325,7 +1325,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
 
   def lambdaParams(): (List[Id], List[ValueParam], List[BlockParam]) =
     nonterminal:
-      if isVariable then (Nil, List(ValueParam(idDef(), None)), Nil)  else paramsOpt()
+      if isVariable then (Nil, List(ValueParam(idDef(), None, span())), Nil)  else paramsOpt()
 
   def params(): (Many[Id], Many[ValueParam], Many[BlockParam]) =
     nonterminal:
@@ -1359,11 +1359,11 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
 
   def valueParam(): ValueParam =
     nonterminal:
-      ValueParam(idDef(), Some(valueTypeAnnotation()))
+      ValueParam(idDef(), Some(valueTypeAnnotation()), span())
 
   def valueParamOpt(): ValueParam =
     nonterminal:
-      ValueParam(idDef(), maybeValueTypeAnnotation())
+      ValueParam(idDef(), maybeValueTypeAnnotation(), span())
 
   def maybeBlockParams(): Many[BlockParam] =
     nonterminal:
@@ -1383,12 +1383,11 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
 
   def blockParam(): BlockParam =
     nonterminal:
-      BlockParam(idDef(), Some(blockTypeAnnotation()))
+      BlockParam(idDef(), Some(blockTypeAnnotation()), span())
 
   def blockParamOpt(): BlockParam =
     nonterminal:
-      BlockParam(idDef(), when(`:`)(Some(blockType()))(None))
-
+      BlockParam(idDef(), when(`:`)(Some(blockType()))(None), span())
 
   def maybeValueTypes(): Many[Type] =
     nonterminal:

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -614,10 +614,10 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
     nonterminal:
       peek.kind match {
         case _: Ident => (peek(1).kind match {
-          case `{` => ExternBody.EffektExternBody(featureFlag(), `{` ~> stmts() <~ `}`)
-          case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template())
+          case `{` => ExternBody.EffektExternBody(featureFlag(), `{` ~> stmts() <~ `}`, span())
+          case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template(), span())
         }) labelled "extern body (string or block)"
-        case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template())
+        case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template(), span())
       }
 
   private def isExternBodyStart: Boolean =

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -789,7 +789,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
   def implementation(): Implementation =
     nonterminal:
       // Interface[...] {}
-      def emptyImplementation() = backtrack { Implementation(blockTypeRef(), `{` ~> Nil <~ `}`) }
+      def emptyImplementation() = backtrack { Implementation(blockTypeRef(), `{` ~> Nil <~ `}`, span()) }
 
       // Interface[...] { def <NAME> = ... }
       def interfaceImplementation() = backtrack {
@@ -798,7 +798,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
         if !peek(`def`) then fail("Expected at least one operation definition to implement this interface.")
         tpe
       } map { tpe =>
-        Implementation(tpe, manyUntil(opClause() labelled "operation clause", `}`)) <~ `}`
+        Implementation(tpe, manyUntil(opClause() labelled "operation clause", `}`) <~ `}`, span())
       }
 
       // Interface[...] { () => ... }
@@ -808,7 +808,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
           val synthesizedId = IdRef(Nil, id.name, id.span.synthesized).withPositionOf(id)
           val interface = TypeRef(id, tps, id.span.synthesized).withPositionOf(id)
           val operation = OpClause(synthesizedId, Nil, vps, bps, None, body, k).withRangeOf(id, body)
-          Implementation(interface, List(operation))
+          Implementation(interface, List(operation), span())
       }
 
       (emptyImplementation() orElse interfaceImplementation() getOrElse operationImplementation()) labelled "interface implementation (starting with its name)"

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -782,7 +782,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
       `with` ~> backtrack(idDef() <~ `:`) ~ implementation() match {
         case capabilityName ~ impl =>
           val capability = capabilityName map { name => BlockParam(name, Some(impl.interface), name.span.synthesized): BlockParam }
-          Handler(capability.unspan, impl)
+          Handler(capability.unspan, impl, span())
       }
 
   // This nonterminal uses limited backtracking: It parses the interface type multiple times.

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -572,14 +572,14 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
 
   def featureFlag(): FeatureFlag = {
     expect("feature flag identifier") {
-      case Ident("default") => FeatureFlag.Default
-      case Ident(flag)      => FeatureFlag.NamedFeatureFlag(flag)
+      case Ident("default") => FeatureFlag.Default(span())
+      case Ident(flag)      => FeatureFlag.NamedFeatureFlag(flag, span())
     }
   }
 
   def maybeFeatureFlag(): FeatureFlag =
     nonterminal:
-      backtrack(featureFlag()).getOrElse(FeatureFlag.Default)
+      backtrack(featureFlag()).getOrElse(FeatureFlag.Default(span()))
 
   def externType(doc: Doc): Def =
     ExternType(`extern` ~> `type` ~> idDef(), maybeTypeParams(), doc, span())

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -807,7 +807,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
         case (id ~ tps ~ k ~ BlockLiteral(_, vps, bps, body, _)) =>
           val synthesizedId = IdRef(Nil, id.name, id.span.synthesized).withPositionOf(id)
           val interface = TypeRef(id, tps, id.span.synthesized).withPositionOf(id)
-          val operation = OpClause(synthesizedId, Nil, vps, bps, None, body, k).withRangeOf(id, body)
+          val operation = OpClause(synthesizedId, Nil, vps, bps, None, body, k, Span(source, id.span.from, body.span.to, Synthesized)).withRangeOf(id, body)
           Implementation(interface, List(operation), span())
       }
 
@@ -835,7 +835,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
           }
 
           // TODO the implicitResume needs to have the correct position assigned (maybe move it up again...)
-          OpClause(id, tps, vps, bps, ret.unspan, body, implicitResume)
+          OpClause(id, tps, vps, bps, ret.unspan, body, implicitResume, span())
       }
 
   def implicitResume: IdDef =

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -627,7 +627,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
   def checkStmt(stmt: Stmt, expected: Option[ValueType])(using Context, Captures): Result[ValueType] =
     checkAgainst(stmt, expected) {
       // local mutable state
-      case source.DefStmt(d @ source.VarDef(id, annot, binding, doc, span), rest) =>
+      case source.DefStmt(d @ source.VarDef(id, annot, binding, doc, span), rest, _) =>
         val sym = d.symbol
         val stCapt = CaptureSet(sym.capture)
 
@@ -648,20 +648,20 @@ object Typer extends Phase[NameResolved, Typechecked] {
           }
         }
 
-      case source.DefStmt(b, rest) =>
+      case source.DefStmt(b, rest, span) =>
         val Result(t, effBinding) = Context in { precheckDef(b); synthDef(b) }
         val Result(r, effStmt) = checkStmt(rest, expected)
         Result(r, effBinding ++ effStmt)
 
       // <expr> ; <stmt>
-      case source.ExprStmt(e, rest) =>
+      case source.ExprStmt(e, rest, span) =>
         val Result(_, eff1) = checkExpr(e, None)
         val Result(r, eff2) = checkStmt(rest, expected)
         Result(r, eff1 ++ eff2)
 
-      case source.Return(e)        => checkExpr(e, expected)
+      case source.Return(e, span)        => checkExpr(e, expected)
 
-      case source.BlockStmt(stmts) => Context in { checkStmt(stmts, expected) }
+      case source.BlockStmt(stmts, span) => Context in { checkStmt(stmts, expected) }
     }
 
   // not really checking, only if defs are fully annotated, we add them to the typeDB

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -283,13 +283,13 @@ object Typer extends Phase[NameResolved, Typechecked] {
         // check that number of patterns matches number of scrutinees
         val arity = scs.length
         clauses.foreach {
-          case cls @ source.MatchClause(source.MultiPattern(patterns, _), guards, body) =>
+          case cls @ source.MatchClause(source.MultiPattern(patterns, _), guards, body, _) =>
             if (patterns.length != arity) {
               Context.at(cls){
                 Context.error(pp"Number of patterns (${patterns.length}) does not match number of parameters / scrutinees (${arity}).")
               }
             }
-          case cls @ source.MatchClause(pattern, guards, body) =>
+          case cls @ source.MatchClause(pattern, guards, body, _) =>
             if (arity != 1) {
               Context.at(cls) {
                 Context.error(pp"Number of patterns (1) does not match number of parameters / scrutinees (${arity}).")
@@ -298,7 +298,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
         }
 
         val tpes = clauses.map {
-          case source.MatchClause(p, guards, body) =>
+          case source.MatchClause(p, guards, body, _) =>
             // (3) infer types for pattern(s)
             p match {
               case source.MultiPattern(ps, _) =>
@@ -612,10 +612,10 @@ object Typer extends Phase[NameResolved, Typechecked] {
   } match { case res => Context.annotateInferredType(pattern, sc); res }
 
   def checkGuard(guard: MatchGuard)(using Context, Captures): Result[Map[Symbol, ValueType]] = guard match {
-    case MatchGuard.BooleanGuard(condition) =>
+    case MatchGuard.BooleanGuard(condition, _) =>
       val Result(tpe, effs) = checkExpr(condition, Some(TBoolean))
       Result(Map.empty, effs)
-    case MatchGuard.PatternGuard(scrutinee, pattern) =>
+    case MatchGuard.PatternGuard(scrutinee, pattern, _) =>
       val Result(tpe, effs) = checkExpr(scrutinee, None)
       Result(checkPattern(tpe, pattern), effs)
   }

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -355,7 +355,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
    * The [[continuationDetails]] are only provided, if a continuation is captured (that is for implementations as part of effect handlers).
    */
   def checkImplementation(impl: source.Implementation, continuationDetails: Option[(ValueType, CaptUnificationVar)])(using Context, Captures): Result[InterfaceType] = Context.focusing(impl) {
-    case source.Implementation(sig, clauses) =>
+    case source.Implementation(sig, clauses, _) =>
 
       var handlerEffects: ConcreteEffects = Pure
 
@@ -677,7 +677,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
       // (2) Store the annotated type (important for (mutually) recursive and out-of-order definitions)
       fun.annotatedType.foreach { tpe => Context.bind(fun, tpe) }
 
-    case d @ source.DefDef(id, annot, source.New(source.Implementation(tpe, clauses), _), doc, span) =>
+    case d @ source.DefDef(id, annot, source.New(source.Implementation(tpe, clauses, _), _), doc, span) =>
       val obj = d.symbol
 
       // (1) make up a fresh capture unification variable

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -376,7 +376,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
         Context.error("Duplicate definitions of operations")
 
       clauses foreach Context.withFocus {
-        case d @ source.OpClause(op, tparams, vparams, bparams, retAnnotation, body, resume) =>
+        case d @ source.OpClause(op, tparams, vparams, bparams, retAnnotation, body, resume, _) =>
 
           retAnnotation.foreach {
             case Effectful(otherTpe, otherEffs2, span) =>

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -871,9 +871,9 @@ object Typer extends Phase[NameResolved, Typechecked] {
           // Note: Externs are always annotated with a type
           val expectedReturnType = d.symbol.annotatedType.get.result
           bodies.foreach {
-            case source.ExternBody.StringExternBody(ff, body) =>
+            case source.ExternBody.StringExternBody(ff, body, span) =>
               body.args.foreach { arg => checkExpr(arg, None) }
-            case source.ExternBody.EffektExternBody(ff, body) =>
+            case source.ExternBody.EffektExternBody(ff, body, span) =>
               checkStmt(body, Some(expectedReturnType))
             case u: source.ExternBody.Unsupported => u
           }

--- a/effekt/shared/src/main/scala/effekt/core/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Parser.scala
@@ -2,10 +2,10 @@ package effekt
 package core
 
 import effekt.core.ValueParam
-import effekt.source.{FeatureFlag, NoSource}
-import effekt.util.messages.{ DebugMessaging, ErrorReporter, ParseError }
-import kiama.parsing.{ Failure, Input, NoSuccess, ParseResult, Success }
-import kiama.util.{ Position, Positions, Range, Source, StringSource }
+import effekt.source.{FeatureFlag, NoSource, Span}
+import effekt.util.messages.{DebugMessaging, ErrorReporter, ParseError}
+import kiama.parsing.{Failure, Input, NoSuccess, ParseResult, Success}
+import kiama.util.{Position, Positions, Range, Source, StringSource}
 
 import scala.util.matching.Regex
 
@@ -77,8 +77,8 @@ class CoreParsers(positions: Positions, names: Names) extends EffektLexers(posit
     })
 
   lazy val featureFlag: P[FeatureFlag] =
-    ("else" ^^ { _ => FeatureFlag.Default }
-    | ident ^^ FeatureFlag.NamedFeatureFlag.apply
+    ("else" ^^ { _ => FeatureFlag.Default(Span.missing) }
+    | ident ^^ (id => FeatureFlag.NamedFeatureFlag(id, Span.missing))
     )
 
 

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -69,8 +69,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
   }
 
   def toDoc(ff: FeatureFlag): Doc = ff match {
-    case FeatureFlag.NamedFeatureFlag(name) => name
-    case FeatureFlag.Default => "default"
+    case FeatureFlag.NamedFeatureFlag(name, span) => name
+    case FeatureFlag.Default(span) => "default"
   }
 
   def toDoc(t: Template[Pure]): Doc =

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -210,12 +210,12 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
   }
 
   def transformUnbox(tree: source.Term)(implicit C: Context): Block = tree match {
-    case source.Unbox(b) => Unbox(transformAsPure(b))
+    case source.Unbox(b, _) => Unbox(transformAsPure(b))
     case _ => Unbox(transformAsPure(tree))
   }
 
   def transformBox(tree: source.Term)(implicit C: Context): Pure = tree match {
-    case source.Box(capt, block) => Box(transformAsBlock(tree), transform(Context.inferredCapture(block)))
+    case source.Box(capt, block, _) => Box(transformAsBlock(tree), transform(Context.inferredCapture(block)))
     case _ => Box(transformAsBlock(tree), transform(Context.inferredCapture(tree)))
   }
 
@@ -241,10 +241,10 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     case v: source.Var =>
       BlockVar(v.definition.asInstanceOf[BlockSymbol])
 
-    case source.BlockLiteral(tparams, vparams, bparams, body) =>
+    case source.BlockLiteral(tparams, vparams, bparams, body, _) =>
       Context.panic(s"Using block literal ${tree} but an object was expected.")
 
-    case source.New(impl) =>
+    case source.New(impl, _) =>
       New(transform(impl, None))
 
     case _ => transformUnbox(tree)
@@ -308,12 +308,12 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
           Context.abort(s"Expected a function but got an object of type ${t}")
       }
 
-    case source.BlockLiteral(tps, vps, bps, body) =>
+    case source.BlockLiteral(tps, vps, bps, body, _) =>
       val tparams = tps.map(t => t.symbol)
       val cparams = bps.map { b => b.symbol.capture }
       BlockLit(tparams, cparams, vps map transform, bps map transform, transform(body))
 
-    case s @ source.New(impl) =>
+    case s @ source.New(impl, _) =>
       Context.abort(s"Expected a function but got an object instantiation: ${s}")
 
     case _ => transformUnbox(tree)
@@ -336,11 +336,11 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       case sym: BlockSymbol => transformBox(tree)
     }
 
-    case source.Literal(value, tpe) =>
+    case source.Literal(value, tpe, _) =>
       Literal(value, transform(tpe))
 
     // [[ sc.field ]] = val x = sc match { tag: { (_, _, x, _) => return x } }; ...
-    case s @ source.Select(receiver, selector) =>
+    case s @ source.Select(receiver, selector, _) =>
       val field: Field = s.definition
 
       val constructor = field.constructor
@@ -369,23 +369,23 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       Context.bind(Stmt.Match(transformAsPure(receiver),
         List((constructor, BlockLit(Nil, Nil, params, Nil, Stmt.Return(Pure.ValueVar(selected, tpe))))), None))
 
-    case source.Box(capt, block) =>
+    case source.Box(capt, block, _) =>
       transformBox(block)
 
-    case source.New(impl) =>
+    case source.New(impl, _) =>
       transformBox(tree)
 
-    case source.Unbox(b) =>
+    case source.Unbox(b, _) =>
       transformBox(tree)
 
-    case source.BlockLiteral(tps, vps, bps, body) =>
+    case source.BlockLiteral(tps, vps, bps, body, _) =>
       transformBox(tree)
 
-    case source.If(List(MatchGuard.BooleanGuard(cond)), thn, els) =>
+    case source.If(List(MatchGuard.BooleanGuard(cond)), thn, els, _) =>
       val c = transformAsPure(cond)
       Context.bind(If(c, transform(thn), transform(els)))
 
-    case source.If(guards, thn, els) =>
+    case source.If(guards, thn, els, _) =>
       val thnClause = preprocess("thn", Nil, guards, transform(thn))
       val elsClause = preprocess("els", Nil, Nil, transform(els))
       Context.bind(PatternMatchingCompiler.compile(List(thnClause, elsClause)))
@@ -399,7 +399,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     // [[ while(cond) { body } ]] =
     //   def loop$13() = if ([[cond]]) { [[ body ]]; loop$13() } else { return () }
     //   loop$13()
-    case source.While(guards, body, default) =>
+    case source.While(guards, body, default, _) =>
       val loopName = TmpBlock("while")
       val loopType = core.BlockType.Function(Nil, Nil, Nil, Nil, core.Type.TUnit)
 
@@ -427,11 +427,11 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       Context.bind(loopCall)
 
     // Empty match (matching on Nothing)
-    case source.Match(List(sc), Nil, None) =>
+    case source.Match(List(sc), Nil, None, _) =>
       val scrutinee: ValueVar = Context.bind(transformAsPure(sc))
       Context.bind(core.Match(scrutinee, Nil, None))
 
-    case source.Match(scs, cs, default) =>
+    case source.Match(scs, cs, default, _) =>
       // (1) Bind scrutinee and all clauses so we do not have to deal with sharing on demand.
       val scrutinees: List[ValueVar] = scs.map{ sc => Context.bind(transformAsPure(sc)) }
       val clauses = cs.zipWithIndex.map((c, i) => preprocess(s"k${i}", scrutinees, c))
@@ -439,7 +439,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       val compiledMatch = PatternMatchingCompiler.compile(clauses ++ defaultClause)
       Context.bind(compiledMatch)
 
-    case source.TryHandle(prog, handlers) =>
+    case source.TryHandle(prog, handlers, _) =>
 
       val transformedProg = transform(prog)
 
@@ -463,7 +463,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
 
       Context.bind(Reset(body))
 
-    case r @ source.Region(name, body) =>
+    case r @ source.Region(name, body, _) =>
       val region = r.symbol
       val tpe = Context.blockTypeOf(region)
       val cap: core.BlockParam = core.BlockParam(region, transform(tpe), Set(region.capture))
@@ -472,14 +472,14 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     case source.Hole(id, stmts, span) =>
       Context.bind(core.Hole())
 
-    case a @ source.Assign(id, expr) =>
+    case a @ source.Assign(id, expr, _) =>
       val sym = a.definition
       // emits `ref := value; return ()`
       Context.bind(Put(sym, transform(Context.captureOf(sym)), transformAsPure(expr), Return(Literal((), core.Type.TUnit))))
       Literal((), core.Type.TUnit)
 
     // methods are dynamically dispatched, so we have to assume they are `control`, hence no PureApp.
-    case c @ source.MethodCall(receiver, id, targs, vargs, bargs) =>
+    case c @ source.MethodCall(receiver, id, targs, vargs, bargs, _) =>
       val rec = transformAsObject(receiver)
       val typeArgs = Context.typeArguments(c).map(transform)
       val valueArgs = vargs.map(transformAsPure)
@@ -497,7 +497,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
 
       Context.bind(Invoke(rec, operation, opType, remainingTypeArgs, valueArgs, blockArgs))
 
-    case c @ source.Call(source.ExprTarget(source.Unbox(expr)), targs, vargs, bargs) =>
+    case c @ source.Call(source.ExprTarget(source.Unbox(expr, _)), targs, vargs, bargs, _) =>
 
       val (funTpe, capture) = Context.inferredTypeOf(expr) match {
         case BoxedType(s: FunctionType, c: CaptureSet) => (s, c)
@@ -511,14 +511,14 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
 
       Context.bind(App(Unbox(e), typeArgs, valueArgs, blockArgs))
 
-    case c @ source.Call(fun: source.IdTarget, _, vargs, bargs) =>
+    case c @ source.Call(fun: source.IdTarget, _, vargs, bargs, _) =>
       // assumption: typer removed all ambiguous references, so there is exactly one
       makeFunctionCall(c, fun.definition, vargs, bargs)
 
-    case c @ source.Call(s: source.ExprTarget, targs, vargs, bargs) =>
+    case c @ source.Call(s: source.ExprTarget, targs, vargs, bargs, _) =>
       Context.panic("Should not happen. Unbox should have been inferred.")
 
-    case source.Do(effect, id, targs, vargs, bargs) =>
+    case source.Do(effect, id, targs, vargs, bargs, _) =>
       Context.panic("Should have been translated away (to explicit selection `@CAP.op()`) by capability passing.")
   }
 
@@ -526,7 +526,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
    * Aims to flatten sequenced ifs into a single match
    */
   def collectClauses(term: source.Term)(using Context): Option[List[Clause]] = term match {
-    case source.If(guards, thn, els) =>
+    case source.If(guards, thn, els, _) =>
       val thenClause = preprocess("thn", Nil, guards, transform(thn))
       val elseClauses = collectClauses(els) match {
         case Some(clauses) => clauses
@@ -714,7 +714,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
         Pattern.Tag(id.symbol, tparams, patterns.map { p => (transformPattern(p), transform(Context.inferredTypeOf(p))) })
       case source.IgnorePattern() =>
         Pattern.Ignore()
-      case source.LiteralPattern(source.Literal(value, tpe)) =>
+      case source.LiteralPattern(source.Literal(value, tpe, _)) =>
         Pattern.Literal(Literal(value, transform(tpe)), equalsFor(tpe))
       case source.MultiPattern(patterns) =>
         Context.panic("Multi-pattern should have been split on toplevel / nested MultiPattern")

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -555,7 +555,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     }
 
     Implementation(coreType, sig.operations.map(clauses.apply).map {
-      case op @ source.OpClause(id, tparams, vparams, bparams, ret, body, resume) =>
+      case op @ source.OpClause(id, tparams, vparams, bparams, ret, body, resume, _) =>
         val vps = vparams.map(transform)
         val tps = tparams.map { p => p.symbol }
 

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -453,7 +453,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       val promptParam: core.BlockParam = core.BlockParam(promptId, promptTpe, Set(promptCapt))
 
       val transformedHandlers = handlers.map {
-        case h @ source.Handler(cap, impl) =>
+        case h @ source.Handler(cap, impl, _) =>
           val id = h.capability.get.symbol
           Binding.Def(id, New(transform(impl, Some(promptVar))))
       }

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -109,7 +109,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       assert(effects.isEmpty)
       val cps = bps.map(b => b.symbol.capture)
       val tBody = bodies match {
-        case source.ExternBody.StringExternBody(ff, body) :: Nil =>
+        case source.ExternBody.StringExternBody(ff, body, span) :: Nil =>
           val args = body.args.map(transformAsExpr).map {
             case p: Pure => p: Pure
             case _ => Context.abort("Spliced arguments need to be pure expressions.")

--- a/effekt/shared/src/main/scala/effekt/core/vm/VM.scala
+++ b/effekt/shared/src/main/scala/effekt/core/vm/VM.scala
@@ -520,7 +520,7 @@ class Interpreter(instrumentation: Instrumentation, runtime: Runtime) {
 
     val builtinFunctions = m.externs.collect {
       case Extern.Def(id, tparams, cparams, vparams, bparams, ret, annotatedCapture,
-        ExternBody.StringExternBody(FeatureFlag.NamedFeatureFlag("vm"), Template(name :: Nil, Nil))) =>
+        ExternBody.StringExternBody(FeatureFlag.NamedFeatureFlag("vm", _), Template(name :: Nil, Nil))) =>
           id -> builtins.getOrElse(name, throw VMError.MissingBuiltin(name))
     }.toMap
 

--- a/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
+++ b/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
@@ -32,39 +32,39 @@ object AnnotateCaptures extends Phase[Typechecked, Typechecked], Query[Unit, Cap
   def combine(r1: CaptureSet, r2: CaptureSet): CaptureSet = r1 ++ r2
 
   override def expr(using Context, Unit) = {
-    case source.Var(id) => id.symbol match {
+    case source.Var(id, _) => id.symbol match {
       case b: BlockSymbol => captureOf(b)
       case x: ValueSymbol => CaptureSet.empty
     }
 
-    case e @ source.Assign(id, expr) =>
+    case e @ source.Assign(id, expr, _) =>
       query(expr) ++ captureOf(id.symbol.asBlockSymbol)
 
-    case l @ source.Box(annotatedCapture, block) =>
+    case l @ source.Box(annotatedCapture, block, _) =>
       query(block)
       CaptureSet.empty
 
-    case source.Unbox(term) =>
+    case source.Unbox(term, _) =>
       val capt = Context.inferredTypeOption(term) match {
         case Some(BoxedType(_, capture: CaptureSet)) => capture
         case _ => Context.panic(pp"Should have an inferred a concrete capture set for ${term}")
       }
       query(term) ++ capt
 
-    case t @ source.Do(effect, op, targs, vargs, bargs) =>
+    case t @ source.Do(effect, op, targs, vargs, bargs, _) =>
       val cap = Context.annotation(Annotations.CapabilityReceiver, t)
       combineAll(vargs.map(query)) ++ combineAll(bargs.map(query)) ++ CaptureSet(cap.capture)
 
-    case t @ source.TryHandle(prog, handlers) =>
+    case t @ source.TryHandle(prog, handlers, _) =>
       val progCapture = query(prog)
       val boundCapture = boundCapabilities(t)
       val usedCapture = combineAll(handlers.map(query))
       (progCapture -- boundCapture) ++ usedCapture
 
-    case t @ source.Region(id, body) =>
+    case t @ source.Region(id, body, _) =>
       query(body) -- captureOf(id.symbol.asBlockSymbol)
 
-    case c @ source.Call(target, targs, vargs, bargs) =>
+    case c @ source.Call(target, targs, vargs, bargs, _) =>
       // TODO what's with unboxed value references???
       //  maybe that's solved by inserting explicit box and unbox in Elaboration
       val tcaps = target match {
@@ -74,7 +74,7 @@ object AnnotateCaptures extends Phase[Typechecked, Typechecked], Query[Unit, Cap
 
       tcaps ++ combineAll(vargs map query) ++ combineAll(bargs map query)
 
-    case b @ source.BlockLiteral(tps, vps, bps, body) =>
+    case b @ source.BlockLiteral(tps, vps, bps, body, _) =>
       query(body) -- boundCapabilities(b) -- CaptureSet(bps.map(_.symbol.capture))
   }
 

--- a/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
+++ b/effekt/shared/src/main/scala/effekt/source/AnnotateCaptures.scala
@@ -80,7 +80,7 @@ object AnnotateCaptures extends Phase[Typechecked, Typechecked], Query[Unit, Cap
 
   override def stmt(using Context, Unit) = {
     // local state
-    case source.DefStmt(tree @ VarDef(id, annot, binding, doc, span), rest) =>
+    case source.DefStmt(tree @ VarDef(id, annot, binding, doc, span), rest, _) =>
       query(binding) ++ (query(rest) -- CaptureSet(tree.symbol.capture))
   }
 

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -132,13 +132,13 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
   override def rewrite(body: ExternBody)(using context.Context): ExternBody = 
     body match {
-      case b @ source.ExternBody.StringExternBody(ff, body) =>
+      case b @ source.ExternBody.StringExternBody(ff, body, span) =>
         val rewrittenTemplate =
           body.copy(
             args = body.args.map { rewrite }
           )
         b.copy(template = rewrittenTemplate)
-      case b @ source.ExternBody.EffektExternBody(ff, body) =>
+      case b @ source.ExternBody.EffektExternBody(ff, body, span) =>
         val rewrittenBody = rewrite(body) 
         b.copy(body = rewrittenBody)
       case u: source.ExternBody.Unsupported => u

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -110,7 +110,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       TryHandle(body, hs, span)
 
-    case n @ source.New(impl @ Implementation(interface, clauses), span) => {
+    case n @ source.New(impl @ Implementation(interface, clauses, implSpan), newSpan) => {
       val cs = clauses map {
         case op @ OpClause(id, tparams, vparams, bparams, ret, body, resume) => {
           val capabilities = Context.annotation(Annotations.BoundCapabilities, op)
@@ -118,8 +118,8 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
           OpClause(id, tparams, vparams, bparams ++ capabilityParams, ret, rewrite(body), resume)
         }
       }
-      val newImpl = Implementation(interface, cs)
-      val tree = source.New(newImpl, span)
+      val newImpl = Implementation(interface, cs, implSpan)
+      val tree = source.New(newImpl, newSpan)
       Context.copyAnnotations(impl, newImpl)
       tree
     }

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -154,6 +154,6 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
   def definitionFor(s: symbols.BlockParam)(using C: Context): source.BlockParam =
     val id = IdDef(s.name.name, Span.missing)
     C.assignSymbol(id, s)
-    val tree: source.BlockParam = source.BlockParam(id, s.tpe.map { source.BlockTypeTree.apply })
+    val tree: source.BlockParam = source.BlockParam(id, s.tpe.map { source.BlockTypeTree.apply }, Span.missing)
     tree
 }

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -56,7 +56,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       val capabilityArgs = others.map(referenceToCapability)
 
       val typeArguments = Context.annotation(Annotations.TypeArguments, c)
-      val typeArgs = typeArguments.map { e => ValueTypeTree(e) }
+      val typeArgs = typeArguments.map { e => ValueTypeTree(e, Span.missing) }
 
       // construct the member selection on the capability as receiver
       MethodCall(referenceToCapability(receiver).inheritPosition(id), id, typeArgs, transformedValueArgs, transformedBlockArgs ++ capabilityArgs, span.synthesized)
@@ -73,7 +73,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       val capabilityArgs = capabilities.map(referenceToCapability)
 
       val typeArguments = Context.annotation(Annotations.TypeArguments, c)
-      val typeArgs = typeArguments.map { e => ValueTypeTree(e) }
+      val typeArgs = typeArguments.map { e => ValueTypeTree(e, Span.missing) }
 
       val recv = rewrite(receiver)
 
@@ -88,7 +88,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       val capabilityArgs = capabilities.map(referenceToCapability)
 
       val typeArguments = Context.annotation(Annotations.TypeArguments, c)
-      val typeArgs = typeArguments.map { e => ValueTypeTree(e) }
+      val typeArgs = typeArguments.map { e => ValueTypeTree(e, Span.missing) }
 
       Call(receiver, typeArgs, valueArgs, blockArgs ++ capabilityArgs, span)
 
@@ -154,6 +154,6 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
   def definitionFor(s: symbols.BlockParam)(using C: Context): source.BlockParam =
     val id = IdDef(s.name.name, Span.missing)
     C.assignSymbol(id, s)
-    val tree: source.BlockParam = source.BlockParam(id, s.tpe.map { source.BlockTypeTree.apply }, Span.missing)
+    val tree: source.BlockParam = source.BlockParam(id, s.tpe.map { source.BlockTypeTree(_, Span.missing) }, Span.missing)
     tree
 }

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -104,7 +104,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       val hs = (handlers zip capabilities).map {
         case (h, cap) => visit(h) {
           // here we annotate the synthesized capability
-          case h @ Handler(_, impl) => Handler(Some(definitionFor(cap)), rewrite(impl))
+          case h @ Handler(_, impl, span) => Handler(Some(definitionFor(cap)), rewrite(impl), span)
         }
       }
 

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -112,10 +112,10 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
     case n @ source.New(impl @ Implementation(interface, clauses, implSpan), newSpan) => {
       val cs = clauses map {
-        case op @ OpClause(id, tparams, vparams, bparams, ret, body, resume) => {
+        case op @ OpClause(id, tparams, vparams, bparams, ret, body, resume, span) => {
           val capabilities = Context.annotation(Annotations.BoundCapabilities, op)
           val capabilityParams = capabilities.map(definitionFor)
-          OpClause(id, tparams, vparams, bparams ++ capabilityParams, ret, rewrite(body), resume)
+          OpClause(id, tparams, vparams, bparams ++ capabilityParams, ret, rewrite(body), resume, span)
         }
       }
       val newImpl = Implementation(interface, cs, implSpan)

--- a/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
@@ -41,7 +41,7 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
   def rewrite(defn: Def)(using Context): Option[Def] = Context.focusing(defn) {
       case Def.ExternDef(capture, id, tparams, vparams, bparams, ret, bodies, doc, span) =>
         findPreferred(bodies) match {
-          case body@ExternBody.StringExternBody(featureFlag, template) =>
+          case body@ExternBody.StringExternBody(featureFlag, template, span) =>
             if (featureFlag.isDefault) {
               Context.warning(s"Extern definition ${id} contains extern string without feature flag. This will likely not work in other backends, "
                 + s"please annotate it with a feature flag (Supported by the current backend: ${Context.compiler.supportedFeatureFlags.mkString(", ")})")
@@ -50,7 +50,7 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
             val d = Def.ExternDef(capture, id, tparams, vparams, bparams, ret, List(body), doc, span)
             Context.copyAnnotations(defn, d)
             Some(d)
-          case ExternBody.EffektExternBody(featureFlag, body) =>
+          case ExternBody.EffektExternBody(featureFlag, body, span) =>
             val d = Def.FunDef(id, tparams, vparams, bparams, Some(ret).spanned(ret.span), body, doc, span)
             Context.copyAnnotations(defn, d)
             Context.annotate(Annotations.BoundCapabilities, d, Nil) // TODO ??

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -578,7 +578,7 @@ case class Handler(capability: Option[BlockParam] = None, impl: Implementation, 
 
 // `ret` is an optional user-provided type annotation for the return type
 // currently the annotation is rejected by [[Typer]] -- after that phase, `ret` should always be `None`
-case class OpClause(id: IdRef,  tparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: Option[Effectful], body: Stmt, resume: IdDef) extends Reference
+case class OpClause(id: IdRef,  tparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: Option[Effectful], body: Stmt, resume: IdDef, override val span: Span) extends Reference
 
 // Pattern Matching
 // ----------------

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -570,7 +570,7 @@ case class Implementation(interface: TypeRef, clauses: List[OpClause], override 
 /**
  * A handler is a pair of an optionally named capability and the handler [[Implementation]]
  */
-case class Handler(capability: Option[BlockParam] = None, impl: Implementation) extends Reference {
+case class Handler(capability: Option[BlockParam] = None, impl: Implementation, override val span: Span) extends Reference {
   def effect = impl.interface
   def clauses = impl.clauses
   def id = impl.id

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -177,8 +177,8 @@ object FeatureFlag {
       case Nil => false
       case name :: other =>
         self.collectFirst {
-          case ExternBody.StringExternBody(flag, a) if flag.matches(name) => ()
-          case ExternBody.EffektExternBody(flag, a) if flag.matches(name) => ()
+          case ExternBody.StringExternBody(flag, a, span) if flag.matches(name) => ()
+          case ExternBody.EffektExternBody(flag, a, span) if flag.matches(name) => ()
         }.isDefined || (self.supportedByFeatureFlags(other))
     }
   }
@@ -188,8 +188,8 @@ sealed trait ExternBody extends Tree {
   def featureFlag: FeatureFlag
 }
 object ExternBody {
-  case class StringExternBody(featureFlag: FeatureFlag, template: Template[source.Term]) extends ExternBody
-  case class EffektExternBody(featureFlag: FeatureFlag, body: source.Stmt) extends ExternBody
+  case class StringExternBody(featureFlag: FeatureFlag, template: Template[source.Term], override val span: Span) extends ExternBody
+  case class EffektExternBody(featureFlag: FeatureFlag, body: source.Stmt, override val span: Span) extends ExternBody
   case class Unsupported(message: util.messages.EffektError) extends ExternBody {
     override def featureFlag: FeatureFlag = FeatureFlag.Default(Span.missing)
   }

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -149,25 +149,25 @@ object Span {
  * Used to mark externs for different backends
  */
 enum FeatureFlag extends Tree {
-  case NamedFeatureFlag(id: String)
-  case Default
+  case NamedFeatureFlag(id: String, override val span: Span)
+  case Default(override val span: Span)
 
   def matches(name: String, matchDefault: Boolean = true): Boolean = this match {
-    case NamedFeatureFlag(n) if n == name => true
-    case Default => matchDefault
+    case NamedFeatureFlag(n, span) if n == name => true
+    case Default(span) => matchDefault
     case _ => false
   }
   def isDefault: Boolean = this == Default
 
   def matches(names: List[String]): Boolean = this match {
-    case NamedFeatureFlag(n) if names.contains(n) => true
-    case Default => true
+    case NamedFeatureFlag(n, span) if names.contains(n) => true
+    case Default(span) => true
     case _ => false
   }
 
   override def toString: String = this match {
-    case FeatureFlag.NamedFeatureFlag(id) => id
-    case FeatureFlag.Default => "else"
+    case FeatureFlag.NamedFeatureFlag(id, span) => id
+    case FeatureFlag.Default(span) => "else"
   }
 }
 object FeatureFlag {
@@ -191,7 +191,7 @@ object ExternBody {
   case class StringExternBody(featureFlag: FeatureFlag, template: Template[source.Term]) extends ExternBody
   case class EffektExternBody(featureFlag: FeatureFlag, body: source.Stmt) extends ExternBody
   case class Unsupported(message: util.messages.EffektError) extends ExternBody {
-    override def featureFlag: FeatureFlag = FeatureFlag.Default
+    override def featureFlag: FeatureFlag = FeatureFlag.Default(Span.missing)
   }
 }
 

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -90,7 +90,7 @@ import scala.annotation.tailrec
  * We extend product to allow reflective access by Kiama.
  */
 sealed trait Tree extends Product {
-  val span: Span = Span.missing
+  val span: Span
 
   def inheritPosition(from: Tree)(implicit C: Context): this.type = {
     C.positions.dupPos(from, this);
@@ -101,10 +101,14 @@ sealed trait Tree extends Product {
 /**
  * Used for builtin and synthesized trees
  */
-case object NoSource extends Tree
+case object NoSource extends Tree {
+  val span: Span = Span.missing
+}
 
 // only used by the lexer
-case class Comment() extends Tree
+case class Comment() extends Tree {
+  val span: Span = Span.missing
+}
 
 type Doc = Option[String]
 
@@ -149,8 +153,8 @@ object Span {
  * Used to mark externs for different backends
  */
 enum FeatureFlag extends Tree {
-  case NamedFeatureFlag(id: String, override val span: Span)
-  case Default(override val span: Span)
+  case NamedFeatureFlag(id: String, span: Span)
+  case Default(span: Span)
 
   def matches(name: String, matchDefault: Boolean = true): Boolean = this match {
     case NamedFeatureFlag(n, span) if n == name => true
@@ -191,9 +195,10 @@ sealed trait ExternBody extends Tree {
   def featureFlag: FeatureFlag
 }
 object ExternBody {
-  case class StringExternBody(featureFlag: FeatureFlag, template: Template[source.Term], override val span: Span) extends ExternBody
-  case class EffektExternBody(featureFlag: FeatureFlag, body: source.Stmt, override val span: Span) extends ExternBody
+  case class StringExternBody(featureFlag: FeatureFlag, template: Template[source.Term], span: Span) extends ExternBody
+  case class EffektExternBody(featureFlag: FeatureFlag, body: source.Stmt, span: Span) extends ExternBody
   case class Unsupported(message: util.messages.EffektError) extends ExternBody {
+    val span: Span = Span.missing
     override def featureFlag: FeatureFlag = FeatureFlag.Default(Span.missing)
   }
 }
@@ -210,14 +215,14 @@ sealed trait Id extends Tree {
   def symbol(using C: Context): Symbol = C.symbolOf(this)
   def clone(using C: Context): Id
 }
-case class IdDef(name: String, override val span: Span) extends Id {
+case class IdDef(name: String, span: Span) extends Id {
   def clone(using C: Context): IdDef = {
     val copy = IdDef(name, span)
     C.positions.dupPos(this, copy)
     copy
   }
 }
-case class IdRef(path: List[String], name: String, override val span: Span) extends Id {
+case class IdRef(path: List[String], name: String, span: Span) extends Id {
   def clone(using C: Context): IdRef = {
     val copy = IdRef(path, name, span)
     C.positions.dupPos(this, copy)
@@ -245,15 +250,15 @@ sealed trait Reference extends Named {
  * A module declaration, the path should be an Effekt include path, not a system dependent file path
  *
  */
-case class ModuleDecl(path: String, includes: List[Include], defs: List[Def], doc: Doc, override val span: Span) extends Tree
-case class Include(path: String, override val span: Span) extends Tree
+case class ModuleDecl(path: String, includes: List[Include], defs: List[Def], doc: Doc, span: Span) extends Tree
+case class Include(path: String, span: Span) extends Tree
 
 /**
  * Parameters and arguments
  */
 enum Param extends Definition {
-  case ValueParam(id: IdDef, tpe: Option[ValueType], override val span: Span)
-  case BlockParam(id: IdDef, tpe: Option[BlockType], override val span: Span)
+  case ValueParam(id: IdDef, tpe: Option[ValueType], span: Span)
+  case BlockParam(id: IdDef, tpe: Option[BlockType], span: Span)
 }
 export Param.*
 
@@ -350,40 +355,40 @@ export SpannedOps._
  */
 enum Def extends Definition {
 
-  case FunDef(id: IdDef, tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], ret: Maybe[Effectful], body: Stmt, doc: Doc, override val span: Span)
-  case ValDef(id: IdDef, annot: Option[ValueType], binding: Stmt, doc: Doc, override val span: Span)
-  case RegDef(id: IdDef, annot: Option[ValueType], region: IdRef, binding: Stmt, doc: Doc, override val span: Span)
-  case VarDef(id: IdDef, annot: Option[ValueType], binding: Stmt, doc: Doc, override val span: Span)
-  case DefDef(id: IdDef, annot: Option[BlockType], block: Term, doc: Doc, override val span: Span)
+  case FunDef(id: IdDef, tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], ret: Maybe[Effectful], body: Stmt, doc: Doc, span: Span)
+  case ValDef(id: IdDef, annot: Option[ValueType], binding: Stmt, doc: Doc, span: Span)
+  case RegDef(id: IdDef, annot: Option[ValueType], region: IdRef, binding: Stmt, doc: Doc, span: Span)
+  case VarDef(id: IdDef, annot: Option[ValueType], binding: Stmt, doc: Doc, span: Span)
+  case DefDef(id: IdDef, annot: Option[BlockType], block: Term, doc: Doc, span: Span)
 
-  case NamespaceDef(id: IdDef, definitions: List[Def], doc: Doc, override val span: Span)
+  case NamespaceDef(id: IdDef, definitions: List[Def], doc: Doc, span: Span)
 
-  case InterfaceDef(id: IdDef, tparams: Many[Id], ops: List[Operation], doc: Doc, override val span: Span)
-  case DataDef(id: IdDef, tparams: Many[Id], ctors: List[Constructor], doc: Doc, override val span: Span)
-  case RecordDef(id: IdDef, tparams: Many[Id], fields: Many[ValueParam], doc: Doc, override val span: Span)
+  case InterfaceDef(id: IdDef, tparams: Many[Id], ops: List[Operation], doc: Doc, span: Span)
+  case DataDef(id: IdDef, tparams: Many[Id], ctors: List[Constructor], doc: Doc, span: Span)
+  case RecordDef(id: IdDef, tparams: Many[Id], fields: Many[ValueParam], doc: Doc, span: Span)
 
   /**
    * Type aliases like `type Matrix[T] = List[List[T]]`
    */
-  case TypeDef(id: IdDef, tparams: List[Id], tpe: ValueType, doc: Doc, override val span: Span)
+  case TypeDef(id: IdDef, tparams: List[Id], tpe: ValueType, doc: Doc, span: Span)
 
   /**
    * Effect aliases like `effect Set = { Get, Put }`
    */
-  case EffectDef(id: IdDef, tparams: List[Id], effs: Effects, doc: Doc, override val span: Span)
+  case EffectDef(id: IdDef, tparams: List[Id], effs: Effects, doc: Doc, span: Span)
 
   /**
    * Only valid on the toplevel!
    */
-  case ExternType(id: IdDef, tparams: Many[Id], doc: Doc, override val span: Span)
+  case ExternType(id: IdDef, tparams: Many[Id], doc: Doc, span: Span)
 
   case ExternDef(capture: CaptureSet, id: IdDef,
                  tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], ret: Effectful,
-                 bodies: List[ExternBody], doc: Doc, override val span: Span) extends Def
+                 bodies: List[ExternBody], doc: Doc, span: Span) extends Def
 
-  case ExternResource(id: IdDef, tpe: BlockType, doc: Doc, override val span: Span)
+  case ExternResource(id: IdDef, tpe: BlockType, doc: Doc, span: Span)
 
-  case ExternInterface(id: IdDef, tparams: List[Id], doc: Doc, override val span: Span)
+  case ExternInterface(id: IdDef, tparams: List[Id], doc: Doc, span: Span)
 
   /**
    * Namer resolves the path and loads the contents in field [[contents]]
@@ -391,7 +396,7 @@ enum Def extends Definition {
    * @note Storing content and id as user-visible fields is a workaround for the limitation that Enum's cannot
    *   have case specific refinements.
    */
-  case ExternInclude(featureFlag: FeatureFlag, path: String, var contents: Option[String] = None, val id: IdDef, doc: Doc, override val span: Span)
+  case ExternInclude(featureFlag: FeatureFlag, path: String, var contents: Option[String] = None, val id: IdDef, doc: Doc, span: Span)
 
   def doc: Doc
 }
@@ -418,10 +423,10 @@ export Def.*
  *
  */
 enum Stmt extends Tree {
-  case DefStmt(d: Def, rest: Stmt, override val span: Span)
-  case ExprStmt(d: Term, rest: Stmt, override val span: Span)
-  case Return(d: Term, override val span: Span)
-  case BlockStmt(stmts: Stmt, override val span: Span)
+  case DefStmt(d: Def, rest: Stmt, span: Span)
+  case ExprStmt(d: Term, rest: Stmt, span: Span)
+  case Return(d: Term, span: Span)
+  case BlockStmt(stmts: Stmt, span: Span)
 }
 export Stmt.*
 
@@ -456,15 +461,15 @@ export Stmt.*
 enum Term extends Tree {
 
   // Variable / Value use (can now also stand for blocks)
-  case Var(id: IdRef, override val span: Span) extends Term, Reference
-  case Assign(id: IdRef, expr: Term, override val span: Span) extends Term, Reference
+  case Var(id: IdRef, span: Span) extends Term, Reference
+  case Assign(id: IdRef, expr: Term, span: Span) extends Term, Reference
 
-  case Literal(value: Any, tpe: symbols.ValueType, override val span: Span)
-  case Hole(id: IdDef, stmts: Stmt, override val span: Span)
+  case Literal(value: Any, tpe: symbols.ValueType, span: Span)
+  case Hole(id: IdDef, stmts: Stmt, span: Span)
 
   // Boxing and unboxing to represent first-class values
-  case Box(capt: Maybe[CaptureSet], block: Term, override val span: Span)
-  case Unbox(term: Term, override val span: Span)
+  case Box(capt: Maybe[CaptureSet], block: Term, span: Span)
+  case Unbox(term: Term, span: Span)
 
   /**
    * Models:
@@ -473,7 +478,7 @@ enum Term extends Tree {
    *
    * The resolved target can help to determine whether the receiver needs to be type-checked as first- or second-class.
    */
-  case Select(receiver: Term, id: IdRef, override val span: Span) extends Term, Reference
+  case Select(receiver: Term, id: IdRef, span: Span) extends Term, Reference
 
   /**
    * A call to an effect operation, i.e., `do raise()`.
@@ -481,12 +486,12 @@ enum Term extends Tree {
    * The [[effect]] is the optionally annotated effect type (not possible in source ATM). In the future, this could
    * look like `do Exc.raise()`, or `do[Exc] raise()`, or do[Exc].raise(), or simply Exc.raise() where Exc is a type.
    */
-  case Do(effect: Option[TypeRef], id: IdRef, targs: List[ValueType], vargs: List[Term], bargs: List[Term], override val span: Span) extends Term, Reference
+  case Do(effect: Option[TypeRef], id: IdRef, targs: List[ValueType], vargs: List[Term], bargs: List[Term], span: Span) extends Term, Reference
 
   /**
    * A call to either an expression, i.e., `(fun() { ...})()`; or a named function, i.e., `foo()`
    */
-  case Call(target: CallTarget, targs: List[ValueType], vargs: List[Term], bargs: List[Term], override val span: Span)
+  case Call(target: CallTarget, targs: List[ValueType], vargs: List[Term], bargs: List[Term], span: Span)
 
   /**
    * Models:
@@ -495,12 +500,12 @@ enum Term extends Tree {
    *
    * The resolved target can help to determine whether the receiver needs to be type-checked as first- or second-class.
    */
-  case MethodCall(receiver: Term, id: IdRef, targs: List[ValueType], vargs: List[Term], bargs: List[Term], override val span: Span) extends Term, Reference
+  case MethodCall(receiver: Term, id: IdRef, targs: List[ValueType], vargs: List[Term], bargs: List[Term], span: Span) extends Term, Reference
 
   // Control Flow
-  case If(guards: List[MatchGuard], thn: Stmt, els: Stmt, override val span: Span)
-  case While(guards: List[MatchGuard], block: Stmt, default: Option[Stmt], override val span: Span)
-  case Match(scrutinees: List[Term], clauses: List[MatchClause], default: Option[Stmt], override val span: Span)
+  case If(guards: List[MatchGuard], thn: Stmt, els: Stmt, span: Span)
+  case While(guards: List[MatchGuard], block: Stmt, default: Option[Stmt], span: Span)
+  case Match(scrutinees: List[Term], clauses: List[MatchClause], default: Option[Stmt], span: Span)
 
   /**
    * Handling effects
@@ -511,14 +516,14 @@ enum Term extends Tree {
    *
    * Each with-clause is modeled as an instance of type [[Handler]].
    */
-  case TryHandle(prog: Stmt, handlers: List[Handler], override val span: Span)
-  case Region(id: IdDef, body: Stmt, override val span: Span) extends Term, Definition
+  case TryHandle(prog: Stmt, handlers: List[Handler], span: Span)
+  case Region(id: IdDef, body: Stmt, span: Span) extends Term, Definition
 
   /**
    * Lambdas / function literals (e.g., { x => x + 1 })
    */
-  case BlockLiteral(tparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], body: Stmt, override val span: Span) extends Term
-  case New(impl: Implementation, override val span: Span)
+  case BlockLiteral(tparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], body: Stmt, span: Span) extends Term
+  case New(impl: Implementation, span: Span)
 }
 export Term.*
 
@@ -541,15 +546,20 @@ enum CallTarget extends Tree {
 
   // not overloaded
   case ExprTarget(receiver: Term)
+
+  val span: Span = this match {
+    case IdTarget(id) => id.span
+    case ExprTarget(receiver) => receiver.span
+  }
 }
 export CallTarget.*
 
 
 // Declarations
 // ------------
-case class Constructor(id: IdDef, tparams: Many[Id], params: Many[ValueParam], doc: Doc, override val span: Span) extends Definition
+case class Constructor(id: IdDef, tparams: Many[Id], params: Many[ValueParam], doc: Doc, span: Span) extends Definition
 
-case class Operation(id: IdDef, tparams: Many[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: Effectful, doc: Doc, override val span: Span) extends Definition
+case class Operation(id: IdDef, tparams: Many[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: Effectful, doc: Doc, span: Span) extends Definition
 
 // Implementations
 // ---------------
@@ -563,14 +573,14 @@ case class Operation(id: IdDef, tparams: Many[Id], vparams: List[ValueParam], bp
  *
  * Called "template" or "class" in other languages.
  */
-case class Implementation(interface: TypeRef, clauses: List[OpClause], override val span: Span) extends Reference {
+case class Implementation(interface: TypeRef, clauses: List[OpClause], span: Span) extends Reference {
   def id = interface.id
 }
 
 /**
  * A handler is a pair of an optionally named capability and the handler [[Implementation]]
  */
-case class Handler(capability: Option[BlockParam] = None, impl: Implementation, override val span: Span) extends Reference {
+case class Handler(capability: Option[BlockParam] = None, impl: Implementation, span: Span) extends Reference {
   def effect = impl.interface
   def clauses = impl.clauses
   def id = impl.id
@@ -578,21 +588,21 @@ case class Handler(capability: Option[BlockParam] = None, impl: Implementation, 
 
 // `ret` is an optional user-provided type annotation for the return type
 // currently the annotation is rejected by [[Typer]] -- after that phase, `ret` should always be `None`
-case class OpClause(id: IdRef,  tparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: Option[Effectful], body: Stmt, resume: IdDef, override val span: Span) extends Reference
+case class OpClause(id: IdRef,  tparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: Option[Effectful], body: Stmt, resume: IdDef, span: Span) extends Reference
 
 // Pattern Matching
 // ----------------
 
-case class MatchClause(pattern: MatchPattern, guards: List[MatchGuard], body: Stmt, override val span: Span) extends Tree
+case class MatchClause(pattern: MatchPattern, guards: List[MatchGuard], body: Stmt, span: Span) extends Tree
 
 enum MatchGuard extends Tree {
 
-  case BooleanGuard(condition: Term, override val span: Span)
+  case BooleanGuard(condition: Term, span: Span)
 
   /**
    * i.e. <EXPR> is <PATTERN>
    */
-  case PatternGuard(scrutinee: Term, pattern: MatchPattern, override val span: Span)
+  case PatternGuard(scrutinee: Term, pattern: MatchPattern, span: Span)
 }
 export MatchGuard.*
 
@@ -603,26 +613,26 @@ enum MatchPattern extends Tree {
    *
    *   case a => ...
    */
-  case AnyPattern(id: IdDef, override val span: Span) extends MatchPattern, Definition
+  case AnyPattern(id: IdDef, span: Span) extends MatchPattern, Definition
 
   /**
    * Pattern matching on a constructor
    *
    *   case Cons(a, as) => ...
    */
-  case TagPattern(id: IdRef, patterns: List[MatchPattern], override val span: Span) extends MatchPattern, Reference
+  case TagPattern(id: IdRef, patterns: List[MatchPattern], span: Span) extends MatchPattern, Reference
 
   /**
    * A wildcard pattern ignoring the matched value
    *
    *   case _ => ...
    */
-  case IgnorePattern(override val span: Span)
+  case IgnorePattern(span: Span)
 
   /**
    * A pattern that matches a single literal value
    */
-  case LiteralPattern(l: Literal, override val span: Span)
+  case LiteralPattern(l: Literal, span: Span)
 
   /**
    * A pattern for multiple values
@@ -631,7 +641,7 @@ enum MatchPattern extends Tree {
    *
    * Currently should *only* occur in lambda-cases during Parsing
    */
-  case MultiPattern(patterns: List[MatchPattern], override val span: Span) extends MatchPattern
+  case MultiPattern(patterns: List[MatchPattern], span: Span) extends MatchPattern
 }
 export MatchPattern.*
 
@@ -658,33 +668,33 @@ sealed trait Type extends Tree
 /**
  * Trees that represent inferred or synthesized *value* types (not present in the source = not parsed)
  */
-case class ValueTypeTree(tpe: symbols.ValueType, override val span: Span) extends Type
+case class ValueTypeTree(tpe: symbols.ValueType, span: Span) extends Type
 
 /**
  * Trees that represent inferred or synthesized *block* types (not present in the source = not parsed)
  */
-case class BlockTypeTree(eff: symbols.BlockType, override val span: Span) extends Type
+case class BlockTypeTree(eff: symbols.BlockType, span: Span) extends Type
 
 /*
  * Reference to a type, potentially with bound occurences in `args`
  */
-case class TypeRef(id: IdRef, args: Many[ValueType], override val span: Span) extends Type, Reference
+case class TypeRef(id: IdRef, args: Many[ValueType], span: Span) extends Type, Reference
 
 /**
  * Types of first-class computations
  */
-case class BoxedType(tpe: BlockType, capt: CaptureSet, override val span: Span) extends Type
+case class BoxedType(tpe: BlockType, capt: CaptureSet, span: Span) extends Type
 
 /**
  * Types of (second-class) functions
  */
-case class FunctionType(tparams: Many[Id], vparams: Many[ValueType], bparams: Many[(Maybe[IdDef], BlockType)], result: ValueType, effects: Effects, override val span: Span) extends Type
+case class FunctionType(tparams: Many[Id], vparams: Many[ValueType], bparams: Many[(Maybe[IdDef], BlockType)], result: ValueType, effects: Effects, span: Span) extends Type
 
 
 /**
  * Type-and-effect annotations
  */
-case class Effectful(tpe: ValueType, eff: Effects, override val span: Span) extends Type
+case class Effectful(tpe: ValueType, eff: Effects, span: Span) extends Type
 
 // These are just type aliases for documentation purposes.
 type BlockType = Type
@@ -694,12 +704,12 @@ type ValueType = Type
  * Represents an annotated set of effects. Before name resolution, we cannot know
  * the concrete nature of its elements (so it is generic [[TypeRef]]).
  */
-case class Effects(effs: List[TypeRef], override val span: Span) extends Tree
+case class Effects(effs: List[TypeRef], span: Span) extends Tree
 object Effects {
   def Pure(span: Span): Effects = Effects(List(), span)
 }
 
-case class CaptureSet(captures: List[IdRef], override val span: Span) extends Tree
+case class CaptureSet(captures: List[IdRef], span: Span) extends Tree
 
 
 object Named {

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -583,16 +583,16 @@ case class OpClause(id: IdRef,  tparams: List[Id], vparams: List[ValueParam], bp
 // Pattern Matching
 // ----------------
 
-case class MatchClause(pattern: MatchPattern, guards: List[MatchGuard], body: Stmt) extends Tree
+case class MatchClause(pattern: MatchPattern, guards: List[MatchGuard], body: Stmt, override val span: Span) extends Tree
 
 enum MatchGuard extends Tree {
 
-  case BooleanGuard(condition: Term)
+  case BooleanGuard(condition: Term, override val span: Span)
 
   /**
    * i.e. <EXPR> is <PATTERN>
    */
-  case PatternGuard(scrutinee: Term, pattern: MatchPattern)
+  case PatternGuard(scrutinee: Term, pattern: MatchPattern, override val span: Span)
 }
 export MatchGuard.*
 

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -658,12 +658,12 @@ sealed trait Type extends Tree
 /**
  * Trees that represent inferred or synthesized *value* types (not present in the source = not parsed)
  */
-case class ValueTypeTree(tpe: symbols.ValueType) extends Type
+case class ValueTypeTree(tpe: symbols.ValueType, override val span: Span) extends Type
 
 /**
  * Trees that represent inferred or synthesized *block* types (not present in the source = not parsed)
  */
-case class BlockTypeTree(eff: symbols.BlockType) extends Type
+case class BlockTypeTree(eff: symbols.BlockType, override val span: Span) extends Type
 
 /*
  * Reference to a type, potentially with bound occurences in `args`
@@ -673,12 +673,12 @@ case class TypeRef(id: IdRef, args: Many[ValueType], override val span: Span) ex
 /**
  * Types of first-class computations
  */
-case class BoxedType(tpe: BlockType, capt: CaptureSet) extends Type
+case class BoxedType(tpe: BlockType, capt: CaptureSet, override val span: Span) extends Type
 
 /**
  * Types of (second-class) functions
  */
-case class FunctionType(tparams: Many[Id], vparams: Many[ValueType], bparams: Many[(Maybe[IdDef], BlockType)], result: ValueType, effects: Effects) extends Type
+case class FunctionType(tparams: Many[Id], vparams: Many[ValueType], bparams: Many[(Maybe[IdDef], BlockType)], result: ValueType, effects: Effects, override val span: Span) extends Type
 
 
 /**
@@ -699,7 +699,7 @@ object Effects {
   def Pure(span: Span): Effects = Effects(List(), span)
 }
 
-case class CaptureSet(captures: List[IdRef]) extends Tree
+case class CaptureSet(captures: List[IdRef], override val span: Span) extends Tree
 
 
 object Named {

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -603,26 +603,26 @@ enum MatchPattern extends Tree {
    *
    *   case a => ...
    */
-  case AnyPattern(id: IdDef) extends MatchPattern, Definition
+  case AnyPattern(id: IdDef, override val span: Span) extends MatchPattern, Definition
 
   /**
    * Pattern matching on a constructor
    *
    *   case Cons(a, as) => ...
    */
-  case TagPattern(id: IdRef, patterns: List[MatchPattern]) extends MatchPattern, Reference
+  case TagPattern(id: IdRef, patterns: List[MatchPattern], override val span: Span) extends MatchPattern, Reference
 
   /**
    * A wildcard pattern ignoring the matched value
    *
    *   case _ => ...
    */
-  case IgnorePattern()
+  case IgnorePattern(override val span: Span)
 
   /**
    * A pattern that matches a single literal value
    */
-  case LiteralPattern(l: Literal)
+  case LiteralPattern(l: Literal, override val span: Span)
 
   /**
    * A pattern for multiple values
@@ -631,7 +631,7 @@ enum MatchPattern extends Tree {
    *
    * Currently should *only* occur in lambda-cases during Parsing
    */
-  case MultiPattern(patterns: List[MatchPattern]) extends MatchPattern
+  case MultiPattern(patterns: List[MatchPattern], override val span: Span) extends MatchPattern
 }
 export MatchPattern.*
 

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -563,7 +563,7 @@ case class Operation(id: IdDef, tparams: Many[Id], vparams: List[ValueParam], bp
  *
  * Called "template" or "class" in other languages.
  */
-case class Implementation(interface: TypeRef, clauses: List[OpClause]) extends Reference {
+case class Implementation(interface: TypeRef, clauses: List[OpClause], override val span: Span) extends Reference {
   def id = interface.id
 }
 

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -157,7 +157,10 @@ enum FeatureFlag extends Tree {
     case Default(span) => matchDefault
     case _ => false
   }
-  def isDefault: Boolean = this == Default
+  def isDefault: Boolean = this match {
+    case Default(_) => true
+    case _          => false
+  }
 
   def matches(names: List[String]): Boolean = this match {
     case NamedFeatureFlag(n, span) if names.contains(n) => true

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -243,14 +243,14 @@ sealed trait Reference extends Named {
  *
  */
 case class ModuleDecl(path: String, includes: List[Include], defs: List[Def], doc: Doc, override val span: Span) extends Tree
-case class Include(path: String, span: Span) extends Tree
+case class Include(path: String, override val span: Span) extends Tree
 
 /**
  * Parameters and arguments
  */
 enum Param extends Definition {
-  case ValueParam(id: IdDef, tpe: Option[ValueType])
-  case BlockParam(id: IdDef, tpe: Option[BlockType])
+  case ValueParam(id: IdDef, tpe: Option[ValueType], override val span: Span)
+  case BlockParam(id: IdDef, tpe: Option[BlockType], override val span: Span)
 }
 export Param.*
 

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -243,7 +243,7 @@ sealed trait Reference extends Named {
  *
  */
 case class ModuleDecl(path: String, includes: List[Include], defs: List[Def], doc: Doc, override val span: Span) extends Tree
-case class Include(path: String) extends Tree
+case class Include(path: String, span: Span) extends Tree
 
 /**
  * Parameters and arguments

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -415,10 +415,10 @@ export Def.*
  *
  */
 enum Stmt extends Tree {
-  case DefStmt(d: Def, rest: Stmt)
-  case ExprStmt(d: Term, rest: Stmt)
-  case Return(d: Term)
-  case BlockStmt(stmts: Stmt)
+  case DefStmt(d: Def, rest: Stmt, override val span: Span)
+  case ExprStmt(d: Term, rest: Stmt, override val span: Span)
+  case Return(d: Term, override val span: Span)
+  case BlockStmt(stmts: Stmt, override val span: Span)
 }
 export Stmt.*
 

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -184,8 +184,8 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
   }
 
   def rewrite(h: Handler)(using Context): Handler = visit(h) {
-    case Handler(capability, impl) =>
-      Handler(capability, rewrite(impl))
+    case Handler(capability, impl, span) =>
+      Handler(capability, rewrite(impl), span)
   }
 
   def rewrite(i: Implementation)(using Context): Implementation = visit(i) {

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -189,8 +189,8 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
   }
 
   def rewrite(i: Implementation)(using Context): Implementation = visit(i) {
-    case Implementation(interface, clauses) =>
-      Implementation(interface, clauses.map(rewrite))
+    case Implementation(interface, clauses, span) =>
+      Implementation(interface, clauses.map(rewrite), span)
   }
 
   def rewrite(h: OpClause)(using Context): OpClause = visit(h) {

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -199,13 +199,13 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
   }
 
   def rewrite(c: MatchClause)(using Context): MatchClause = visit(c) {
-    case MatchClause(pattern, guards, body) =>
-      MatchClause(pattern, guards.map(rewrite), rewrite(body))
+    case MatchClause(pattern, guards, body, span) =>
+      MatchClause(pattern, guards.map(rewrite), rewrite(body), span)
   }
 
   def rewrite(g: MatchGuard)(using Context): MatchGuard = g match {
-    case BooleanGuard(condition) => BooleanGuard(rewriteAsExpr(condition))
-    case PatternGuard(scrutinee, pattern) => PatternGuard(rewriteAsExpr(scrutinee), pattern)
+    case BooleanGuard(condition, span) => BooleanGuard(rewriteAsExpr(condition), span)
+    case PatternGuard(scrutinee, pattern, span) => PatternGuard(rewriteAsExpr(scrutinee), pattern, span)
   }
 
   /**

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -170,17 +170,17 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
   }
 
   def rewrite(t: Stmt)(using C: Context): Stmt = visit(t) {
-    case DefStmt(d, rest) =>
-      flattenNamespaces(d).foldRight(rewrite(rest)) { case (d, rest) => DefStmt(d, rest) }
+    case DefStmt(d, rest, span) =>
+      flattenNamespaces(d).foldRight(rewrite(rest)) { case (d, rest) => DefStmt(d, rest, span) }
 
-    case ExprStmt(e, rest) =>
-      ExprStmt(rewriteAsExpr(e), rewrite(rest))
+    case ExprStmt(e, rest, span) =>
+      ExprStmt(rewriteAsExpr(e), rewrite(rest), span)
 
-    case Return(e) =>
-      Return(rewriteAsExpr(e))
+    case Return(e, span) =>
+      Return(rewriteAsExpr(e), span)
 
-    case BlockStmt(b) =>
-      BlockStmt(rewrite(b))
+    case BlockStmt(b, span) =>
+      BlockStmt(rewrite(b), span)
   }
 
   def rewrite(h: Handler)(using Context): Handler = visit(h) {

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -194,8 +194,8 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
   }
 
   def rewrite(h: OpClause)(using Context): OpClause = visit(h) {
-    case OpClause(id, tparams, vparams, bparams, ret, body, resume) =>
-      OpClause(id, tparams, vparams, bparams, ret, rewrite(body), resume)
+    case OpClause(id, tparams, vparams, bparams, ret, body, resume, span) =>
+      OpClause(id, tparams, vparams, bparams, ret, rewrite(body), resume, span)
   }
 
   def rewrite(c: MatchClause)(using Context): MatchClause = visit(c) {

--- a/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
@@ -100,7 +100,7 @@ object ExhaustivityChecker {
   def preprocess(roots: List[source.Term], cl: source.MatchClause)(using Context): Clause = (roots, cl) match {
     case (List(root), source.MatchClause(pattern, guards, body)) =>
       Clause.normalized(Condition.Patterns(Map(Trace.Root(root) -> preprocessPattern(pattern))) :: guards.map(preprocessGuard), cl)
-    case (roots, source.MatchClause(MultiPattern(patterns), guards, body)) =>
+    case (roots, source.MatchClause(MultiPattern(patterns, _), guards, body)) =>
       val rootConds: Map[Trace, Pattern] = (roots zip patterns).map { case (root, pattern) =>
         Trace.Root(root) -> preprocessPattern(pattern)
       }.toMap
@@ -108,11 +108,11 @@ object ExhaustivityChecker {
     case (_, _) => Context.abort("Malformed multi-match")
   }
   def preprocessPattern(p: source.MatchPattern)(using Context): Pattern = p match {
-    case AnyPattern(id)  => Pattern.Any()
-    case IgnorePattern() => Pattern.Any()
-    case p @ TagPattern(id, patterns) => Pattern.Tag(p.definition, patterns.map(preprocessPattern))
-    case LiteralPattern(lit) => Pattern.Literal(lit.value, lit.tpe)
-    case MultiPattern(patterns) =>
+    case AnyPattern(id, _)  => Pattern.Any()
+    case IgnorePattern(_) => Pattern.Any()
+    case p @ TagPattern(id, patterns, _) => Pattern.Tag(p.definition, patterns.map(preprocessPattern))
+    case LiteralPattern(lit, _) => Pattern.Literal(lit.value, lit.tpe)
+    case MultiPattern(patterns, _) =>
       Context.panic("Multi-pattern should have been split in preprocess already / nested MultiPattern")
   }
   def preprocessGuard(g: source.MatchGuard)(using Context): Condition = g match {

--- a/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
@@ -98,9 +98,9 @@ object ExhaustivityChecker {
 
 
   def preprocess(roots: List[source.Term], cl: source.MatchClause)(using Context): Clause = (roots, cl) match {
-    case (List(root), source.MatchClause(pattern, guards, body)) =>
+    case (List(root), source.MatchClause(pattern, guards, body, _)) =>
       Clause.normalized(Condition.Patterns(Map(Trace.Root(root) -> preprocessPattern(pattern))) :: guards.map(preprocessGuard), cl)
-    case (roots, source.MatchClause(MultiPattern(patterns, _), guards, body)) =>
+    case (roots, source.MatchClause(MultiPattern(patterns, _), guards, body, _)) =>
       val rootConds: Map[Trace, Pattern] = (roots zip patterns).map { case (root, pattern) =>
         Trace.Root(root) -> preprocessPattern(pattern)
       }.toMap
@@ -116,9 +116,9 @@ object ExhaustivityChecker {
       Context.panic("Multi-pattern should have been split in preprocess already / nested MultiPattern")
   }
   def preprocessGuard(g: source.MatchGuard)(using Context): Condition = g match {
-    case MatchGuard.BooleanGuard(condition) =>
+    case MatchGuard.BooleanGuard(condition, _) =>
       Condition.Guard(condition)
-    case MatchGuard.PatternGuard(scrutinee, pattern) =>
+    case MatchGuard.PatternGuard(scrutinee, pattern, _) =>
       Condition.Patterns(Map(Trace.Root(scrutinee) -> preprocessPattern(pattern)))
   }
 

--- a/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
@@ -99,7 +99,7 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
   }
 
   override def stmt(using Context, WFContext) = {
-    case stmt @ source.DefStmt(tree @ source.VarDef(id, annot, rhs, doc, span), rest) =>
+    case stmt @ source.DefStmt(tree @ source.VarDef(id, annot, rhs, doc, span), rest, _) =>
       val capt = tree.symbol.capture
       binding(captures = Set(capt)) {
 

--- a/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
@@ -1,10 +1,10 @@
 package effekt
 package typer
 
-import effekt.context.{ Annotations, Context }
+import effekt.context.{Annotations, Context}
 import effekt.symbols.*
 import effekt.context.assertions.*
-import effekt.source.{ CallTarget, Def, ExprTarget, IdTarget, MatchGuard, MatchPattern, Tree }
+import effekt.source.{CallTarget, Def, ExprTarget, IdTarget, MatchGuard, MatchPattern, Span, Tree}
 import effekt.source.Tree.Visit
 import effekt.util.messages.ErrorReporter
 
@@ -164,8 +164,8 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
     case tree @ source.Match(scrutinees, clauses, default, _) => Context.at(tree) {
       // TODO copy annotations from default to synthesized defaultClause (in particular positions)
       val defaultPattern = scrutinees match {
-        case List(_) => source.IgnorePattern()
-        case scs => source.MultiPattern(List.fill(scs.length){source.IgnorePattern()})
+        case List(_) => source.IgnorePattern(Span.missing)
+        case scs => source.MultiPattern(List.fill(scs.length){source.IgnorePattern(Span.missing)}, Span.missing)
       }
 
       val defaultClause = default.toList.map(body => source.MatchClause(defaultPattern, Nil, body))
@@ -293,7 +293,7 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
   }
 
   def existentials(p: MatchPattern)(using Context): Set[TypeVar] = p match {
-    case p @ MatchPattern.TagPattern(id, patterns) =>
+    case p @ MatchPattern.TagPattern(id, patterns, _) =>
       Context.annotation(Annotations.TypeParameters, p).toSet ++ patterns.flatMap(existentials)
     case _ => Set.empty
   }

--- a/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
@@ -266,7 +266,7 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
   }
 
   override def query(op: source.OpClause)(using Context, WFContext): Unit = op match {
-    case tree @ source.OpClause(id, tps, vps, bps, ret, body, resume) =>
+    case tree @ source.OpClause(id, tps, vps, bps, ret, body, resume, _) =>
       val boundTypes = Context.annotation(Annotations.TypeParameters, op).toSet
       // bound capabilities are ONLY available on New(Implementation(OpClause ... )))
       // but not TryHandle(Implementation(OpClause) since their they are bound by the resumption

--- a/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/Wellformedness.scala
@@ -168,7 +168,7 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
         case scs => source.MultiPattern(List.fill(scs.length){source.IgnorePattern(Span.missing)}, Span.missing)
       }
 
-      val defaultClause = default.toList.map(body => source.MatchClause(defaultPattern, Nil, body))
+      val defaultClause = default.toList.map(body => source.MatchClause(defaultPattern, Nil, body, Span.missing))
       ExhaustivityChecker.checkExhaustive(scrutinees, clauses ++ defaultClause)
 
       scrutinees foreach { query }
@@ -252,7 +252,7 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
   }
 
   override def query(c: source.MatchClause)(using Context, WFContext): Unit = c match {
-    case source.MatchClause(pattern, guards, body) =>
+    case source.MatchClause(pattern, guards, body, _) =>
 
       var bound: Set[TypeVar] = existentials(pattern)
 
@@ -284,10 +284,10 @@ object Wellformedness extends Phase[Typechecked, Typechecked], Visit[WFContext] 
   }
 
   def queryGuardsExistentials(p: MatchGuard)(using Context, WFContext): Set[TypeVar] = p match {
-    case MatchGuard.BooleanGuard(condition) =>
+    case MatchGuard.BooleanGuard(condition, _) =>
       query(condition);
       Set.empty
-    case MatchGuard.PatternGuard(scrutinee, pattern) =>
+    case MatchGuard.PatternGuard(scrutinee, pattern, _) =>
       query(scrutinee);
       existentials(pattern)
   }

--- a/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
+++ b/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
@@ -103,7 +103,7 @@ trait DocumentationGenerator {
     arr(list.map(generate))
 
   def generateVparams(list: List[ValueParam])(using C: Context): DocValue = arr(list.map {
-    case ValueParam(id, tpe) =>
+    case ValueParam(id, tpe, span) =>
       obj(HashMap(
         "kind" -> str("ValueParam"),
         "id" -> generate(id),
@@ -112,7 +112,7 @@ trait DocumentationGenerator {
   })
 
   def generateBparams(list: List[BlockParam])(using C: Context): DocValue = arr(list.map {
-    case BlockParam(id, tpe) =>
+    case BlockParam(id, tpe, span) =>
       obj(HashMap(
         "kind" -> str("BlockParam"),
         "id" -> generate(id),

--- a/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
+++ b/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
@@ -50,8 +50,8 @@ trait DocumentationGenerator {
     ))
 
     // block params
-    case BlockTypeTree(eff) => ???
-    case FunctionType(tparams, vparams, bparams, result, effects) => obj(HashMap(
+    case BlockTypeTree(eff, _) => ???
+    case FunctionType(tparams, vparams, bparams, result, effects, span) => obj(HashMap(
       "kind" -> str("FunctionType"),
       "tparams" -> generateTparams(tparams.unspan),
       "vparams" -> arr(vparams.unspan.map(generate)),
@@ -64,14 +64,16 @@ trait DocumentationGenerator {
       )),
       "result" -> generate(result),
       "effects" -> generate(effects),
+      "span" -> generate(span),
     ))
 
     // value params
-    case ValueTypeTree(tpe) => ???
-    case BoxedType(tpe, capt) => obj(HashMap(
+    case ValueTypeTree(tpe, _) => ???
+    case BoxedType(tpe, capt, span) => obj(HashMap(
       "kind" -> str("BoxedType"),
       "tpe" -> generate(tpe),
       "capt" -> generate(capt),
+      "span" -> generate(span),
     ))
   }
 

--- a/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
+++ b/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
@@ -145,7 +145,7 @@ trait DocumentationGenerator {
   }
 
   def generate(module: Include): DocValue = module match {
-    case Include(path) => obj(HashMap(
+    case Include(path, span) => obj(HashMap(
       "kind" -> str("Include"),
       "path" -> str(path),
     ))

--- a/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
+++ b/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
@@ -108,6 +108,7 @@ trait DocumentationGenerator {
         "kind" -> str("ValueParam"),
         "id" -> generate(id),
         "tpe" -> tpe.map(generate).getOrElse(empty),
+        "span" -> generate(span),
       ))
   })
 
@@ -117,6 +118,7 @@ trait DocumentationGenerator {
         "kind" -> str("BlockParam"),
         "id" -> generate(id),
         "tpe" -> tpe.map(generate).getOrElse(empty),
+        "span" -> generate(span),
       ))
   })
 
@@ -148,6 +150,7 @@ trait DocumentationGenerator {
     case Include(path, span) => obj(HashMap(
       "kind" -> str("Include"),
       "path" -> str(path),
+      "span" -> generate(span),
     ))
   }
 

--- a/examples/neg/higher_rank_poly_vs_poly.check
+++ b/examples/neg/higher_rank_poly_vs_poly.check
@@ -1,3 +1,3 @@
-[error] examples/neg/higher_rank_poly_vs_poly.effekt:9:28: Type parameter count does not match [A](List[A]) => Int vs. List[Int] => Int
+[error] examples/neg/higher_rank_poly_vs_poly.effekt:9:30: Type parameter count does not match [A](List[A]) => Int vs. List[Int] => Int
 def main() = len([1, 2, 3]){ count }
-                           ^^^^^^^^^
+                             ^^^^^


### PR DESCRIPTION
Working towards completing the span transition, this PR adds the remaining spans to syntax tree nodes. In particular, this PR adds spans to:

* Feature flags
* `ExternBody`
* `Include`
* `Param`
* `Stmt`
* `Term`
* `Type`
* `MatchPattern`
* `Implementation`
* `Handler`
* `OpClause`

We still need to tear down the legacy `Positions` map and switch everything over to use the new spans. There are also still a few missing spans (`Span.missing`), but these should only affect places where it is non-trivial to add spans and where we also didn't have spans before.