### PR TITLE
Natural language holes

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1073,7 +1073,7 @@ class LSPTests extends FunSuite {
     withClientAndServer { (client, server) =>
       val (textDoc, range) =
         """
-             |def foo(x: Int): Int = <{ ${ x } }>
+             |def foo(x: Int): Int = <" ${ x } ">
              |                       ↑          ↑
              |""".textDocumentAndRange
 
@@ -1119,7 +1119,7 @@ class LSPTests extends FunSuite {
     withClientAndServer { (client, server) =>
       val (textDoc, range) =
            """
-             |def foo[T](x: T): Unit = <{ ${ println("1"); println("2") } }>
+             |def foo[T](x: T): Unit = <" ${ println("1"); println("2") } ">
              |                         ↑                                   ↑
              |""".textDocumentAndRange
 
@@ -1297,8 +1297,8 @@ class LSPTests extends FunSuite {
       val source =
            """
              |type MyInt = Int
-             |def foo(x: Int): Bool = <{ ${ x } }>
-             |def bar(x: String): Int = <{ ${ <> } }> // a hole within a hole
+             |def foo(x: Int): Bool = <" ${ x } ">
+             |def bar(x: String): Int = <" ${ <> } "> // a hole within a hole
              |""".textDocument
       val initializeParams = new InitializeParams()
       val initializationOptions = """{"effekt": {"showHoles": true}}"""

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -313,11 +313,7 @@ class LSPTests extends FunSuite {
                                 |def foo(x: Int): Bool = <{ x }>
                                 |                          ↑
                                 |""".textDocumentAndPosition
-      val hoverContents =
-        raw"""| | Outside       | Inside        |
-             | |:------------- |:------------- |
-             | | `Bool` | `Int` |
-             |""".stripMargin
+      val hoverContents = "Hole of type `Bool`"
 
       val didOpenParams = new DidOpenTextDocumentParams()
       didOpenParams.setTextDocument(textDoc)
@@ -341,11 +337,7 @@ class LSPTests extends FunSuite {
                                 |def foo(x: Int): Int / { raise } = <{ do raise(); 42 }>
                                 |                                     ↑
                                 |""".textDocumentAndPosition
-      val hoverContents =
-        raw"""| | Outside       | Inside        |
-             | |:------------- |:------------- |
-             | | `Int` | `Int` |
-             |""".stripMargin
+      val hoverContents = "Hole of type `Int`"
 
       val didOpenParams = new DidOpenTextDocumentParams()
       didOpenParams.setTextDocument(textDoc)
@@ -1080,9 +1072,9 @@ class LSPTests extends FunSuite {
   test("codeAction can close hole with an expression") {
     withClientAndServer { (client, server) =>
       val (textDoc, range) =
-        raw"""
-             |def foo(x: Int): Int = <{ x }>
-             |                       ↑     ↑
+        """
+             |def foo(x: Int): Int = <{ ${ x } }>
+             |                       ↑          ↑
              |""".textDocumentAndRange
 
       val didOpenParams = new DidOpenTextDocumentParams()
@@ -1126,9 +1118,9 @@ class LSPTests extends FunSuite {
   test("codeAction can close hole with statements") {
     withClientAndServer { (client, server) =>
       val (textDoc, range) =
-        raw"""
-             |def foo[T](x: T): Unit = <{ println("1"); println("2") }>
-             |                         ↑                              ↑
+           """
+             |def foo[T](x: T): Unit = <{ ${ println("1"); println("2") } }>
+             |                         ↑                                   ↑
              |""".textDocumentAndRange
 
       val didOpenParams = new DidOpenTextDocumentParams()
@@ -1225,24 +1217,7 @@ class LSPTests extends FunSuite {
              |              Synthesized()
              |            )
              |          ),
-             |          Return(
-             |            Literal(
-             |              (),
-             |              ValueTypeApp(Unit_whatever, Nil),
-             |              Span(
-             |                StringSource(def main() = <>, file://test.effekt),
-             |                13,
-             |                15,
-             |                Synthesized()
-             |              )
-             |            ),
-             |            Span(
-             |              StringSource(def main() = <>, file://test.effekt),
-             |              13,
-             |              15,
-             |              Synthesized()
-             |            )
-             |          ),
+             |          Template(Nil, Nil),
              |          Span(StringSource(def main() = <>, file://test.effekt), 13, 15, Real())
              |        ),
              |        Span(StringSource(def main() = <>, file://test.effekt), 13, 15, Real())
@@ -1320,10 +1295,10 @@ class LSPTests extends FunSuite {
   test("Server publishes list of holes in file") {
     withClientAndServer { (client, server) =>
       val source =
-        raw"""
+           """
              |type MyInt = Int
-             |def foo(x: Int): Bool = <{ x }>
-             |def bar(x: String): Int = <{ <> }> // a hole within a hole
+             |def foo(x: Int): Bool = <{ ${ x } }>
+             |def bar(x: String): Int = <{ ${ <> } }> // a hole within a hole
              |""".textDocument
       val initializeParams = new InitializeParams()
       val initializationOptions = """{"effekt": {"showHoles": true}}"""
@@ -1407,7 +1382,7 @@ class LSPTests extends FunSuite {
 
       val hole2 = receivedHoles.head.holes(2)
       assertEquals(hole2.id, "bar1")
-      assertEquals(hole2.innerType, Some("Unit"))
+      assertEquals(hole2.innerType, None)
       assertEquals(hole2.expectedType, None)
     }
   }

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -359,6 +359,14 @@ class RecursiveDescentTests extends munit.FunSuite {
     intercept[Throwable] { parseExpr("box { f }") }
   }
 
+  test("Holes") {
+    parseExpr("<>")
+    parseExpr("<{ natural language text }>")
+    parseExpr("<{ natural language text with { braces } }>")
+    parseExpr("<{ natural language text with terms like ${ 1 + 1 } inside }>")
+    parseExpr("<{ deeply ${ 1 + <{ nested stuff ${ 2 } }> + 3 } }>")
+  }
+
   test("Pattern matching") {
     parseExpr(
       """do raise(RuntimeError(), msg) match {}

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -366,6 +366,20 @@ class RecursiveDescentTests extends munit.FunSuite {
     parseExpr("<{ natural language text with terms like ${ 1 + 1 } inside }>")
     parseExpr("<{ deeply ${ 1 + <{ nested stuff ${ 2 } }> + 3 } }>")
     parseExpr("<{ you can use statements like ${ val foo = 42 } inside }>")
+
+    {
+      val (source, expectedSpan) =
+        """<{ let's check that the span is correct }>
+          |↑                                        ↑
+          |""".sourceAndSpan
+      val hole = parseExpr(source.content)
+      hole match {
+        case Term.Hole(_, _, span) =>
+          assertEquals(span, expectedSpan)
+        case other =>
+          throw new IllegalArgumentException(s"Expected Hole but got ${other.getClass.getSimpleName}")
+      }
+    }
   }
 
   test("Pattern matching") {

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -361,15 +361,15 @@ class RecursiveDescentTests extends munit.FunSuite {
 
   test("Holes") {
     parseExpr("<>")
-    parseExpr("<{ natural language text }>")
-    parseExpr("<{ natural language text with { braces } }>")
-    parseExpr("<{ natural language text with terms like ${ 1 + 1 } inside }>")
-    parseExpr("<{ deeply ${ 1 + <{ nested stuff ${ 2 } }> + 3 } }>")
-    parseExpr("<{ you can use statements like ${ val foo = 42 } inside }>")
+    parseExpr("<\" natural language text \">")
+    parseExpr("<\" natural language text with { braces } \">")
+    parseExpr("<\" natural language text with terms like ${ 1 + 1 } inside \">")
+    parseExpr("<\" deeply ${ 1 + <\" nested stuff ${ 2 } \"> + 3 } \">")
+    parseExpr("<\" you can use statements like ${ val foo = 42 } inside \">")
 
     {
       val (source, expectedSpan) =
-        """<{ let's check that the span is correct }>
+        """<" let's check that the span is correct ">
           |↑                                        ↑
           |""".sourceAndSpan
       val hole = parseExpr(source.content)

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -366,6 +366,8 @@ class RecursiveDescentTests extends munit.FunSuite {
     parseExpr("<\" natural language text with terms like ${ 1 + 1 } inside \">")
     parseExpr("<\" deeply ${ 1 + <\" nested stuff ${ 2 } \"> + 3 } \">")
     parseExpr("<\" you can use statements like ${ val foo = 42 } inside \">")
+    parseExpr("<\"\">")
+    parseExpr("<\" ${ x }\">")
 
     {
       val (source, expectedSpan) =

--- a/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/RecursiveDescentTests.scala
@@ -365,6 +365,7 @@ class RecursiveDescentTests extends munit.FunSuite {
     parseExpr("<{ natural language text with { braces } }>")
     parseExpr("<{ natural language text with terms like ${ 1 + 1 } inside }>")
     parseExpr("<{ deeply ${ 1 + <{ nested stuff ${ 2 } }> + 3 } }>")
+    parseExpr("<{ you can use statements like ${ val foo = 42 } inside }>")
   }
 
   test("Pattern matching") {

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -147,17 +147,16 @@ trait Intelligence {
 
   def getHoleInfo(hole: source.Hole)(using C: Context): Option[String] = for {
     (outerTpe, outerEff) <- C.inferredTypeAndEffectOption(hole)
-    (innerTpe, innerEff) <- C.inferredTypeAndEffectOption(hole.stmts)
-  } yield pp"""| | Outside       | Inside        |
-               | |:------------- |:------------- |
-               | | `${outerTpe}` | `${innerTpe}` |
-               |""".stripMargin
+  } yield pp"Hole of type `${outerTpe}`".stripMargin
 
   def getHoles(src: Source)(using C: Context): List[HoleInfo] = for {
     (hole, scope) <- C.annotationOption(Annotations.HolesForFile, src).getOrElse(Nil)
-    innerType = hole.innerType.map { t => pp"${t}" }
-    expectedType = hole.expectedType.map { t => pp"${t}" }
   } yield {
+    val innerType = hole.argTypes match {
+      case Some(t) :: Nil => Some(pp"${t}")
+      case _ => None
+    };
+    val expectedType = hole.expectedType.map { t => pp"${t}" }
     val scopeInfo = allBindings(scope)
     HoleInfo(
       hole.name.name,

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -493,7 +493,7 @@ class Lexer(source: Source) {
   }
 
   /** Matches a hole containing natural language text.
-   * Holes may contain unquotes, i.e., "${ do foo }" that include arbitrary expressions.
+   * Holes may contain unquotes, e.g., "${ do foo }" that include arbitrary expressions.
    * Unlike regular string literals, holes cannot contain escape sequences.
    * They do emit [[TokenKind.Str]] tokens with the `multiline` flag set to `true`.
    */
@@ -518,7 +518,7 @@ class Lexer(source: Source) {
           return TokenKind.HoleStr(stringContent.mkString)
         }
         case None =>
-          return err("Unterminated string.", start, start + offset)
+          return err("Unterminated hole.", start, start + offset)
         case Some(c) =>
           consume()
           stringContent.addOne(c)

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -288,7 +288,7 @@ class Lexer(source: Source) {
     }
 
   /** Main entry-point of the lexer. Whitespace is ignored and comments are collected.
-   * If an error is encountered, all successfully scanned tokens this far will returned,
+   * If an error is encountered, all successfully scanned tokens this far will be returned,
    * including the error.
    */
   def run(): Vector[Token] = {

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -30,6 +30,7 @@ enum TokenKind {
   case Integer(n: Long)
   case Float(d: Double)
   case Str(s: String, multiline: Boolean)
+  case HoleStr(s: String)
   case Chr(c: Int)
   // identifiers
   case Ident(id: String)
@@ -307,10 +308,11 @@ class Lexer(source: Source) {
               delimiters.pop() match {
                 case `${{` | `{{` =>  err(errMsg)
                 case strDelim: StrDelim => matchString(strDelim, true)
+                case `<{{` => matchHole(true)
               }
             // Last `}` is not be considered as part of string interpolation. Let the parser fail if braces don't match
             // and just continue lexing
-            case `{{` | `"` | `"""` | `'` => nextToken()
+            case `{{` | `"` | `"""` | `'` | `<{{` => nextToken()
           }
         } else nextToken()
       kind match {
@@ -399,6 +401,7 @@ class Lexer(source: Source) {
   case object `"""` extends StrDelim
   /** Delimiter for characters */
   case object `'` extends StrDelim
+  case object `<{{` extends Delimiter
 
   /** Matches a string literal -- both single- and multi-line strings.
    * Strings may contain space characters (e.g. \n, \t, \r), which are stored unescaped.
@@ -487,6 +490,42 @@ class Lexer(source: Source) {
     }
 
     TokenKind.Str(stringContent.mkString, delim.isMultiline)
+  }
+
+  /** Matches a hole containing natural language text.
+   * Holes may contain unquotes, i.e., "${ do foo }" that include arbitrary expressions.
+   * Unlike regular string literals, holes cannot contain escape sequences.
+   * They do emit [[TokenKind.Str]] tokens with the `multiline` flag set to `true`.
+   */
+  def matchHole(continued: Boolean = false): TokenKind = {
+    val delim = `<{{`
+    if (nextMatches("}>")) return TokenKind.Str("", true)
+    val offset = 2
+    val st = if (continued) start else start + offset
+    var endString = false
+    val stringContent = StringBuilder()
+
+    delimiters.push(delim)
+    while (!endString) {
+      peek() match {
+        case Some(c) if c == '}' && peekN(2).contains('>') => {
+          consume();
+          consume();
+          delimiters.pop()
+          endString = true
+        }
+        case Some('$') if peekN(2).contains('{') => {
+          return TokenKind.HoleStr(stringContent.mkString)
+        }
+        case None =>
+          return err("Unterminated string.", start, start + offset)
+        case Some(c) =>
+          consume()
+          stringContent.addOne(c)
+      }
+    }
+
+    TokenKind.HoleStr(stringContent.mkString)
   }
 
   /** Matches a character: '.+' */
@@ -596,7 +635,7 @@ class Lexer(source: Source) {
       case ':' => `:`
       case ';' => `;`
       case '@' => `@`
-      case '<' if nextMatches('{') => `<{`
+      case '<' if nextMatches('{') => matchHole()
       case '<' if nextMatches('>') => `<>`
       case '<' if nextMatches('=') => `<=`
       case '<' => `<`

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -297,7 +297,7 @@ class Lexer(source: Source) {
       val kind =
         // If the last token was `}` and we are currently inside unquotes, remember to directly continue
         // lexing a string
-        if (tokens.lastOption.map { _.kind }.contains(TokenKind.`}`) && !delimiters.isEmpty) {
+        if (tokens.lastOption.map { _.kind }.contains(TokenKind.`}`) && delimiters.nonEmpty) {
           delimiters.pop() match {
             case `${{` =>
               // there has to be a string delimiter on the stack since `${ }` may only appear in strings

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -499,7 +499,7 @@ class Lexer(source: Source) {
    */
   def matchHole(continued: Boolean = false): TokenKind = {
     val delim = `<""`
-    if (nextMatches("\">")) return TokenKind.Str("", true)
+    if (nextMatches("\">")) return TokenKind.HoleStr("")
     val offset = 2
     val st = if (continued) start else start + offset
     var endString = false

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -419,11 +419,13 @@ object Namer extends Phase[Parsed, NameResolved] {
 
     case source.Literal(value, tpe, _) => ()
 
-    case hole @ source.Hole(id, stmts, span) =>
+    case hole @ source.Hole(id, Template(strings, args), span) =>
       val h = Hole(Name.local(freshHoleId), hole)
       Context.addHole(h)
       Context.assignSymbol(id, h)
-      Context scoped { resolve(stmts) }
+      Context scoped {
+        args.foreach(resolve)
+      }
 
     case source.Unbox(term, _) => resolve(term)
 

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -1130,6 +1130,7 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
 
   def isHole: Boolean = peek.kind match {
     case `<>` => true
+    case `<{` => true
     case HoleStr(_) => true
     case _ => false
   }
@@ -1137,6 +1138,10 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
     nonterminal:
       peek.kind match {
         case `<>` => `<>` ~> Hole(IdDef("hole", span().synthesized), Template(Nil, Nil), span())
+        case `<{` => {
+          val s = `<{` ~> stmts() <~ `}>`
+          Hole(IdDef("hole", span().synthesized), Template(Nil, List(s)), span())
+        }
         case _: HoleStr => {
           val body = holeTemplate()
           Hole(IdDef("hole", span().synthesized), body, span())

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -1145,11 +1145,11 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
       }
     }
 
-  def holeTemplate(): Template[Term] =
+  def holeTemplate(): Template[Stmt] =
     nonterminal:
       val first = holeString()
-      val (exprs, strs) = manyWhile((`${` ~> expr() <~ `}`, holeString()), `${`).unzip
-      Template(first :: strs, exprs)
+      val (s, strs) = manyWhile((`${` ~> stmts() <~ `}`, holeString()), `${`).unzip
+      Template(first :: strs, s)
 
   def holeString(): String =
     nonterminal:

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -1128,17 +1128,34 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
         case Many(xs, _) => Call(IdTarget(IdRef(List("effekt"), s"Tuple${xs.size}", span().synthesized)), Nil, xs.toList, Nil, span().synthesized)
       }
 
-  def isHole: Boolean = peek(`<>`) || peek(`<{`)
+  def isHole: Boolean = peek.kind match {
+    case `<>` => true
+    case HoleStr(_) => true
+    case _ => false
+  }
   def hole(): Term = {
     nonterminal:
       peek.kind match {
         case `<>` => `<>` ~> Hole(IdDef("hole", span().synthesized), Return(UnitLit(span().synthesized), span().synthesized), span())
-        case `<{` =>
-          val s = `<{` ~> stmts() <~ `}>`
-          Hole(IdDef("hole", span().synthesized), s, span())
+        case _: HoleStr => {
+          holeTemplate()
+          Hole(IdDef("hole", span().synthesized), Return(UnitLit(span().synthesized), span().synthesized), span())
+        }
         case k => fail("hole", k)
       }
     }
+
+  def holeTemplate(): Template[Term] =
+    nonterminal:
+      val first = holeString()
+      val (exprs, strs) = manyWhile((`${` ~> expr() <~ `}`, holeString()), `${`).unzip
+      Template(first :: strs, exprs)
+
+  def holeString(): String =
+    nonterminal:
+      expect("natural language text") {
+        case HoleStr(s) => s
+      }
 
   def isLiteral: Boolean = peek.kind match {
     case _: (Integer | Float | Str | Chr) => true

--- a/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
+++ b/effekt/shared/src/main/scala/effekt/RecursiveDescent.scala
@@ -1136,10 +1136,10 @@ class RecursiveDescent(positions: Positions, tokens: Seq[Token], source: Source)
   def hole(): Term = {
     nonterminal:
       peek.kind match {
-        case `<>` => `<>` ~> Hole(IdDef("hole", span().synthesized), Return(UnitLit(span().synthesized), span().synthesized), span())
+        case `<>` => `<>` ~> Hole(IdDef("hole", span().synthesized), Template(Nil, Nil), span())
         case _: HoleStr => {
-          holeTemplate()
-          Hole(IdDef("hole", span().synthesized), Return(UnitLit(span().synthesized), span().synthesized), span())
+          val body = holeTemplate()
+          Hole(IdDef("hole", span().synthesized), body, span())
         }
         case k => fail("hole", k)
       }

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -327,12 +327,14 @@ object Typer extends Phase[NameResolved, Typechecked] {
         // we can unify with everything.
         Result(Context.join(tpes: _*), resEff)
 
-      case source.Hole(id, stmt, span) =>
-        val Result(tpe, effs) = checkStmt(stmt, None)
+      case source.Hole(id, Template(strings, args), span) =>
         val h = id.symbol.asHole
-
+        val tpes = args.map(stmt =>
+          val Result(tpe, effs) = checkStmt(stmt, None)
+          Some(tpe)
+        )
         h.expectedType = expected
-        h.innerType = Some(tpe)
+        h.argTypes = tpes
 
         Result(expected.getOrElse(TBottom), Pure)
 

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -465,7 +465,7 @@ enum Term extends Tree {
   case Assign(id: IdRef, expr: Term, span: Span) extends Term, Reference
 
   case Literal(value: Any, tpe: symbols.ValueType, span: Span)
-  case Hole(id: IdDef, stmts: Stmt, span: Span)
+  case Hole(id: IdDef, body: Template[Stmt], span: Span)
 
   // Boxing and unboxing to represent first-class values
   case Box(capt: Maybe[CaptureSet], block: Term, span: Span)

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -183,7 +183,7 @@ case class Lambda(vparams: List[ValueParam], bparams: List[BlockParam], decl: so
   def tparams = Nil
 }
 
-case class Hole(name: Name, decl: source.Hole, var expectedType: Option[ValueType] = None, var innerType: Option[ValueType] = None) extends ValueSymbol
+case class Hole(name: Name, decl: source.Hole, var expectedType: Option[ValueType] = None, var argTypes: List[Option[ValueType]] = Nil) extends ValueSymbol
 
 /**
  * Binders represent local value and variable binders

--- a/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/BoxUnboxInference.scala
@@ -106,8 +106,8 @@ object BoxUnboxInference extends Phase[NameResolved, NameResolved] {
     case Region(name, body, span) =>
       Region(name, rewrite(body), span)
 
-    case Hole(id, stmts, span) =>
-      Hole(id, rewrite(stmts), span)
+    case Hole(id, Template(strings, args), span) =>
+      Hole(id, Template(strings, args.map(rewrite)), span)
 
     case Box(c, b, span) =>
       Box(c, rewriteAsBlock(b), span)


### PR DESCRIPTION
Introduces holes that can contain arbitrary natural language text. The syntax is as follows:

```scala
def foo(x: Int): Int = <"
    Holes can splice in Effekt expressions:
    ${ x }
    or statements:
    ${ do bar(); println("hey") }
">
```

The "close hole" code action now only shows if there is a hole with a single splice (this could be improved in the future, but I consider it outside the scope of this PR).

Similarly, the extension currently expects to receive a single (optional) *inner type* for each hole. This PR only provides this if there is a single splice.

This PR preserves the existing behavior of `<>` and `<{ ... }>`.