### PR TITLE
Visibility Modifiers

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Repl.scala
+++ b/effekt/jvm/src/main/scala/effekt/Repl.scala
@@ -315,7 +315,7 @@ class Repl(driver: Driver) extends REPL[Tree, EffektConfig, EffektError] {
       val fullSpan = Span(source, 0, source.content.length, origin = Origin.Synthesized)
       ModuleDecl("interactive", includes,
         definitions :+ FunDef(IdDef("main", fakeSpan), Many.empty(fakeSpan), Many.empty(fakeSpan), Many.empty(fakeSpan), Maybe.None(fakeSpan),
-          body, None, fullSpan), None, fullSpan)
+          body, Info.empty(fakeSpan), fullSpan), None, fullSpan)
     }
 
     def makeEval(source: Source, expr: Term): ModuleDecl = {

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -48,14 +48,14 @@ class LSPTests extends FunSuite {
   def withClientAndServer(testBlock: (MockLanguageClient, Server) => Unit): Unit = {
     withClientAndServer(true)(testBlock)
   }
-  
+
   /** Normalize the output of the IR by replacing the generated identifiers and stripping all whitespace
    */
   def normalizeIRString(ir: String): String = {
     ir.replaceAll("_\\d+", "_whatever")
       .replaceAll("\\s+", "")
   }
-  
+
   def assertIREquals(ir: String, expected: String): Unit = {
     val normalizedIR = normalizeIRString(ir)
     val normalizedExpected = normalizeIRString(expected)
@@ -1222,7 +1222,18 @@ class LSPTests extends FunSuite {
              |        ),
              |        Span(StringSource(def main() = <>, file://test.effekt), 13, 15, Real())
              |      ),
-             |      None(),
+             |      Info(
+             |        None(),
+             |        Maybe(
+             |          None(),
+             |          Span(StringSource(def main() = <>, file://test.effekt), 0, 0, Real())
+             |        ),
+             |        Maybe(
+             |          None(),
+             |          Span(StringSource(def main() = <>, file://test.effekt), 0, 0, Real())
+             |        ),
+             |        None()
+             |      ),
              |      Span(StringSource(def main() = <>, file://test.effekt), 0, 15, Real())
              |    )
              |  ),
@@ -1410,7 +1421,7 @@ class LSPTests extends FunSuite {
       assertEquals(receivedHoles.head.holes.length, 1)
     }
   }
-  
+
   test("Server publishes hole id for nested defs") {
     withClientAndServer { (client, server) =>
       val source =

--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -142,7 +142,7 @@ class ParserTests extends munit.FunSuite {
     parse(input, _.program())
 
   def parseExternDef(input: String, positions: Positions = new Positions())(using munit.Location): Def =
-    parse(input, _.externDef(None))
+    parse(input, _.externDef())
 
   def parseInfo(input: String, positions: Positions = new Positions())(using munit.Location): Info =
     parse(input, _.info())

--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -145,7 +145,7 @@ class ParserTests extends munit.FunSuite {
     parse(input, _.externDef())
 
   def parseInfo(input: String, positions: Positions = new Positions())(using munit.Location): Info =
-    parse(input, _.info())
+    parse(input, _.info(parseCaptures = true))
 
   // Custom asserts
   //
@@ -1000,7 +1000,8 @@ class ParserTests extends munit.FunSuite {
           IdDef("foo", Span(source, pos(0), pos(1))),
           None,
           Var(IdRef(Nil, "f", Span(source, pos(2), pos(3))), Span(source, pos(2), pos(3))),
-          None, Span(source, 0, pos.last)))
+          Info.empty(Span(source, 0, 0)),
+          Span(source, 0, pos.last)))
     }
 
     parseDefinition(
@@ -1080,6 +1081,17 @@ class ParserTests extends munit.FunSuite {
     }
     assertEquals(funDef.bparams.span, Span(source, pos(0), pos(1)))
     assertEquals(funDef.ret.span, Span(source, pos(1), pos(1)))
+  }
+
+  test("Function definition with comment") {
+    val (source, pos) =
+      raw"""/// Calculate the answer to the ultimate question of life, the universe, and everything
+           |def calculate() = 42
+           |""".sourceAndPositions
+
+    val definition = parseDefinition(source.content)
+
+    assertEquals(definition.doc, Some(" Calculate the answer to the ultimate question of life, the universe, and everything"))
   }
 
   test("Function definition with whitespaces instead of return type") {

--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -142,7 +142,7 @@ class ParserTests extends munit.FunSuite {
     parse(input, _.program())
 
   def parseExternDef(input: String, positions: Positions = new Positions())(using munit.Location): Def =
-    parse(input, _.externDef())
+    parse(input, _.externDef(None))
 
   // Custom asserts
   //

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -125,6 +125,7 @@ trait Intelligence {
         p.productElementNames.zip(p.productIterator)
           .collectFirst {
             case ("doc", Some(s: String)) => s
+            case ("info", source.Info(Some(s: String), _, _, _)) => s
           }
       case _ => None
   }

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -130,11 +130,7 @@ enum TokenKind {
   case `fun`
   case `match`
   case `def`
-  case `module`
-  case `import`
-  case `export`
   case `extern`
-  case `include`
   case `record`
   case `box`
   case `unbox`
@@ -146,6 +142,12 @@ enum TokenKind {
   case `is`
   case `namespace`
   case `pure`
+
+  case `module`
+  case `import`
+  case `export`
+  case `include`
+  case `private`
 }
 
 object TokenKind {
@@ -178,7 +180,7 @@ object TokenKind {
     `let`, `true`, `false`, `val`, `var`, `if`, `else`, `while`, `type`, `effect`, `interface`,
     `try`, `with`, `case`, `do`, `fun`, `match`, `def`, `module`, `import`, `export`, `extern`,
     `include`, `record`, `box`, `unbox`, `return`, `region`, `resource`, `new`, `and`, `is`,
-    `namespace`, `pure`
+    `namespace`, `pure`, `private`
   )
 
   val keywordMap: immutable.HashMap[String, TokenKind] =

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -357,7 +357,14 @@ class Parser(positions: Positions, tokens: Seq[Token], source: Source) {
        spaces()
        shebang()
        spaces()
-       val (name, doc) = moduleDecl()
+       val (name, doc) = documentedKind match {
+         case `module` =>
+           val doc = maybeDocumentation()
+           consume(`module`)
+           (moduleName(), doc)
+         case _ => (defaultModulePath, None)
+       }
+
        val res = ModuleDecl(name, manyWhile(includeDecl(), `import`), toplevelDefs(), doc, span())
 
        if (!peek(`EOF`)) {
@@ -374,15 +381,6 @@ class Parser(positions: Positions, tokens: Seq[Token], source: Source) {
     peek.kind match {
       case Shebang(_) => consume(peek.kind); shebang()
       case _ => ()
-    }
-
-  def moduleDecl(): Tuple2[String, Doc] =
-    documentedKind match {
-      case `module` =>
-        val doc = maybeDocumentation()
-        consume(`module`)
-        (moduleName(), doc)
-      case _ => (defaultModulePath, None)
     }
 
   // we are purposefully not using File here since the parser needs to work both

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -359,8 +359,7 @@ class Parser(positions: Positions, tokens: Seq[Token], source: Source) {
       spaces()
 
       // potential documentation for the file / module
-      documented: doc =>
-
+      documented { doc =>
         val (name, moduleDoc, unusedDoc) = peek.kind match {
           case `module` =>
             consume(`module`)
@@ -388,6 +387,7 @@ class Parser(positions: Positions, tokens: Seq[Token], source: Source) {
         }
 
         ModuleDecl(name, imports, definitions, moduleDoc, span())
+      }
 
   @tailrec
   private def shebang(): Unit =

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -629,9 +629,11 @@ class Parser(positions: Positions, tokens: Seq[Token], source: Source) {
       case `interface` => externInterface(info)
       case `resource`  => externResource(info)
       case `include`   => externInclude(info)
+      case `def`       => externFun(info)
       // extern """..."""
       case s: Str      => externString(info)
-      case `def`       => externFun(info)
+      // extern js """..."""
+      case t if info.externCapture.nonEmpty => fail(s"Expected string literal but got ${explain(t)}")
       case _           => fail("Expected an extern definition")
     }
 

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -441,7 +441,7 @@ class Parser(positions: Positions, tokens: Seq[Token], source: Source) {
               List(NamespaceDef(id, defs, doc, span()))
           }
         case _ =>
-          if (isToplevel) toplevelDef(doc) :: toplevelDefs()
+          if (isToplevel) nonterminal { toplevelDef(doc) } :: toplevelDefs()
           else Nil
       }
 

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -113,6 +113,29 @@ case class Comment() extends Tree {
 type Doc = Option[String]
 
 /**
+ * The meta-data of a definition / declaration, consisting of everything up
+ * until, but not including the introducing keyword (such as `def`, or `interface`).
+ * For example:
+ *
+ *     /// documentation
+ *     private
+ *     extern
+ *     pure
+ *     def
+ */
+case class Info(
+  doc: Doc,
+  // we use Maybe[Unit] instead of Boolean to have position info for validation errors
+  isPrivate: Maybe[Unit],
+  isExtern: Maybe[Unit],
+  // TODO this should be moved from the Info to extern functions, once we changed the syntax
+  externCapture: Option[CaptureSet]
+)
+object Info {
+  def empty(span: Span) = Info(None, Maybe.None(span), Maybe.None(span), None)
+}
+
+/**
  * The origin of the span
  *
  * Possible values:
@@ -212,7 +235,6 @@ object ExternBody {
     override def featureFlag: FeatureFlag = FeatureFlag.Default(Span.missing)
   }
 }
-
 
 /**
  * We distinguish between identifiers corresponding to

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -130,7 +130,11 @@ case class Info(
   isExtern: Maybe[Unit],
   // TODO this should be moved from the Info to extern functions, once we changed the syntax
   externCapture: Option[CaptureSet]
-)
+) {
+  def isEmpty = doc.isEmpty && isPrivate.isEmpty && isExtern.isEmpty && externCapture.isEmpty
+  def nonEmpty = !isEmpty
+}
+
 object Info {
   def empty(span: Span) = Info(None, Maybe.None(span), Maybe.None(span), None)
 }
@@ -347,7 +351,7 @@ case class Maybe[+T](unspan: Option[T], span: Span) {
       case None => alternative
     }
 
-  export unspan.{foreach, get, getOrElse, isEmpty}
+  export unspan.{foreach, get, getOrElse, isEmpty, nonEmpty}
 }
 
 object Maybe {
@@ -394,40 +398,40 @@ export SpannedOps._
  */
 enum Def extends Definition {
 
-  case FunDef(id: IdDef, tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], ret: Maybe[Effectful], body: Stmt, doc: Doc, span: Span)
-  case ValDef(id: IdDef, annot: Option[ValueType], binding: Stmt, doc: Doc, span: Span)
-  case RegDef(id: IdDef, annot: Option[ValueType], region: IdRef, binding: Stmt, doc: Doc, span: Span)
-  case VarDef(id: IdDef, annot: Option[ValueType], binding: Stmt, doc: Doc, span: Span)
-  case DefDef(id: IdDef, annot: Option[BlockType], block: Term, doc: Doc, span: Span)
+  case FunDef(id: IdDef, tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], ret: Maybe[Effectful], body: Stmt, info: Info, span: Span)
+  case ValDef(id: IdDef, annot: Option[ValueType], binding: Stmt, _doc: Doc, span: Span)
+  case RegDef(id: IdDef, annot: Option[ValueType], region: IdRef, binding: Stmt, _doc: Doc, span: Span)
+  case VarDef(id: IdDef, annot: Option[ValueType], binding: Stmt, _doc: Doc, span: Span)
+  case DefDef(id: IdDef, annot: Option[BlockType], block: Term, _doc: Doc, span: Span)
 
-  case NamespaceDef(id: IdDef, definitions: List[Def], doc: Doc, span: Span)
+  case NamespaceDef(id: IdDef, definitions: List[Def], _doc: Doc, span: Span)
 
-  case InterfaceDef(id: IdDef, tparams: Many[Id], ops: List[Operation], doc: Doc, span: Span)
-  case DataDef(id: IdDef, tparams: Many[Id], ctors: List[Constructor], doc: Doc, span: Span)
-  case RecordDef(id: IdDef, tparams: Many[Id], fields: Many[ValueParam], doc: Doc, span: Span)
+  case InterfaceDef(id: IdDef, tparams: Many[Id], ops: List[Operation], _doc: Doc, span: Span)
+  case DataDef(id: IdDef, tparams: Many[Id], ctors: List[Constructor], _doc: Doc, span: Span)
+  case RecordDef(id: IdDef, tparams: Many[Id], fields: Many[ValueParam], _doc: Doc, span: Span)
 
   /**
    * Type aliases like `type Matrix[T] = List[List[T]]`
    */
-  case TypeDef(id: IdDef, tparams: List[Id], tpe: ValueType, doc: Doc, span: Span)
+  case TypeDef(id: IdDef, tparams: List[Id], tpe: ValueType, _doc: Doc, span: Span)
 
   /**
    * Effect aliases like `effect Set = { Get, Put }`
    */
-  case EffectDef(id: IdDef, tparams: List[Id], effs: Effects, doc: Doc, span: Span)
+  case EffectDef(id: IdDef, tparams: List[Id], effs: Effects, _doc: Doc, span: Span)
 
   /**
    * Only valid on the toplevel!
    */
-  case ExternType(id: IdDef, tparams: Many[Id], doc: Doc, span: Span)
+  case ExternType(id: IdDef, tparams: Many[Id], _doc: Doc, span: Span)
 
   case ExternDef(capture: CaptureSet, id: IdDef,
                  tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], ret: Effectful,
-                 bodies: List[ExternBody], doc: Doc, span: Span) extends Def
+                 bodies: List[ExternBody], info: Info, span: Span) extends Def
 
-  case ExternResource(id: IdDef, tpe: BlockType, doc: Doc, span: Span)
+  case ExternResource(id: IdDef, tpe: BlockType, _doc: Doc, span: Span)
 
-  case ExternInterface(id: IdDef, tparams: List[Id], doc: Doc, span: Span)
+  case ExternInterface(id: IdDef, tparams: List[Id], _doc: Doc, span: Span)
 
   /**
    * Namer resolves the path and loads the contents in field [[contents]]
@@ -435,9 +439,9 @@ enum Def extends Definition {
    * @note Storing content and id as user-visible fields is a workaround for the limitation that Enum's cannot
    *   have case specific refinements.
    */
-  case ExternInclude(featureFlag: FeatureFlag, path: String, var contents: Option[String] = None, val id: IdDef, doc: Doc, span: Span)
+  case ExternInclude(featureFlag: FeatureFlag, path: String, var contents: Option[String] = None, val id: IdDef, _doc: Doc, span: Span)
 
-  def doc: Doc
+  def doc: Doc = ???
 }
 object Def {
   type Extern = ExternType | ExternDef | ExternResource | ExternInterface | ExternInclude

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -399,39 +399,39 @@ export SpannedOps._
 enum Def extends Definition {
 
   case FunDef(id: IdDef, tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], ret: Maybe[Effectful], body: Stmt, info: Info, span: Span)
-  case ValDef(id: IdDef, annot: Option[ValueType], binding: Stmt, _doc: Doc, span: Span)
-  case RegDef(id: IdDef, annot: Option[ValueType], region: IdRef, binding: Stmt, _doc: Doc, span: Span)
-  case VarDef(id: IdDef, annot: Option[ValueType], binding: Stmt, _doc: Doc, span: Span)
-  case DefDef(id: IdDef, annot: Option[BlockType], block: Term, _doc: Doc, span: Span)
+  case ValDef(id: IdDef, annot: Option[ValueType], binding: Stmt, info: Info, span: Span)
+  case RegDef(id: IdDef, annot: Option[ValueType], region: IdRef, binding: Stmt, info: Info, span: Span)
+  case VarDef(id: IdDef, annot: Option[ValueType], binding: Stmt, info: Info, span: Span)
+  case DefDef(id: IdDef, annot: Option[BlockType], block: Term, info: Info, span: Span)
 
-  case NamespaceDef(id: IdDef, definitions: List[Def], _doc: Doc, span: Span)
+  case NamespaceDef(id: IdDef, definitions: List[Def], info: Info, span: Span)
 
-  case InterfaceDef(id: IdDef, tparams: Many[Id], ops: List[Operation], _doc: Doc, span: Span)
-  case DataDef(id: IdDef, tparams: Many[Id], ctors: List[Constructor], _doc: Doc, span: Span)
-  case RecordDef(id: IdDef, tparams: Many[Id], fields: Many[ValueParam], _doc: Doc, span: Span)
+  case InterfaceDef(id: IdDef, tparams: Many[Id], ops: List[Operation], info: Info, span: Span)
+  case DataDef(id: IdDef, tparams: Many[Id], ctors: List[Constructor], info: Info, span: Span)
+  case RecordDef(id: IdDef, tparams: Many[Id], fields: Many[ValueParam], info: Info, span: Span)
 
   /**
    * Type aliases like `type Matrix[T] = List[List[T]]`
    */
-  case TypeDef(id: IdDef, tparams: List[Id], tpe: ValueType, _doc: Doc, span: Span)
+  case TypeDef(id: IdDef, tparams: List[Id], tpe: ValueType, info: Info, span: Span)
 
   /**
    * Effect aliases like `effect Set = { Get, Put }`
    */
-  case EffectDef(id: IdDef, tparams: List[Id], effs: Effects, _doc: Doc, span: Span)
+  case EffectDef(id: IdDef, tparams: List[Id], effs: Effects, info: Info, span: Span)
 
   /**
    * Only valid on the toplevel!
    */
-  case ExternType(id: IdDef, tparams: Many[Id], _doc: Doc, span: Span)
+  case ExternType(id: IdDef, tparams: Many[Id], info: Info, span: Span)
 
   case ExternDef(capture: CaptureSet, id: IdDef,
                  tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], ret: Effectful,
                  bodies: List[ExternBody], info: Info, span: Span) extends Def
 
-  case ExternResource(id: IdDef, tpe: BlockType, _doc: Doc, span: Span)
+  case ExternResource(id: IdDef, tpe: BlockType, info: Info, span: Span)
 
-  case ExternInterface(id: IdDef, tparams: List[Id], _doc: Doc, span: Span)
+  case ExternInterface(id: IdDef, tparams: List[Id], info: Info, span: Span)
 
   /**
    * Namer resolves the path and loads the contents in field [[contents]]
@@ -439,9 +439,10 @@ enum Def extends Definition {
    * @note Storing content and id as user-visible fields is a workaround for the limitation that Enum's cannot
    *   have case specific refinements.
    */
-  case ExternInclude(featureFlag: FeatureFlag, path: String, var contents: Option[String] = None, val id: IdDef, _doc: Doc, span: Span)
+  case ExternInclude(featureFlag: FeatureFlag, path: String, var contents: Option[String] = None, val id: IdDef, info: Info, span: Span)
 
-  def doc: Doc = ???
+  def info: Info
+  def doc: Doc = info.doc
 }
 object Def {
   type Extern = ExternType | ExternDef | ExternResource | ExternInterface | ExternInclude

--- a/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
+++ b/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
@@ -157,14 +157,14 @@ trait DocumentationGenerator {
   }
 
   def generate(definition: Def)(using C: Context): DocValue = definition match {
-    case Def.FunDef(id, tparams, vparams, bparams, ret, body, doc, span) => obj(HashMap(
+    case Def.FunDef(id, tparams, vparams, bparams, ret, body, info, span) => obj(HashMap(
       "kind" -> str("FunDef"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams.unspan),
       "vparams" -> generateVparams(vparams.unspan),
       "bparams" -> generateBparams(bparams.unspan),
       "ret" -> ret.map(generate).getOrElse(empty),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
@@ -262,14 +262,14 @@ trait DocumentationGenerator {
       "span" -> generate(span),
     ))
 
-    case Def.ExternDef(capture, id, tparams, vparams, bparams, ret, bodies, doc, span) => obj(HashMap(
+    case Def.ExternDef(capture, id, tparams, vparams, bparams, ret, bodies, info, span) => obj(HashMap(
       "kind" -> str("ExternDef"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams.unspan),
       "vparams" -> generateVparams(vparams.unspan),
       "bparams" -> generateBparams(bparams.unspan),
       "ret" -> generate(ret),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 

--- a/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
+++ b/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
@@ -168,97 +168,97 @@ trait DocumentationGenerator {
       "span" -> generate(span),
     ))
 
-    case Def.ValDef(id, annot, binding, doc, span) => obj(HashMap(
+    case Def.ValDef(id, annot, binding, info, span) => obj(HashMap(
       "kind" -> str("ValDef"),
       "id" -> generate(id),
       "annot" -> annot.map(generate).getOrElse(empty),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.RegDef(id, annot, region, binding, doc, span) => obj(HashMap(
+    case Def.RegDef(id, annot, region, binding, info, span) => obj(HashMap(
       "kind" -> str("RegDef"),
       "id" -> generate(id),
       "annot" -> annot.map(generate).getOrElse(empty),
       "region" -> generate(region),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.VarDef(id, annot, binding, doc, span) => obj(HashMap(
+    case Def.VarDef(id, annot, binding, info, span) => obj(HashMap(
       "kind" -> str("VarDef"),
       "id" -> generate(id),
       "annot" -> annot.map(generate).getOrElse(empty),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.DefDef(id, annot, block, doc, span) => obj(HashMap(
+    case Def.DefDef(id, annot, block, info, span) => obj(HashMap(
       "kind" -> str("DefDef"),
       "id" -> generate(id),
       "annot" -> annot.map(generate).getOrElse(empty),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.NamespaceDef(id, definitions, doc, span) => obj(HashMap(
+    case Def.NamespaceDef(id, definitions, info, span) => obj(HashMap(
       "kind" -> str("NamespaceDef"),
       "id" -> generate(id),
       "definitions" -> arr(definitions.map(generate)),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.InterfaceDef(id, tparams, ops, doc, span) => obj(HashMap(
+    case Def.InterfaceDef(id, tparams, ops, info, span) => obj(HashMap(
       "kind" -> str("InterfaceDef"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams.unspan),
       "ops" -> arr(ops.map(generate)),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.DataDef(id, tparams, ctors, doc, span) => obj(HashMap(
+    case Def.DataDef(id, tparams, ctors, info, span) => obj(HashMap(
       "kind" -> str("DataDef"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams.unspan),
       "ctors" -> arr(ctors.map(generate)),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.RecordDef(id, tparams, fields, doc, span) => obj(HashMap(
+    case Def.RecordDef(id, tparams, fields, info, span) => obj(HashMap(
       "kind" -> str("RecordDef"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams.unspan),
       "vparams" -> generateVparams(fields.unspan),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.TypeDef(id, tparams, tpe, doc, span) => obj(HashMap(
+    case Def.TypeDef(id, tparams, tpe, info, span) => obj(HashMap(
       "kind" -> str("TypeDef"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams),
       "tpe" -> generate(tpe),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.EffectDef(id, tparams, effs, doc, span) => obj(HashMap(
+    case Def.EffectDef(id, tparams, effs, info, span) => obj(HashMap(
       "kind" -> str("EffectDef"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams),
       "effs" -> generate(effs),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.ExternType(id, tparams, doc, span) => obj(HashMap(
+    case Def.ExternType(id, tparams, info, span) => obj(HashMap(
       "kind" -> str("ExternType"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams.unspan),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
@@ -273,28 +273,28 @@ trait DocumentationGenerator {
       "span" -> generate(span),
     ))
 
-    case Def.ExternResource(id, tpe, doc, span) => obj(HashMap(
+    case Def.ExternResource(id, tpe, info, span) => obj(HashMap(
       "kind" -> str("ExternResource"),
       "id" -> generate(id),
       "tpe" -> generate(tpe),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.ExternInterface(id, tparams, doc, span) => obj(HashMap(
+    case Def.ExternInterface(id, tparams, info, span) => obj(HashMap(
       "kind" -> str("ExternInterface"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
 
-    case Def.ExternInclude(featureFlag, path, contents, id, doc, span) => obj(HashMap(
+    case Def.ExternInclude(featureFlag, path, contents, id, info, span) => obj(HashMap(
       "kind" -> str("ExternInclude"),
       "featureFlag" -> str(featureFlag.toString),
       "path" -> str(path),
       "id" -> generate(id),
-      "doc" -> generate(doc),
+      "doc" -> generate(info.doc),
       "span" -> generate(span),
     ))
   }


### PR DESCRIPTION
This PR reorganizes parsing of modifiers on declaraionts, which are now grouped in `Info`. It also adds one new modifier `private`, which is parsed, but then ignored.