### PR TITLE
Change error message for missing closing } in interface declaration

### DIFF
--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -536,7 +536,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
         // InterfaceDef(`interface` ~> idDef(), maybeTypeParams(),
         //   `{` ~> manyWhile(documented { opDoc => `def` ~> operation(opDoc) }, documentedKind == `def`) <~ `}`, doc, span())
         InterfaceDef(`interface` ~> idDef(), maybeTypeParams(),
-          `{` ~> manyUntil(documented { opDoc => { `def` ~> operation(opDoc) } labelled "operation declaration" }, `}`) <~ `}`, doc, span())
+          `{` ~> manyUntil(documented { opDoc => { `def` ~> operation(opDoc) } labelled "} or another operation declaration" }, `}`) <~ `}`, doc, span())
       }
 
   def namespaceDef(): Def =

--- a/examples/neg/parsing/eof-instead-of-token.check
+++ b/examples/neg/parsing/eof-instead-of-token.check
@@ -1,3 +1,3 @@
-[error] examples/neg/parsing/eof-instead-of-token.effekt:1:16: Expected operation declaration but got end of file
+[error] examples/neg/parsing/eof-instead-of-token.effekt:1:16: Expected } or another operation declaration but got end of file
 interface Foo {
                ^

--- a/examples/neg/parsing/interface-missing-brace.check
+++ b/examples/neg/parsing/interface-missing-brace.check
@@ -1,0 +1,3 @@
+[error] examples/neg/parsing/interface-missing-brace.effekt:1:36: Expected } or another operation declaration but got end of file
+interface Greet { def hello(): Unit
+                                   ^

--- a/examples/neg/parsing/interface-missing-brace.effekt
+++ b/examples/neg/parsing/interface-missing-brace.effekt
@@ -1,0 +1,1 @@
+interface Greet { def hello(): Unit

--- a/examples/neg/parsing/val-in-interface.check
+++ b/examples/neg/parsing/val-in-interface.check
@@ -1,3 +1,3 @@
-[error] examples/neg/parsing/val-in-interface.effekt:2:3: Expected operation declaration but got keyword val
+[error] examples/neg/parsing/val-in-interface.effekt:2:3: Expected } or another operation declaration but got keyword val
   val x = 4
   ^^^


### PR DESCRIPTION
In #1008 the error message for
```
interface Foo { def greet(): Unit
```
changed from
```
expected }, got end of file
```
to
```
expected operation declaration, got end of file
```

This goes back to also mentioning the `}`.