### PR TITLE
Update scala version to 3.3.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val noPublishSettings = Seq(
 )
 
 lazy val commonSettings = Seq(
-  scalaVersion := "3.3.1",
+  scalaVersion := "3.3.6",
   semanticdbEnabled := true,
   scalacOptions ++= Seq(
     "-encoding", "utf8",

--- a/effekt/shared/src/main/scala/effekt/util/Source.scala
+++ b/effekt/shared/src/main/scala/effekt/util/Source.scala
@@ -33,7 +33,7 @@ case class MarkdownSource(source: Source) extends Source {
     // we map non-code lines to empty lines to preserve line numbers
     source.content.linesIterator.foreach { 
       case fenceLine(lang, ots) =>
-        val opts = if (ots != null) { ots.tail.split(":").toList } else { Nil }
+        val opts = if (ots != null) { ots.split(":").tail.toList } else { Nil }
         if (opts.contains("ignore")) {
           fenceType = Some(Ignore)
           lines += ""

--- a/effekt/shared/src/main/scala/effekt/util/TreeDocs.scala
+++ b/effekt/shared/src/main/scala/effekt/util/TreeDocs.scala
@@ -3,6 +3,7 @@ package util
 
 import scala.deriving.*
 import scala.compiletime.*
+import scala.annotation.nowarn
 
 
 // TODO we need to get rid of spurious pipes:
@@ -21,6 +22,7 @@ import scala.compiletime.*
 //      |
 trait Docs[A] { def show(indentation: String, depth: Int): String }
 
+@nowarn("msg=New anonymous class definition will be duplicated at each inline")
 object Docs {
 
   inline def summonAll[T <: Tuple]: List[Docs[_]] =


### PR DESCRIPTION
The current version of the Scala compiler (3.3.1) is no longer supported by Metals LSP. We should move to the latest LTS version.