### PR TITLE
Hide document symbols without spans

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -5,7 +5,7 @@ import effekt.Intelligence.CaptureInfo
 import effekt.context.Context
 import effekt.source.Def.FunDef
 import effekt.source.Term.Hole
-import effekt.source.{Span, Tree}
+import effekt.source.{Origin, Span, Tree}
 import effekt.symbols.Binder.{ValBinder, VarBinder}
 import effekt.symbols.BlockTypeConstructor.{ExternInterface, Interface}
 import effekt.symbols.TypeConstructor.{DataType, ExternType}
@@ -289,10 +289,10 @@ class Server(config: EffektConfig, compileOnChange: Boolean=false) extends Langu
       decl <- getSourceTreeFor(sym)
       kind <- getSymbolKind(sym)
       detail <- getInfoOf(sym)(using context)
+      if decl.span.origin != Origin.Missing
       declRange = convertRange(decl.span.range)
       idRange = convertRange(id.span.range)
     } yield new DocumentSymbol(sym.name.name, kind, declRange, idRange, detail.header)
-
     val result = Collections.seqToJavaList(
       documentSymbols.map(sym => messages.Either.forRight[SymbolInformation, DocumentSymbol](sym))
     )

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -625,14 +625,8 @@ class LSPTests extends FunSuite {
 
       val params = new DocumentSymbolParams()
       params.setTextDocument(textDoc.versionedTextDocumentIdentifier)
-
-      val documentSymbols = server.getTextDocumentService().documentSymbol(params).get()
-      // FIXME: The server currently returns spurious symbols at position (0, 0) that we need to filter out.
-      val filtered = server.getTextDocumentService().documentSymbol(params).get().asScala.filter {
-        symbol => symbol.getRight.getRange.getStart != new Position(0, 0) && symbol.getRight.getRange.getEnd != new Position(0, 0)
-      }.asJava
-
-      assertEquals(filtered, expectedSymbols.asJava)
+      val actualSymbols = server.getTextDocumentService().documentSymbol(params).get()
+      assertEquals(actualSymbols, expectedSymbols.asJava)
     }
   }
 


### PR DESCRIPTION
During `ExplicitCapabilities`, we asssign some symbols for the explicitly passed capabilities (as additional block params).
It might be interesting to add spans to them in the future and maybe even show them as (optional) inlay hints for educational purposes. However, in this PR, I just hide them from the list of document symbols for now, which has previously been cluttered by them.

Resolves #895.
Depends on #1097.
