### PR TITLE
Only accept config under "effekt" key

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -506,7 +506,6 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
     // The former is sent by the VSCode extension for `initializationOptions`,
     // the latter by newer extension versions for `workspace/didChangeConfiguration`.
     val newSettings = params.getSettings.asInstanceOf[JsonElement].getAsJsonObject
-    this.settings = newSettings;
     if (newSettings == null) return
     val effektSection = newSettings.get("effekt")
     if (effektSection != null) {

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -379,7 +379,7 @@ class LSPTests extends FunSuite {
       server.getTextDocumentService().didOpen(didOpenParams)
 
       val configParams = new DidChangeConfigurationParams()
-      val settings: JsonElement = JsonParser.parseString("""{"showExplanations": true}""")
+      val settings: JsonElement = JsonParser.parseString("""{"effekt": {"showExplanations": true}}""")
       configParams.setSettings(settings)
       server.getWorkspaceService().didChangeConfiguration(configParams)
 
@@ -1139,7 +1139,7 @@ class LSPTests extends FunSuite {
         raw"""def main() = <>""".textDocument
       val textDoc = new TextDocumentItem("file://path/to/test.effekt", "effekt", 0, source.getText)
       val initializeParams = new InitializeParams()
-      val initializationOptions = """{"showIR": "source"}"""
+      val initializationOptions = """{"effekt": {"showIR": "source"}}"""
       initializeParams.setInitializationOptions(JsonParser.parseString(initializationOptions))
       server.initialize(initializeParams).get()
 
@@ -1210,7 +1210,7 @@ class LSPTests extends FunSuite {
              |"""
       val textDoc = new TextDocumentItem("file://path/to/test.effekt", "effekt", 0, source.stripMargin)
       val initializeParams = new InitializeParams()
-      val initializationOptions = """{"showIR": "source"}"""
+      val initializationOptions = """{"effekt": {"showIR": "source"}}"""
       initializeParams.setInitializationOptions(JsonParser.parseString(initializationOptions))
       server.initialize(initializeParams).get()
 
@@ -1266,7 +1266,7 @@ class LSPTests extends FunSuite {
              |def bar(x: String): Int = <{ <> }> // a hole within a hole
              |""".textDocument
       val initializeParams = new InitializeParams()
-      val initializationOptions = """{"showHoles": true}"""
+      val initializationOptions = """{"effekt": {"showHoles": true}}"""
       initializeParams.setInitializationOptions(JsonParser.parseString(initializationOptions))
       server.initialize(initializeParams).get()
 
@@ -1335,7 +1335,7 @@ class LSPTests extends FunSuite {
              |""".textDocument
 
       val initializeParams = new InitializeParams()
-      val initializationOptions = """{"showHoles": true}"""
+      val initializationOptions = """{"effekt": {"showHoles": true}}"""
       initializeParams.setInitializationOptions(JsonParser.parseString(initializationOptions))
       server.initialize(initializeParams).get()
 
@@ -1401,7 +1401,7 @@ class LSPTests extends FunSuite {
              |""".textDocument
 
       val initializeParams = new InitializeParams()
-      val initializationOptions = """{"showHoles": true}"""
+      val initializationOptions = """{"effekt": {"showHoles": true}}"""
       initializeParams.setInitializationOptions(JsonParser.parseString(initializationOptions))
       server.initialize(initializeParams).get()
 


### PR DESCRIPTION
Unifies the server side with https://github.com/effekt-lang/effekt-vscode/pull/91. I think we should wait with merging this at least until a new release of the VSCode extension has been made. We could also have a longer transition period, since there is urgency to stop accepting configuration not nested under an `"effekt"` key.