### PR TITLE
Continuation statements to omit braces

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -94,7 +94,7 @@ class ParserTests extends munit.FunSuite {
     parse(input, _.stmt())
 
   def parseStmts(input: String, positions: Positions = new Positions())(using munit.Location): Stmt =
-    parse(input, _.stmts())
+    parse(input, _.stmts(inBraces = true))
 
   def parseMatchPattern(input: String, positions: Positions = new Positions())(using munit.Location): MatchPattern =
     parse(input, _.matchPattern())

--- a/examples/neg/no_continuation_defs.effekt
+++ b/examples/neg/no_continuation_defs.effekt
@@ -1,0 +1,2 @@
+def foo() =
+  def bar() = 42 // ERROR enclosed in braces

--- a/examples/pos/confusing_statements.check
+++ b/examples/pos/confusing_statements.check
@@ -1,0 +1,3 @@
+doing something
+doing something
+doing something

--- a/examples/pos/confusing_statements.effekt
+++ b/examples/pos/confusing_statements.effekt
@@ -1,0 +1,13 @@
+def compute(): Unit = println("doing something")
+
+/// Prints "doing something" three times, since
+/// the second `compute()` is NOT part of `bar`.
+/// The language is NOT indentation senstive!
+def main() = {
+  def bar() =
+    compute(); // <--- this is part of bar!
+    compute()  // <--- this is part of main, not bar!
+
+  bar();
+  bar()
+}

--- a/examples/pos/multistatement.check
+++ b/examples/pos/multistatement.check
@@ -1,0 +1,5 @@
+Open files
+Open port 8080
+Running!
+Close port
+Close files

--- a/examples/pos/multistatement.effekt
+++ b/examples/pos/multistatement.effekt
@@ -1,0 +1,17 @@
+def filesystem { p: => Unit }: Unit = {
+  println("Open files")
+  p()
+  println("Close files")
+}
+def network(port: Int) { p: => Unit }: Unit = {
+  println("Open port " ++ port.show)
+  p()
+  println("Close port")
+}
+def readInt(): Int = 8080
+
+def main() =
+  with filesystem;
+  val port = readInt();
+  with network(port);
+  println("Running!")

--- a/examples/pos/parser.effekt
+++ b/examples/pos/parser.effekt
@@ -39,7 +39,7 @@ def parens(): Int / { flip, next, fail } =
 // Int = Result
 def reader[R](s: Stream) { p : => R / next } : R / fail =
   var inn = s;
-  try p() with next { () =>
+  try p() with next {
     inn match {
       case Nil() =>
         do fail("Unexpected Nil")
@@ -52,36 +52,34 @@ def reader[R](s: Stream) { p : => R / next } : R / fail =
 def eager[R] { p: => R / { flip, fail, error } }: ParseResult[R] = try {
   Success(p())
 } with flip { () =>
-    resume(true) match {
-        case Failure(msg) => resume(false)
-        case Success(res) => Success(res)
-        case ParseError(msg) => ParseError(msg)
-    }
+  resume(true) match {
+    case Failure(msg) => resume(false)
+    case Success(res) => Success(res)
+    case ParseError(msg) => ParseError(msg)
+  }
 } with fail { (msg) =>
-    Failure(msg)
+  Failure(msg)
 } with error { (msg) =>
-    ParseError(msg)
+  ParseError(msg)
 }
 
 def commit[R] { p : => R / fail } : R / error =
-  try { p() } with fail { (msg) =>
+  try p() with fail { (msg) =>
     do error(msg)
   }
 
 def nocut[R] { p: => R / error } : R / fail =
-  try { p() } with error { (msg) =>
-     do fail(msg)
+  try p() with error { (msg) =>
+    do fail(msg)
   }
 
 def opt[R] { p: => R }: Option[R] / flip =
-   or { Some(p()) } { None() }
+  or { Some(p()) } { None() }
 
 def parse[R](s: Stream) { p : => R / { flip, next, fail, error } } =
-  eager {
-    reader(s) {
-      p()
-    }
-  }
+  with eager
+  with reader(s)
+  p()
 
 def ex() =
   or {

--- a/examples/pos/parser.effekt
+++ b/examples/pos/parser.effekt
@@ -21,17 +21,13 @@ type ParseResult[R] {
   ParseError(msg: String)
 }
 
-def accept(exp: String) = {
-    val got = do next();
-    if (got == exp) {
-        got
-    } else {
-        do fail("Expected " ++ exp ++ " but got " ++ got)
-    }
-}
+def accept(exp: String) =
+  val got = do next();
+  if (got == exp) got
+  else do fail("Expected " ++ exp ++ " but got " ++ got)
 
 def or[R] { p: => R } { q: => R } =
-  if (do flip()) { p() } else { q() }
+  if (do flip()) p() else q()
 
 def asOrB(): Int / { flip, next, fail } =
   or { accept("a"); asOrB() + 1 } { accept("b"); 0 }
@@ -41,19 +37,17 @@ def parens(): Int / { flip, next, fail } =
      { accept("("); val res = parens(); accept(")"); res + 1 }
 
 // Int = Result
-def reader[R](s: Stream) { p : => R / next } : R / fail = {
-    var inn = s;
-    try{
-      p()
-    } with next { () => inn match {
-        case Nil() =>
-          do fail("Unexpected Nil")
-        case Cons(el, rest) =>
-          inn = rest;
-          resume(el)
-      }
+def reader[R](s: Stream) { p : => R / next } : R / fail =
+  var inn = s;
+  try p() with next { () =>
+    inn match {
+      case Nil() =>
+        do fail("Unexpected Nil")
+      case Cons(el, rest) =>
+        inn = rest;
+        resume(el)
     }
-}
+  }
 
 def eager[R] { p: => R / { flip, fail, error } }: ParseResult[R] = try {
   Success(p())
@@ -99,34 +93,30 @@ def ex() =
     1
   }
 
-def p1() = {
+def p1() =
   val inn = ["a", "a", "a", "b"];
   parse(inn) { asOrB() } match {
     case Success(n) => println(n)
     case Failure(msg) => ()
     case ParseError(msg) => ()
   }
-}
 
-def p2() = {
+
+def p2() =
   val inn = ["do", "foo"];
   parse(inn) { ex() } match {
     case Success(n) => println(n)
     case Failure(msg) => ()
     case ParseError(msg) => ()
   }
-}
 
-def p4() = {
+def p4() =
   val inn = ["(", "(", "()", ")", ")"];
   parse(inn) { parens() } match {
     case Success(n) => println(n)
     case Failure(msg) => ()
     case ParseError(msg) => ()
   }
-}
-
-
 
 def main() = {
     p1();


### PR DESCRIPTION
This allows us to use multiple statements in a single statement position without braces.

Current rules:

- no definitions allowed, when no braces are used(`def`) -- could potentially be relaxed
- no sequencing of expressions (`expr; expr`) outside of braces

It should be fully backwards compatible for code that parsed before.
It accepts more programs and also changes the error message for one failing test case.

Here is how it looks like (also see the added test)

```
def main() =
  with filesystem;
  val port = readInt();
  with network(port);
  println("Running!")
```