### PR TITLE
Spanned holes: threading positions through holes

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/PatternMatchingTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/PatternMatchingTests.scala
@@ -47,7 +47,7 @@ class PatternMatchingTests extends CoreTests {
   }
 
   test("Sanity check: compiling empty list of clauses") {
-    assertEquals(compile(Nil), core.Hole())
+    assertEquals(compile(Nil), core.Hole(effekt.source.Span.missing))
   }
 
   test("Simple guard") {

--- a/effekt/shared/src/main/scala/effekt/core/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Parser.scala
@@ -347,7 +347,7 @@ class CoreParsers(positions: Positions, names: Names) extends EffektLexers(posit
       }
     | (`if` ~> `(` ~/> pure <~ `)`) ~ stmt ~ (`else` ~> stmt) ^^ Stmt.If.apply
     | `region` ~> blockLit ^^ Stmt.Region.apply
-    | `<>` ^^^ Hole()
+    | `<>` ^^^ Hole(effekt.source.Span.missing)
     | (pure <~ `match`) ~/ (`{` ~> many(clause) <~ `}`) ~ (`else` ~> stmt).? ^^ Stmt.Match.apply
     )
 

--- a/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PatternMatchingCompiler.scala
@@ -86,7 +86,7 @@ object PatternMatchingCompiler {
    */
   def compile(clauses: List[Clause]): core.Stmt = {
     // This shouldn't be reachable anymore since we specialize matching on void before calling compile
-    if (clauses.isEmpty) return core.Hole()
+    if (clauses.isEmpty) return core.Hole(effekt.source.Span.missing)
 
     // (0) normalize clauses
     val normalized @ (headClause :: remainingClauses) = clauses.map(normalize) : @unchecked

--- a/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PolymorphismBoxing.scala
@@ -267,7 +267,7 @@ object PolymorphismBoxing extends Phase[CoreTransformed, CoreTransformed] {
           val boxedResult = transformArg(originalResult)
           coerce(Stmt.Region(BlockLit(tparams, cparams, vparams, bparams, coerce(body, boxedResult))), originalResult)
       }
-    case Stmt.Hole() => Stmt.Hole()
+    case Stmt.Hole(span) => Stmt.Hole(span)
   }
 
   def transform(expr: Expr)(using Context, DeclarationContext): Bind[Expr] = expr match {

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -235,8 +235,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
       val d = default.map { body => space <> "else" <+> braces(nest(line <> toDocStmts(body))) }.getOrElse { emptyDoc }
       toDoc(sc) <+> "match" <+> cs <> d
 
-    case Hole() =>
-      "<>"
+    case Hole(span) =>
+      "<>" <+> s"// @ ${span.range.from.format}"
   }
 
   def toDoc(tpe: core.BlockType): Doc = tpe match {

--- a/effekt/shared/src/main/scala/effekt/core/Recursive.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Recursive.scala
@@ -83,7 +83,7 @@ class Recursive(
     case Stmt.Shift(prompt, body) => process(prompt); process(body)
     case Stmt.Resume(k, body) => process(k); process(body)
     case Stmt.Region(body) => process(body)
-    case Stmt.Hole() => ()
+    case Stmt.Hole(span) => ()
   }
 
   def process(e: Expr): Unit = e match {

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -470,7 +470,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       Context.bind(Region(BlockLit(Nil, List(region.capture), Nil, List(cap), transform(body))))
 
     case source.Hole(id, stmts, span) =>
-      Context.bind(core.Hole())
+      Context.bind(core.Hole(span))
 
     case a @ source.Assign(id, expr, _) =>
       val sym = a.definition

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -303,7 +303,7 @@ enum Stmt extends Tree {
   case Resume(k: BlockVar, body: Stmt)
 
   // Others
-  case Hole()
+  case Hole(span: effekt.source.Span)
 
   val tpe: ValueType = Type.inferType(this)
   val capt: Captures = Type.inferCapt(this)
@@ -637,7 +637,7 @@ object Variables {
     case Stmt.Reset(body) => free(body)
     case Stmt.Shift(prompt, body) => free(prompt) ++ free(body)
     case Stmt.Resume(k, body) => free(k) ++ free(body)
-    case Stmt.Hole() => Variables.empty
+    case Stmt.Hole(span) => Variables.empty
   }
 
   def bound(t: ValueParam): Variables = Variables.value(t.id, t.tpe)

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -225,7 +225,7 @@ object Type {
     }
     case Stmt.Region(body) => body.returnType
 
-    case Stmt.Hole() => TBottom
+    case Stmt.Hole(span) => TBottom
   }
 
   def inferCapt(stmt: Stmt): Captures = stmt match {
@@ -245,7 +245,7 @@ object Type {
     case Stmt.Shift(prompt, body) => prompt.capt ++ body.capt
     case Stmt.Resume(k, body) => k.capt ++ body.capt
     case Stmt.Region(body) => body.capt
-    case Stmt.Hole() => Set.empty
+    case Stmt.Hole(span) => Set.empty
   }
 
   def inferType(expr: Expr): ValueType = expr match {

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/BindSubexpressions.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/BindSubexpressions.scala
@@ -86,7 +86,7 @@ object BindSubexpressions {
     case Stmt.Reset(body) => Stmt.Reset(transform(body))
     case Stmt.Shift(prompt, body) => Stmt.Shift(transform(prompt), transform(body))
     case Stmt.Resume(k, body) => Stmt.Resume(transform(k), transform(body))
-    case Stmt.Hole() => Stmt.Hole()
+    case Stmt.Hole(span) => Stmt.Hole(span)
   }
 
   def transform(b: Block)(using Env): Bind[Block] = b match {

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/DirectStyle.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/DirectStyle.scala
@@ -28,7 +28,7 @@ object DirectStyle extends Tree.Rewrite {
 
   private def canBeDirect(s: Stmt): Boolean = s match {
     case Return(expr) => true
-    case Hole() => true
+    case Hole(_) => true
 
     // non-tail calls
     case App(_, _, _, _) => false
@@ -56,7 +56,7 @@ object DirectStyle extends Tree.Rewrite {
 
   private def toDirectStyle(stmt: Stmt, label: Block.BlockVar): Stmt = stmt match {
     case Return(expr) => App(label, Nil, List(expr), Nil)
-    case Hole() => stmt
+    case Hole(_) => stmt
 
     // non-tail calls
     case App(_, _, _, _) => stmt

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Normalizer.scala
@@ -326,7 +326,7 @@ object Normalizer { normal =>
     case Stmt.Var(ref, init, capture, body) => Stmt.Var(ref, normalize(init), capture, normalize(body))
     case Stmt.Get(id, tpe, ref, capt, body) => Stmt.Get(id, tpe, ref, capt, normalize(body))
     case Stmt.Put(ref, capt, value, body) => Stmt.Put(ref, capt, normalize(value), normalize(body))
-    case Stmt.Hole() => s
+    case Stmt.Hole(span) => s
   }
   def normalize(b: BlockLit)(using Context): BlockLit =
     b match {

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
@@ -98,7 +98,7 @@ class Reachable(
     case Stmt.Shift(prompt, body) => process(prompt); process(body)
     case Stmt.Resume(k, body) => process(k); process(body)
     case Stmt.Region(body) => process(body)
-    case Stmt.Hole() => ()
+    case Stmt.Hole(span) => ()
   }
 
   def process(e: Expr)(using defs: Definitions): Unit = e match {

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/RemoveTailResumptions.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/RemoveTailResumptions.scala
@@ -40,7 +40,7 @@ object RemoveTailResumptions {
       case Stmt.Reset(BlockLit(tparams, cparams, vparams, bparams, body)) => false
       case Stmt.Shift(prompt, body) => stmt.tpe == Type.TBottom
       case Stmt.Resume(k2, body) => k2.id == k // what if k is free in body?
-      case Stmt.Hole() => true
+      case Stmt.Hole(span) => true
     }
 
   def removeTailResumption(k: Id, stmt: Stmt): Stmt = stmt match {
@@ -60,7 +60,7 @@ object RemoveTailResumptions {
 
     case Stmt.Resume(k, body) => stmt
     case Stmt.Shift(prompt, body) => stmt
-    case Stmt.Hole() => stmt
+    case Stmt.Hole(span) => stmt
     case Stmt.Return(expr) => stmt
     case Stmt.App(callee, targs, vargs, bargs) => stmt
     case Stmt.Invoke(callee, method, methodTpe, targs, vargs, bargs) => stmt

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/StaticArguments.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/StaticArguments.scala
@@ -160,7 +160,7 @@ object StaticArguments {
     case Stmt.Var(ref, init, capture, body) => Stmt.Var(ref, rewrite(init), capture, rewrite(body))
     case Stmt.Get(id, tpe, ref, capt, body) => Stmt.Get(id, tpe, ref, capt, rewrite(body))
     case Stmt.Put(ref, capt, value, body) => Stmt.Put(ref, capt, rewrite(value), rewrite(body))
-    case Stmt.Hole() => Stmt.Hole()
+    case Stmt.Hole(span) => Stmt.Hole(span)
   }
   def rewrite(b: BlockLit)(using StaticArgumentsContext): BlockLit =
     b match {

--- a/effekt/shared/src/main/scala/effekt/core/vm/VM.scala
+++ b/effekt/shared/src/main/scala/effekt/core/vm/VM.scala
@@ -104,7 +104,7 @@ enum VMError extends Throwable {
   case MissingBuiltin(name: String)
   case RuntimeTypeError(msg: String)
   case NonExhaustive(missingCase: Id)
-  case Hole()
+  case Hole(span: effekt.source.Span)
   case NoMain()
 
   override def getMessage: String = this match {
@@ -113,7 +113,7 @@ enum VMError extends Throwable {
     case VMError.MissingBuiltin(name) => s"Missing builtin: ${name}"
     case VMError.RuntimeTypeError(msg) => s"Runtime type error: ${msg}"
     case VMError.NonExhaustive(missingCase) => s"Non exhaustive: ${missingCase}"
-    case VMError.Hole() => s"Reached hole"
+    case VMError.Hole(span) => s"Reached hole @ ${span.range.from.format}"
     case VMError.NoMain() => s"No main"
   }
 }
@@ -436,7 +436,7 @@ class Interpreter(instrumentation: Instrumentation, runtime: Runtime) {
           }
           State.Step(body, env, rewind(cont, stack), heap)
 
-        case Stmt.Hole() => throw VMError.Hole()
+        case Stmt.Hole(span) => throw VMError.Hole(span)
       }
     }
 

--- a/effekt/shared/src/main/scala/effekt/cps/Contify.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Contify.scala
@@ -152,7 +152,7 @@ object Contify {
     case Stmt.Resume(r, body, ks, k) =>
       Stmt.Resume(r, rewrite(body), ks, rewrite(k))
 
-    case Stmt.Hole() => Stmt.Hole()
+    case Stmt.Hole(span) => Stmt.Hole(span)
   }
 
   def rewrite(clause: Clause): Clause = clause match {
@@ -223,7 +223,7 @@ object Contify {
       returnsTo(id, body) ++ returnsTo(id, k)
     case Stmt.Jump(_, vargs, _) =>
       all(vargs, returnsTo(id, _))
-    case Stmt.Hole() => Set.empty
+    case Stmt.Hole(_) => Set.empty
   }
 
   def returnsTo(id: Id, b: Block): Set[Cont] = b match {

--- a/effekt/shared/src/main/scala/effekt/cps/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/PrettyPrinter.scala
@@ -150,8 +150,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Stmt.Resume(r, body, ks, k) =>
       "resume" <> parens(toDoc(r)) <+> toDoc(body) <+> "@" <+> toDoc(ks) <> "," <+> toDoc(k)
 
-    case Stmt.Hole() =>
-      "<>"
+    case Stmt.Hole(span) =>
+      "<>" <+> s"// @ ${span.range.from.format}"
   }
 
   def toDoc(clause: Clause): Doc = clause match {

--- a/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
@@ -129,7 +129,7 @@ object Transformer {
       Resume(cont.id, Block.BlockLit(Nil, Nil, ks2, k2, transform(body, ks2, Continuation.Dynamic(k2))),
         MetaCont(ks), k.reifyAt(stmt.tpe))
 
-    case core.Stmt.Hole() => Hole()
+    case core.Stmt.Hole(span) => Hole(span)
 
     case core.Stmt.Region(core.Block.BlockLit(_, _, _, List(region), body)) =>
       cps.Region(region.id, MetaCont(ks),

--- a/effekt/shared/src/main/scala/effekt/cps/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Tree.scala
@@ -133,7 +133,7 @@ enum Stmt extends Tree {
   case Resume(resumption: Id, body: BlockLit, ks: MetaCont, k: Cont)
 
   // Others
-  case Hole()
+  case Hole(span: effekt.source.Span)
 }
 export Stmt.*
 
@@ -213,7 +213,7 @@ object Variables {
     case Stmt.Reset(prog, ks, k) => free(prog) ++ free(ks) ++ free(k)
     case Stmt.Shift(prompt, body, ks, k) => block(prompt) ++ free(body) ++ free(ks) ++ free(k)
     case Stmt.Resume(r, body, ks, k) => block(r) ++ free(body) ++ free(ks) ++ free(k)
-    case Stmt.Hole() => empty
+    case Stmt.Hole(span) => empty
   }
 
   def free(cl: (Id, Clause)): Variables = cl match {

--- a/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
@@ -90,7 +90,7 @@ trait Transformer {
       }
       chez.Cond(cls, default.map(toChezExpr))
 
-    case Hole() => chez.Builtin("hole")
+    case Hole(span) => chez.Call(chez.Builtin("hole"), chez.ChezString(span.range.from.format))
 
     case Var(ref, init, capt, body) =>
       state(nameDef(ref), toChez(init), toChez(body))

--- a/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
@@ -90,7 +90,7 @@ trait Transformer {
       }
       chez.Cond(cls, default.map(toChezExpr))
 
-    case Hole(span) => chez.Call(chez.Builtin("hole"), chez.ChezString(span.range.from.format))
+    case Hole(span) => chez.Builtin("hole", chez.ChezString(span.range.from.format))
 
     case Var(ref, init, capt, body) =>
       state(nameDef(ref), toChez(init), toChez(body))

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -400,8 +400,8 @@ object TransformerCps extends Transformer {
     case cps.Stmt.Resume(r, b, ks2, k2) =>
       pure(js.Return(js.Call(RESUME, nameRef(r), toJS(b)(using nonrecursive(b)), toJS(ks2), requiringThunk { toJS(k2) })) :: Nil)
 
-    case cps.Stmt.Hole() =>
-      pure(js.Return($effekt.call("hole")) :: Nil)
+    case cps.Stmt.Hole(span) =>
+      pure(js.Return($effekt.call("hole", JsString(span.range.from.format))) :: Nil)
   }
 
   def toJS(scrutinee: js.Expr, variant: Id, clause: cps.Clause)(using C: TransformerContext): (js.Expr, Binding[List[js.Stmt]]) =
@@ -526,7 +526,7 @@ object TransformerCps extends Transformer {
       case Stmt.Reset(prog, ks, k) => notIn(stmt)
       case Stmt.Shift(prompt, body, ks, k) => notIn(stmt)
       case Stmt.Resume(resumption, body, ks, k) => notIn(stmt)
-      case Stmt.Hole() => true
+      case Stmt.Hole(span) => true
     }
 
 

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -391,11 +391,17 @@ object Transformer {
         }
         transform(rest)
 
-      case machine.Statement.Hole(span) => // TODO: call `hole` with `posfmt`
-        val posfmt = span.range.from.format
-        emit(Comment("Hole"))
-        emit(Call("_", Ccc(), VoidType(), ConstantGlobal("hole"), List.empty))
-        RetVoid()
+     case machine.Statement.Hole(span) =>
+       val posfmt = span.range.from.format
+       emit(Comment(s"Hole @ $posfmt"))
+
+       // Reused from LiteralUTF8String
+       val utf8 = (posfmt + "\u0000").getBytes("UTF-8") // null-terminated
+       val litName = freshName("hole_pos")
+       emit(GlobalConstant(s"$litName.lit", ConstantArray(IntegerType8(), utf8.map { b => ConstantInteger8(b) }.toList)))
+
+       emit(Call("_", Ccc(), VoidType(), ConstantGlobal("hole"), List(ConstantGlobal(s"$litName.lit"))))
+       RetVoid()
     }
 
   def transform(label: machine.Label): ConstantGlobal =

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -391,7 +391,8 @@ object Transformer {
         }
         transform(rest)
 
-      case machine.Statement.Hole =>
+      case machine.Statement.Hole(span) => // TODO: call `hole` with `posfmt`
+        val posfmt = span.range.from.format
         emit(Comment("Hole"))
         emit(Call("_", Ccc(), VoidType(), ConstantGlobal("hole"), List.empty))
         RetVoid()

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -53,5 +53,5 @@ def freeVariables(statement: Statement): Set[Variable] =
       arguments.toSet ++ (freeVariables(rest) - name)
     case Coerce(name, value, rest) =>
       Set(value) ++ (freeVariables(rest) - name)
-    case Hole => Set.empty
+    case Hole(_) => Set.empty
   }

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -110,7 +110,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Coerce(name, value, rest) =>
       "let" <+> name <+> ":" <+> toDoc(name.tpe) <+> "=" <+> "coerce" <+> value <+> ":" <+> toDoc(value.tpe) <> ";" <> line <> toDocStmts(rest)
 
-    case Hole => "<>"
+    case Hole(span) => "<>" <+> s"// @ ${span.range.from.format}"
   }
 
   def nested(content: Doc): Doc = group(nest(line <> content))

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -308,7 +308,7 @@ object Transformer {
           StoreVar(reference, value, transform(body))
         }
 
-      case core.Hole() => machine.Statement.Hole
+      case core.Hole(span) => machine.Statement.Hole(span)
 
       case _ =>
         ErrorReporter.abort(s"Unsupported statement: $stmt")

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -211,7 +211,7 @@ enum Statement {
   /**
    * Statement that is executed when a Hole is encountered.
    */
-  case Hole
+  case Hole(span: effekt.source.Span)
 }
 export Statement.*
 

--- a/libraries/chez/common/effekt_primitives.ss
+++ b/libraries/chez/common/effekt_primitives.ss
@@ -134,4 +134,4 @@
   (raise
     (condition
       (make-error)
-      (make-message-condition (string-append "not implemented " pos)))))
+      (make-message-condition (string-append pos " not implemented yet" )))))

--- a/libraries/chez/common/effekt_primitives.ss
+++ b/libraries/chez/common/effekt_primitives.ss
@@ -130,8 +130,8 @@
     (run warmup)
     (run iterations)))
 
-(define (hole)
+(define (hole pos)
   (raise
     (condition
       (make-error)
-      (make-message-condition "not implemented"))))
+      (make-message-condition (string-append "not implemented " pos)))))

--- a/libraries/js/effekt_builtins.js
+++ b/libraries/js/effekt_builtins.js
@@ -58,4 +58,4 @@ $effekt.unit = { __unit: true }
 
 $effekt.emptyMatch = function() { throw "empty match" }
 
-$effekt.hole = function(pos) { throw "not implemented, yet @ " + pos }
+$effekt.hole = function(pos) { throw pos + " not implemented yet" }

--- a/libraries/js/effekt_builtins.js
+++ b/libraries/js/effekt_builtins.js
@@ -58,4 +58,4 @@ $effekt.unit = { __unit: true }
 
 $effekt.emptyMatch = function() { throw "empty match" }
 
-$effekt.hole = function() { throw "not implemented, yet" }
+$effekt.hole = function(pos) { throw "not implemented, yet @ " + pos }

--- a/libraries/llvm/forward-declare-c.ll
+++ b/libraries/llvm/forward-declare-c.ll
@@ -6,7 +6,7 @@ declare %Pos @c_get_arg(i64)
 declare void @c_io_println(%Pos)
 declare %Pos @c_io_readln()
 
-declare void @hole()
+declare void @hole(i8*)
 declare void @duplicated_prompt()
 
 declare %Pos @c_ref_fresh(%Pos)

--- a/libraries/llvm/panic.c
+++ b/libraries/llvm/panic.c
@@ -7,8 +7,8 @@
 // this should _morally_ be using `stderr`, but we don't tee it in tests
 // see PR #823 & issue #815 for context
 
-void hole() {
-    printf("PANIC: Reached a hole in the program\n");
+void hole(const char* message) {
+    printf("PANIC: Reached a hole in the program at %s\n", message);
     exit(1);
 }
 

--- a/libraries/llvm/panic.c
+++ b/libraries/llvm/panic.c
@@ -8,7 +8,7 @@
 // see PR #823 & issue #815 for context
 
 void hole(const char* message) {
-    printf("PANIC: %s reached a hole in the program\n", message);
+    printf("PANIC: %s not implemented yet\n", message);
     exit(1);
 }
 

--- a/libraries/llvm/panic.c
+++ b/libraries/llvm/panic.c
@@ -8,7 +8,7 @@
 // see PR #823 & issue #815 for context
 
 void hole(const char* message) {
-    printf("PANIC: Reached a hole in the program at %s\n", message);
+    printf("PANIC: %s reached a hole in the program\n", message);
     exit(1);
 }
 


### PR DESCRIPTION
Every hole is now internally associated with a span which is printed when the hole is encountered:
```sh
$ for BACKEND in chez-callcc llvm js; do effekt hole.effekt --backend $BACKEND; done
```

```log
# Chez
Exception: hole.effekt:8:15: not implemented yet
[error] Process exited with non-zero exit code 255.

# LLVM
PANIC: hole.effekt:8:15: not implemented yet
[error] Process exited with non-zero exit code 1.

# JS
.../out/hole.js:208
    else throw e
         ^
hole.effekt:8:15: not implemented yet
(Use `node --trace-uncaught ...` to show where the exception was thrown)

Node.js v22.16.0
[error] Process exited with non-zero exit code 1.
```