### PR TITLE
Fix stdlib/network

### DIFF
--- a/examples/benchmarks/input_output/server_client.effekt
+++ b/examples/benchmarks/input_output/server_client.effekt
@@ -23,7 +23,7 @@ def main() = {
   val results = array::build(10) { i =>
     promise(box {
       with on[IOError].result
-      wait(100 * i)
+      wait(1000)
       val connection = connect("127.0.0.1", 8080)
       println("connected")
       var buffer = bytearray::allocate(4096)

--- a/examples/benchmarks/input_output/server_client.effekt
+++ b/examples/benchmarks/input_output/server_client.effekt
@@ -20,10 +20,10 @@ def main() = {
 
   println("started")
 
-  val results = array::build(2) { i =>
+  val results = array::build(10) { i =>
     promise(box {
       with on[IOError].result
-      wait(1000)
+      wait(100 * i)
       val connection = connect("127.0.0.1", 8080)
       println("connected")
       var buffer = bytearray::allocate(4096)

--- a/libraries/llvm/io.c
+++ b/libraries/llvm/io.c
@@ -216,11 +216,11 @@ void c_tcp_connect(String host, Int port, Stack stack) {
 
     struct sockaddr_in addr;
     result = uv_ip4_addr(host_str, port, &addr);
+    free(host_str);
 
     if (result < 0) {
         free(tcp_handle);
         free(connect_req);
-        free(host_str);
         resume_Int(stack, result);
         return;
     }
@@ -230,7 +230,6 @@ void c_tcp_connect(String host, Int port, Stack stack) {
     if (result < 0) {
         free(tcp_handle);
         free(connect_req);
-        free(host_str);
         resume_Int(stack, result);
         return;
     }

--- a/libraries/llvm/io.c
+++ b/libraries/llvm/io.c
@@ -243,6 +243,7 @@ typedef struct {
 } tcp_read_closure_t;
 
 void c_tcp_read_cb(uv_stream_t* stream, ssize_t bytes_read, const uv_buf_t* buf) {
+    (void)(buf);
     tcp_read_closure_t* read_closure = (tcp_read_closure_t*)stream->data;
     Stack stack = read_closure->stack;
 
@@ -253,6 +254,7 @@ void c_tcp_read_cb(uv_stream_t* stream, ssize_t bytes_read, const uv_buf_t* buf)
 }
 
 void c_tcp_read_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf) {
+    (void)(suggested_size);
     tcp_read_closure_t* read_closure = (tcp_read_closure_t*)handle->data;
     buf->base = read_closure->data;
     buf->len = read_closure->size;

--- a/libraries/llvm/io.c
+++ b/libraries/llvm/io.c
@@ -416,7 +416,7 @@ void c_tcp_accept(Int listener, struct Pos handler, Stack stack) {
     accept_closure->handler = handler;
     server->data = accept_closure;
 
-    int result = uv_listen(server, 0, c_tcp_accept_cb);
+    int result = uv_listen(server, SOMAXCONN, c_tcp_accept_cb);
     if (result < 0) {
         free(accept_closure);
         erasePositive(handler);

--- a/libraries/llvm/main.c
+++ b/libraries/llvm/main.c
@@ -37,6 +37,5 @@ int main(int argc, char *argv[]) {
     effektMain();
     uv_loop_t *loop = uv_default_loop();
     uv_run(loop, UV_RUN_DEFAULT);
-    uv_loop_close(loop);
-    return 0;
+    return uv_loop_close(loop);
 }


### PR DESCRIPTION
This fixes a memory leak and increases the backlog of uv_listen to SOMAXCONN, such that connections are put in a queue when the previous acceptor is not yet finished (this is the case with a timeout, which triggers the connects at the same time)

Another memory leak remains which I couldn't find.

```
==130847== 128 bytes in 1 blocks are definitely lost in loss record 1 of 1
==130847==    at 0x48577A8: malloc (vg_replace_malloc.c:446)
==130847==    by 0x4003F90: ??? (in server_client)
==130847==    by 0x4004499: ??? (in server_client)
==130847==    by 0x4004557: run (in server_client)
==130847==    by 0x4004A1C: spawn_4055 (in server_client)
==130847==    by 0x40044F6: resume_Int (in server_client)
==130847==    by 0x4002BA0: c_tcp_listen (io.c:367)
==130847==    by 0x4004B65: listen_4331 (in server_client)
==130847==    by 0x400CA5D: effektMain (in server_client)
==130847==    by 0x4003D60: main (main.c:37)
```