### PR TITLE
Feature: UFCS on blocks

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -311,6 +311,14 @@ class RecursiveDescentTests extends munit.FunSuite {
     intercept[Throwable] { parseExpr("[,1]") }
   }
 
+  test("ufcs") {
+    parseExpr("{ l }.foo { x => x + 1}.bar { x => x * 2}")
+    parseExpr("{ 42 }.bar")
+    parseExpr("{ 42 }.bar()")
+    parseExpr("{ x => x }.foo(42)")
+    parseExpr("l.bar { fn }")
+  }
+
   test("Boxing") {
     parseExpr("box f")
     parseExpr("unbox f")

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -97,7 +97,11 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
       if (hasMethods) {
         MethodCall(rewriteAsBlock(receiver), id, targs, vargsTransformed, bargsTransformed)
       } else {
-        Call(IdTarget(id).inheritPosition(id), targs, rewriteAsExpr(receiver) :: vargsTransformed, bargsTransformed)
+        receiver match
+          case _: BlockLiteral =>
+            Call(IdTarget(id).inheritPosition(id), targs, vargsTransformed, rewriteAsBlock(receiver) :: bargsTransformed)
+          case _ => 
+            Call(IdTarget(id).inheritPosition(id), targs, rewriteAsExpr(receiver) :: vargsTransformed, bargsTransformed)
       }
 
     case TryHandle(prog, handlers) =>


### PR DESCRIPTION
This PR adds UFCS for blocks such that you can write `{ x => x + 42 }.foo { y => x * 2 }`, for example.