### PR TITLE
Use different names for noopt tests

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/EffektTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/EffektTests.scala
@@ -107,7 +107,7 @@ trait EffektTests extends munit.FunSuite {
     foreachFileIn(dir) {
       case (f, None) => sys error s"Missing checkfile for ${f.getPath}"
       case (f, Some(expected)) =>
-        test(s"${f.getPath} (${backendName})") {
+        test(s"${f.getPath} (${backendName}-noopt)") {
           assertNoDiff(run(f, false), expected)
         }
     }


### PR DESCRIPTION
Closes #951 by using different names for tests without optimizations enabled.