### PR TITLE
Do not hide errors for bad type annotation in 'val' definitions

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -102,6 +102,9 @@ class ParserTests extends munit.FunSuite {
   def parseMatchClause(input: String, positions: Positions = new Positions())(using munit.Location): MatchClause =
     parse(input, _.matchClause())
 
+  def parseValueTypeAnnotation(input: String, positions: Positions = new Positions())(using munit.Location): ValueType =
+    parse(input, _.valueTypeAnnotation())
+
   def parseReturnAnnotation(input: String, positions: Positions = new Positions())(using munit.Location): Effectful =
     parse(input, _.returnAnnotation())
 
@@ -643,6 +646,13 @@ class ParserTests extends munit.FunSuite {
     parseExpr("map(x) { map(x) { return 42 } }")
   }
 
+  test("Value type annotation") {
+    parseValueTypeAnnotation(": Int")
+    parseValueTypeAnnotation(": List[Int]")
+    parseValueTypeAnnotation(": Int => Int at {}")
+    parseValueTypeAnnotation(": String => List[Bool] at {p}")
+  }
+
   test("Return annotations") {
     parseReturnAnnotation(": Int")
     parseReturnAnnotation(": Int / Exc")
@@ -701,6 +711,7 @@ class ParserTests extends munit.FunSuite {
     parseValueType("List[Int]")
     parseValueType("list::List[Int]")
     parseValueType("list::List[effekt::Int]")
+    parseValueType("S => T at {p}")
   }
 
   test("Block types") {

--- a/examples/neg/parsing/val-bad-type-correct-pos.check
+++ b/examples/neg/parsing/val-bad-type-correct-pos.check
@@ -1,0 +1,3 @@
+[error] examples/neg/parsing/val-bad-type-correct-pos.effekt:1:8: Expected value type but got {
+val f: {This[Is(Not)A] match -ing type!} = <>
+       ^

--- a/examples/neg/parsing/val-bad-type-correct-pos.effekt
+++ b/examples/neg/parsing/val-bad-type-correct-pos.effekt
@@ -1,0 +1,2 @@
+val f: {This[Is(Not)A] match -ing type!} = <>
+def main() = ()

--- a/examples/neg/parsing/val-type-bad-capture.check
+++ b/examples/neg/parsing/val-type-bad-capture.check
@@ -1,0 +1,3 @@
+[error] examples/neg/parsing/val-type-bad-capture.effekt:7:20: Expected capture set but got identifier p
+  val f: S => T at p = try p() with State[S] {
+                   ^

--- a/examples/neg/parsing/val-type-bad-capture.effekt
+++ b/examples/neg/parsing/val-type-bad-capture.effekt
@@ -1,0 +1,14 @@
+interface State[S] {
+  def get(): S
+  def put(value: S): Unit
+}
+
+def state[S, T](init: S) { p: => T / State[S] }: T = {
+  val f: S => T at p = try p() with State[S] {
+    def get() = <> // box { (s: S) => (resume(s))(s) }
+    def put(v) = <>
+  }
+  f(init)
+}
+
+def main() = ()


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/63042c56-7d01-420c-bf11-59dc84f10d5e)

After:
<img alt="Screenshot 2025-07-07 at 13 50 16" src="https://github.com/user-attachments/assets/95d79b16-d0fa-4d5b-b2b4-5eed910eba4e" />
