### PR TITLE
Add back hack for DeclPrinter

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1938,6 +1938,24 @@ class LSPTests extends FunSuite {
     }
   }
 
+  test("Server does not crash on file with type variables") {
+    withClientAndServer { (client, server) =>
+      val source =
+        raw"""def foo[T]() = <>
+             |""".textDocument
+
+      val initializeParams = new InitializeParams()
+      val initializationOptions = """{"effekt": {"showHoles": true}}"""
+      initializeParams.setInitializationOptions(JsonParser.parseString(initializationOptions))
+      server.initialize(initializeParams).get()
+      val didOpenParams = new DidOpenTextDocumentParams()
+      didOpenParams.setTextDocument(source)
+      server.getTextDocumentService().didOpen(didOpenParams)
+      val receivedHoles = client.receivedHoles()
+      assertEquals(receivedHoles.length, 1)
+    }
+  }
+
   // Text document DSL
   //
   //

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -197,10 +197,11 @@ trait Intelligence {
       })
     }
 
-    sorted.map((name, path, sym) => sym match {
-      case sym: TypeSymbol => TypeBinding(path, name, origin, DeclPrinter(sym))
-      case sym: ValueSymbol => TermBinding(path, name, origin, C.valueTypeOption(sym).map(t => pp"${t}"))
-      case sym: BlockSymbol => TermBinding(path, name, origin, C.blockTypeOption(sym).map(t => pp"${t}"))
+    sorted.flatMap((name, path, sym) => sym match {
+      // TODO this is extremely hacky, printing is not defined for all types at the moment
+      case sym: TypeSymbol => try { Some(TypeBinding(path, name, origin, DeclPrinter(sym))) } catch { case e => None }
+      case sym: ValueSymbol => Some(TermBinding(path, name, origin, C.valueTypeOption(sym).map(t => pp"${t}")))
+      case sym: BlockSymbol => Some(TermBinding(path, name, origin, C.blockTypeOption(sym).map(t => pp"${t}")))
     }).toList
 
   def allSymbols(origin: String, bindings: Bindings, path: List[String] = Nil)(using C: Context): Array[(String, List[String], TypeSymbol | TermSymbol)] = {


### PR DESCRIPTION
In a previous PR, we decided to remove this workaround because we thought it was likely no longer necessary. It turns out it is necessary, because `DeclPrinter` contains a partial pattern match, leading to a `MatchError` when an unexpected symbol is encountered.
Pending a proper fix, this adds back the hack.