### PR TITLE
Include definition location in LSP hole bindings 

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -625,17 +625,23 @@ case class EffektPublishHolesParams(uri: String, holes: List[EffektHoleInfo])
 case class EffektHoleInfo(
   id: String,
   range: LSPRange,
+  uri: String,
   innerType: Option[String],
   expectedType: Option[String],
   scope: Intelligence.ScopeInfo,
   body: List[Intelligence.HoleItem],
- )
+)
 
 object EffektHoleInfo {
   def fromHoleInfo(info: Intelligence.HoleInfo): EffektHoleInfo = {
+    val uri = info.span.origin match {
+      case Origin.File(name) => Convert.toURI(name)
+      case _ => ""
+    }
     EffektHoleInfo(
       info.id,
       convertRange(info.span.range),
+      uri,
       info.innerType,
       info.expectedType,
       info.scope,

--- a/effekt/jvm/src/main/scala/effekt/Server.scala
+++ b/effekt/jvm/src/main/scala/effekt/Server.scala
@@ -634,14 +634,10 @@ case class EffektHoleInfo(
 
 object EffektHoleInfo {
   def fromHoleInfo(info: Intelligence.HoleInfo): EffektHoleInfo = {
-    val uri = info.span.origin match {
-      case Origin.File(name) => Convert.toURI(name)
-      case _ => ""
-    }
     EffektHoleInfo(
       info.id,
       convertRange(info.span.range),
-      uri,
+      Convert.toURI(info.span.source.name),
       info.innerType,
       info.expectedType,
       info.scope,

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1425,7 +1425,6 @@ class LSPTests extends FunSuite {
             "x: Int"
           ),
           signatureHtml = Some("<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">Int</span>"),
-          uri = Some("file://test.effekt"),
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
@@ -1447,7 +1446,6 @@ class LSPTests extends FunSuite {
           signatureHtml = Some(
             "<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">bar</span>(<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Int</span> / {}"
           ),
-          uri = Some("file://test.effekt"),
           kind = BindingKind.Term,
           definitionLocation = Some(LSPLocation("file://test.effekt", LSPRange(LSPPosition(3, 0), LSPPosition(3, 39))))
         ),
@@ -1461,7 +1459,6 @@ class LSPTests extends FunSuite {
           signatureHtml = Some(
             "<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">foo</span>(<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">Int</span>): <span class=\"effekt-ident pascal-case\">Bool</span> / {}"
           ),
-          uri = Some("file://test.effekt"),
           kind = BindingKind.Term,
           definitionLocation = Some(LSPLocation("file://test.effekt", LSPRange(LSPPosition(2, 0), LSPPosition(2, 36))))
         ),
@@ -1473,7 +1470,6 @@ class LSPTests extends FunSuite {
           signatureHtml = Some(
             "<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">MyInt</span>"
           ),
-          uri = Some("file://test.effekt"),
           kind = BindingKind.Type,
           definitionLocation = Some(LSPLocation("file://test.effekt", LSPRange(LSPPosition(1, 0), LSPPosition(1, 16))))
         )
@@ -1599,7 +1595,6 @@ class LSPTests extends FunSuite {
           origin = BindingOrigin.Defined,
           signature = Some("def bar(): Nothing / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">bar</span>(): <span class=\"effekt-ident pascal-case\">Nothing</span> / {}"),
-          uri = Some("file://test.effekt"),
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
@@ -1962,7 +1957,6 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("type Foo1"),
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Foo1</span>"),
-          uri = Some("file://test.effekt"),
           kind = "Type",
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
@@ -1980,7 +1974,6 @@ class LSPTests extends FunSuite {
             "def Foo1(theField: String): Foo1 / {}"
           ),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Foo1</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Foo1</span> / {}"),
-          uri = Some("file://test.effekt"),
           kind = "Term",
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
@@ -1998,7 +1991,6 @@ class LSPTests extends FunSuite {
             "def theField(Foo1: Foo1): String / {}"
           ),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">theField</span>(<span class=\"effekt-ident pascal-case\">Foo1</span>: <span class=\"effekt-ident pascal-case\">Foo1</span>): <span class=\"effekt-ident pascal-case\">String</span> / {}"),
-          uri = Some("file://test.effekt"),
           kind = "Term",
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
@@ -2014,7 +2006,6 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("type Foo2"),
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Foo2</span>"),
-          uri = Some("file://test.effekt"),
           kind = "Type",
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
@@ -2030,7 +2021,6 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("def Foo2(theField: String): Foo2 / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Foo2</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Foo2</span> / {}"),
-          uri = Some("file://test.effekt"),
           kind = "Term",
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
@@ -2046,7 +2036,6 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("def theField(Foo2: Foo2): String / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">theField</span>(<span class=\"effekt-ident pascal-case\">Foo2</span>: <span class=\"effekt-ident pascal-case\">Foo2</span>): <span class=\"effekt-ident pascal-case\">String</span> / {}"),
-          uri = Some("file://test.effekt"),
           kind = "Term",
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
@@ -2062,7 +2051,6 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("type Bar"),
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Bar</span>"),
-          uri = Some("file://test.effekt"),
           kind = "Type",
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
@@ -2078,7 +2066,6 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("def Bar(theField: Int): Bar / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Bar</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">Int</span>): <span class=\"effekt-ident pascal-case\">Bar</span> / {}"),
-          uri = Some("file://test.effekt"),
           kind = "Term",
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
@@ -2094,7 +2081,6 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("def main(): Nothing / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">main</span>(): <span class=\"effekt-ident pascal-case\">Nothing</span> / {}"),
-          uri = Some("file://test.effekt"),
           kind = "Term",
           definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1,7 +1,7 @@
 package effekt
 
 import com.google.gson.{Gson, GsonBuilder, JsonElement, JsonParser}
-import effekt.Intelligence.{BindingInfo, BindingOrigin, Code, HoleItemKind, NaturalLanguage, ScopeInfo, ScopeKind, TermBinding, TypeBinding}
+import effekt.Intelligence.{BindingInfo, BindingKind, BindingOrigin, Code, DefinitionLocation, HoleItemKind, LSPPosition, LSPRange, NaturalLanguage, ScopeInfo, ScopeKind, TermBinding, TypeBinding}
 import munit.FunSuite
 import org.eclipse.lsp4j.{CodeAction, CodeActionKind, CodeActionParams, Command, DefinitionParams, Diagnostic, DiagnosticSeverity, DidChangeConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentSymbol, DocumentSymbolParams, Hover, HoverParams, InitializeParams, InitializeResult, InlayHint, InlayHintKind, InlayHintParams, MarkupContent, MessageActionItem, MessageParams, Position, PublishDiagnosticsParams, Range, ReferenceContext, ReferenceParams, SaveOptions, ServerCapabilities, SetTraceParams, ShowMessageRequestParams, SymbolInformation, SymbolKind, TextDocumentContentChangeEvent, TextDocumentItem, TextDocumentSyncKind, TextDocumentSyncOptions, TextEdit, VersionedTextDocumentIdentifier, WorkspaceEdit}
 import org.eclipse.lsp4j.jsonrpc.messages
@@ -1447,7 +1447,9 @@ class LSPTests extends FunSuite {
           signatureHtml = Some(
             "<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">bar</span>(<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Int</span> / {}"
           ),
-          uri = Some("file://test.effekt")
+          uri = Some("file://test.effekt"),
+          kind = BindingKind.Term,
+          definitionLocation = Some(DefinitionLocation("file://test.effekt", LSPRange(LSPPosition(3, 0), LSPPosition(3, 39))))
         ),
         TermBinding(
           qualifier = List(),
@@ -1459,7 +1461,9 @@ class LSPTests extends FunSuite {
           signatureHtml = Some(
             "<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">foo</span>(<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">Int</span>): <span class=\"effekt-ident pascal-case\">Bool</span> / {}"
           ),
-          uri = Some("file://test.effekt")
+          uri = Some("file://test.effekt"),
+          kind = BindingKind.Term,
+          definitionLocation = Some(DefinitionLocation("file://test.effekt", LSPRange(LSPPosition(2, 0), LSPPosition(2, 36))))
         ),
         TypeBinding(
           qualifier = Nil,
@@ -1469,7 +1473,9 @@ class LSPTests extends FunSuite {
           signatureHtml = Some(
             "<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">MyInt</span>"
           ),
-          uri = Some("file://test.effekt")
+          uri = Some("file://test.effekt"),
+          kind = BindingKind.Type,
+          definitionLocation = Some(DefinitionLocation("file://test.effekt", LSPRange(LSPPosition(1, 0), LSPPosition(1, 16))))
         )
       )
 
@@ -2061,8 +2067,8 @@ class LSPTests extends FunSuite {
           definitionLocation = Some(Intelligence.DefinitionLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
-              start = Intelligence.LSPPosition(line = 5, character = 2),
-              end = Intelligence.LSPPosition(line = 5, character = 32)
+              start = Intelligence.LSPPosition(line = 6, character = 2),
+              end = Intelligence.LSPPosition(line = 6, character = 33)
             )
           ))
         ),
@@ -2077,8 +2083,8 @@ class LSPTests extends FunSuite {
           definitionLocation = Some(Intelligence.DefinitionLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
-              start = Intelligence.LSPPosition(line = 5, character = 2),
-              end = Intelligence.LSPPosition(line = 5, character = 32)
+              start = Intelligence.LSPPosition(line = 6, character = 13),
+              end = Intelligence.LSPPosition(line = 6, character = 31)
             )
           ))
         ),
@@ -2093,8 +2099,8 @@ class LSPTests extends FunSuite {
           definitionLocation = Some(Intelligence.DefinitionLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
-              start = Intelligence.LSPPosition(line = 7, character = 2),
-              end = Intelligence.LSPPosition(line = 7, character = 16)
+              start = Intelligence.LSPPosition(line = 8, character = 2),
+              end = Intelligence.LSPPosition(line = 8, character = 17)
             )
           ))
         )

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1425,6 +1425,7 @@ class LSPTests extends FunSuite {
             "x: Int"
           ),
           signatureHtml = Some("<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">Int</span>"),
+          uri = Some("file://test.effekt")
         )
       )
 
@@ -1438,7 +1439,8 @@ class LSPTests extends FunSuite {
           ),
           signatureHtml = Some(
             "<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">bar</span>(<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Int</span> / {}"
-          )
+          ),
+          uri = Some("file://test.effekt")
         ),
         TermBinding(
           qualifier = List(),
@@ -1450,6 +1452,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some(
             "<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">foo</span>(<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">Int</span>): <span class=\"effekt-ident pascal-case\">Bool</span> / {}"
           ),
+          uri = Some("file://test.effekt")
         ),
         TypeBinding(
           qualifier = Nil,
@@ -1459,6 +1462,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some(
             "<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">MyInt</span>"
           ),
+          uri = Some("file://test.effekt")
         )
       )
 
@@ -1582,6 +1586,7 @@ class LSPTests extends FunSuite {
           origin = BindingOrigin.Defined,
           signature = Some("def bar(): Nothing / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">bar</span>(): <span class=\"effekt-ident pascal-case\">Nothing</span> / {}"),
+          uri = Some("file://test.effekt")
         )
       )
 
@@ -1937,6 +1942,7 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("type Foo1"),
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Foo1</span>"),
+          uri = Some("file://test.effekt"),
           kind = "Type"
         ),
         TermBinding(
@@ -1947,6 +1953,7 @@ class LSPTests extends FunSuite {
             "def Foo1(theField: String): Foo1 / {}"
           ),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Foo1</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Foo1</span> / {}"),
+          uri = Some("file://test.effekt"),
           kind = "Term",
         ),
         TermBinding(
@@ -1957,6 +1964,7 @@ class LSPTests extends FunSuite {
             "def theField(Foo1: Foo1): String / {}"
           ),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">theField</span>(<span class=\"effekt-ident pascal-case\">Foo1</span>: <span class=\"effekt-ident pascal-case\">Foo1</span>): <span class=\"effekt-ident pascal-case\">String</span> / {}"),
+          uri = Some("file://test.effekt"),
           kind = "Term",
         ),
         TypeBinding(
@@ -1965,6 +1973,7 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("type Foo2"),
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Foo2</span>"),
+          uri = Some("file://test.effekt"),
           kind = "Type"
         ),
         TermBinding(
@@ -1973,6 +1982,7 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("def Foo2(theField: String): Foo2 / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Foo2</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Foo2</span> / {}"),
+          uri = Some("file://test.effekt"),
           kind = "Term"
         ),
         TermBinding(
@@ -1981,6 +1991,7 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("def theField(Foo2: Foo2): String / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">theField</span>(<span class=\"effekt-ident pascal-case\">Foo2</span>: <span class=\"effekt-ident pascal-case\">Foo2</span>): <span class=\"effekt-ident pascal-case\">String</span> / {}"),
+          uri = Some("file://test.effekt"),
           kind = "Term"
         ),
         TypeBinding(
@@ -1989,6 +2000,7 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("type Bar"),
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Bar</span>"),
+          uri = Some("file://test.effekt"),
           kind = "Type"
         ),
         TermBinding(
@@ -1997,6 +2009,7 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("def Bar(theField: Int): Bar / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Bar</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">Int</span>): <span class=\"effekt-ident pascal-case\">Bar</span> / {}"),
+          uri = Some("file://test.effekt"),
           kind = "Term"
         ),
         TermBinding(
@@ -2005,6 +2018,7 @@ class LSPTests extends FunSuite {
           origin = "Defined",
           signature = Some("def main(): Nothing / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">main</span>(): <span class=\"effekt-ident pascal-case\">Nothing</span> / {}"),
+          uri = Some("file://test.effekt"),
           kind = "Term"
         )
       )

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1425,7 +1425,14 @@ class LSPTests extends FunSuite {
             "x: Int"
           ),
           signatureHtml = Some("<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">Int</span>"),
-          uri = Some("file://test.effekt")
+          uri = Some("file://test.effekt"),
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 2, character = 8),
+              end = Intelligence.LSPPosition(line = 2, character = 14)
+            )
+          ))
         )
       )
 
@@ -1586,7 +1593,14 @@ class LSPTests extends FunSuite {
           origin = BindingOrigin.Defined,
           signature = Some("def bar(): Nothing / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">bar</span>(): <span class=\"effekt-ident pascal-case\">Nothing</span> / {}"),
-          uri = Some("file://test.effekt")
+          uri = Some("file://test.effekt"),
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 2, character = 2),
+              end = Intelligence.LSPPosition(line = 2, character = 16)
+            )
+          ))
         )
       )
 
@@ -1943,7 +1957,14 @@ class LSPTests extends FunSuite {
           signature = Some("type Foo1"),
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Foo1</span>"),
           uri = Some("file://test.effekt"),
-          kind = "Type"
+          kind = "Type",
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 2, character = 2),
+              end = Intelligence.LSPPosition(line = 2, character = 31)
+            )
+          ))
         ),
         TermBinding(
           qualifier = Nil,
@@ -1955,6 +1976,13 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Foo1</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Foo1</span> / {}"),
           uri = Some("file://test.effekt"),
           kind = "Term",
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 2, character = 2),
+              end = Intelligence.LSPPosition(line = 2, character = 31)
+            )
+          ))
         ),
         TermBinding(
           qualifier = Nil,
@@ -1966,6 +1994,13 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">theField</span>(<span class=\"effekt-ident pascal-case\">Foo1</span>: <span class=\"effekt-ident pascal-case\">Foo1</span>): <span class=\"effekt-ident pascal-case\">String</span> / {}"),
           uri = Some("file://test.effekt"),
           kind = "Term",
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 2, character = 14),
+              end = Intelligence.LSPPosition(line = 2, character = 30)
+            )
+          ))
         ),
         TypeBinding(
           qualifier = Nil,
@@ -1974,7 +2009,14 @@ class LSPTests extends FunSuite {
           signature = Some("type Foo2"),
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Foo2</span>"),
           uri = Some("file://test.effekt"),
-          kind = "Type"
+          kind = "Type",
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 3, character = 2),
+              end = Intelligence.LSPPosition(line = 3, character = 31)
+            )
+          ))
         ),
         TermBinding(
           qualifier = Nil,
@@ -1983,7 +2025,14 @@ class LSPTests extends FunSuite {
           signature = Some("def Foo2(theField: String): Foo2 / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Foo2</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Foo2</span> / {}"),
           uri = Some("file://test.effekt"),
-          kind = "Term"
+          kind = "Term",
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 3, character = 2),
+              end = Intelligence.LSPPosition(line = 3, character = 31)
+            )
+          ))
         ),
         TermBinding(
           qualifier = Nil,
@@ -1992,7 +2041,14 @@ class LSPTests extends FunSuite {
           signature = Some("def theField(Foo2: Foo2): String / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">theField</span>(<span class=\"effekt-ident pascal-case\">Foo2</span>: <span class=\"effekt-ident pascal-case\">Foo2</span>): <span class=\"effekt-ident pascal-case\">String</span> / {}"),
           uri = Some("file://test.effekt"),
-          kind = "Term"
+          kind = "Term",
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 3, character = 14),
+              end = Intelligence.LSPPosition(line = 3, character = 30)
+            )
+          ))
         ),
         TypeBinding(
           qualifier = Nil,
@@ -2001,7 +2057,14 @@ class LSPTests extends FunSuite {
           signature = Some("type Bar"),
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Bar</span>"),
           uri = Some("file://test.effekt"),
-          kind = "Type"
+          kind = "Type",
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 5, character = 2),
+              end = Intelligence.LSPPosition(line = 5, character = 32)
+            )
+          ))
         ),
         TermBinding(
           qualifier = Nil,
@@ -2010,7 +2073,14 @@ class LSPTests extends FunSuite {
           signature = Some("def Bar(theField: Int): Bar / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Bar</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">Int</span>): <span class=\"effekt-ident pascal-case\">Bar</span> / {}"),
           uri = Some("file://test.effekt"),
-          kind = "Term"
+          kind = "Term",
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 5, character = 2),
+              end = Intelligence.LSPPosition(line = 5, character = 32)
+            )
+          ))
         ),
         TermBinding(
           qualifier = Nil,
@@ -2019,7 +2089,14 @@ class LSPTests extends FunSuite {
           signature = Some("def main(): Nothing / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">main</span>(): <span class=\"effekt-ident pascal-case\">Nothing</span> / {}"),
           uri = Some("file://test.effekt"),
-          kind = "Term"
+          kind = "Term",
+          definitionLocation = Some(Intelligence.DefinitionLocation(
+            uri = "file://test.effekt",
+            range = Intelligence.LSPRange(
+              start = Intelligence.LSPPosition(line = 7, character = 2),
+              end = Intelligence.LSPPosition(line = 7, character = 16)
+            )
+          ))
         )
       )
 

--- a/effekt/jvm/src/test/scala/effekt/LSPTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LSPTests.scala
@@ -1,7 +1,7 @@
 package effekt
 
 import com.google.gson.{Gson, GsonBuilder, JsonElement, JsonParser}
-import effekt.Intelligence.{BindingInfo, BindingKind, BindingOrigin, Code, DefinitionLocation, HoleItemKind, LSPPosition, LSPRange, NaturalLanguage, ScopeInfo, ScopeKind, TermBinding, TypeBinding}
+import effekt.Intelligence.{BindingInfo, BindingKind, BindingOrigin, Code, LSPLocation, HoleItemKind, LSPPosition, LSPRange, NaturalLanguage, ScopeInfo, ScopeKind, TermBinding, TypeBinding}
 import munit.FunSuite
 import org.eclipse.lsp4j.{CodeAction, CodeActionKind, CodeActionParams, Command, DefinitionParams, Diagnostic, DiagnosticSeverity, DidChangeConfigurationParams, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentSymbol, DocumentSymbolParams, Hover, HoverParams, InitializeParams, InitializeResult, InlayHint, InlayHintKind, InlayHintParams, MarkupContent, MessageActionItem, MessageParams, Position, PublishDiagnosticsParams, Range, ReferenceContext, ReferenceParams, SaveOptions, ServerCapabilities, SetTraceParams, ShowMessageRequestParams, SymbolInformation, SymbolKind, TextDocumentContentChangeEvent, TextDocumentItem, TextDocumentSyncKind, TextDocumentSyncOptions, TextEdit, VersionedTextDocumentIdentifier, WorkspaceEdit}
 import org.eclipse.lsp4j.jsonrpc.messages
@@ -1426,7 +1426,7 @@ class LSPTests extends FunSuite {
           ),
           signatureHtml = Some("<span class=\"effekt-ident camel-case\">x</span>: <span class=\"effekt-ident pascal-case\">Int</span>"),
           uri = Some("file://test.effekt"),
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 2, character = 8),
@@ -1449,7 +1449,7 @@ class LSPTests extends FunSuite {
           ),
           uri = Some("file://test.effekt"),
           kind = BindingKind.Term,
-          definitionLocation = Some(DefinitionLocation("file://test.effekt", LSPRange(LSPPosition(3, 0), LSPPosition(3, 39))))
+          definitionLocation = Some(LSPLocation("file://test.effekt", LSPRange(LSPPosition(3, 0), LSPPosition(3, 39))))
         ),
         TermBinding(
           qualifier = List(),
@@ -1463,7 +1463,7 @@ class LSPTests extends FunSuite {
           ),
           uri = Some("file://test.effekt"),
           kind = BindingKind.Term,
-          definitionLocation = Some(DefinitionLocation("file://test.effekt", LSPRange(LSPPosition(2, 0), LSPPosition(2, 36))))
+          definitionLocation = Some(LSPLocation("file://test.effekt", LSPRange(LSPPosition(2, 0), LSPPosition(2, 36))))
         ),
         TypeBinding(
           qualifier = Nil,
@@ -1475,7 +1475,7 @@ class LSPTests extends FunSuite {
           ),
           uri = Some("file://test.effekt"),
           kind = BindingKind.Type,
-          definitionLocation = Some(DefinitionLocation("file://test.effekt", LSPRange(LSPPosition(1, 0), LSPPosition(1, 16))))
+          definitionLocation = Some(LSPLocation("file://test.effekt", LSPRange(LSPPosition(1, 0), LSPPosition(1, 16))))
         )
       )
 
@@ -1600,7 +1600,7 @@ class LSPTests extends FunSuite {
           signature = Some("def bar(): Nothing / {}"),
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">bar</span>(): <span class=\"effekt-ident pascal-case\">Nothing</span> / {}"),
           uri = Some("file://test.effekt"),
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 2, character = 2),
@@ -1964,7 +1964,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Foo1</span>"),
           uri = Some("file://test.effekt"),
           kind = "Type",
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 2, character = 2),
@@ -1982,7 +1982,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Foo1</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Foo1</span> / {}"),
           uri = Some("file://test.effekt"),
           kind = "Term",
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 2, character = 2),
@@ -2000,7 +2000,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">theField</span>(<span class=\"effekt-ident pascal-case\">Foo1</span>: <span class=\"effekt-ident pascal-case\">Foo1</span>): <span class=\"effekt-ident pascal-case\">String</span> / {}"),
           uri = Some("file://test.effekt"),
           kind = "Term",
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 2, character = 14),
@@ -2016,7 +2016,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Foo2</span>"),
           uri = Some("file://test.effekt"),
           kind = "Type",
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 3, character = 2),
@@ -2032,7 +2032,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Foo2</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">String</span>): <span class=\"effekt-ident pascal-case\">Foo2</span> / {}"),
           uri = Some("file://test.effekt"),
           kind = "Term",
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 3, character = 2),
@@ -2048,7 +2048,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">theField</span>(<span class=\"effekt-ident pascal-case\">Foo2</span>: <span class=\"effekt-ident pascal-case\">Foo2</span>): <span class=\"effekt-ident pascal-case\">String</span> / {}"),
           uri = Some("file://test.effekt"),
           kind = "Term",
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 3, character = 14),
@@ -2064,7 +2064,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">type</span> <span class=\"effekt-ident pascal-case\">Bar</span>"),
           uri = Some("file://test.effekt"),
           kind = "Type",
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 6, character = 2),
@@ -2080,7 +2080,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident pascal-case\">Bar</span>(<span class=\"effekt-ident camel-case\">theField</span>: <span class=\"effekt-ident pascal-case\">Int</span>): <span class=\"effekt-ident pascal-case\">Bar</span> / {}"),
           uri = Some("file://test.effekt"),
           kind = "Term",
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 6, character = 13),
@@ -2096,7 +2096,7 @@ class LSPTests extends FunSuite {
           signatureHtml = Some("<span class=\"effekt-keyword\">def</span> <span class=\"effekt-ident camel-case\">main</span>(): <span class=\"effekt-ident pascal-case\">Nothing</span> / {}"),
           uri = Some("file://test.effekt"),
           kind = "Term",
-          definitionLocation = Some(Intelligence.DefinitionLocation(
+          definitionLocation = Some(Intelligence.LSPLocation(
             uri = "file://test.effekt",
             range = Intelligence.LSPRange(
               start = Intelligence.LSPPosition(line = 8, character = 2),
@@ -2173,30 +2173,6 @@ class LSPTests extends FunSuite {
   //
 
   test("Hole info includes correct file URI") {
-    withClientAndServer { (client, server) =>
-      val source = """
-                    |def foo(x: Int): Bool = <>
-                    |""".textDocument
-
-      val initializeParams = new InitializeParams()
-      val initializationOptions = """{"effekt": {"showHoles": true}}"""
-      initializeParams.setInitializationOptions(JsonParser.parseString(initializationOptions))
-      server.initialize(initializeParams).get()
-
-      val didOpenParams = new DidOpenTextDocumentParams()
-      didOpenParams.setTextDocument(source)
-      server.getTextDocumentService().didOpen(didOpenParams)
-
-      val receivedHoles = client.receivedHoles()
-      assertEquals(receivedHoles.length, 1)
-      assertEquals(receivedHoles.head.holes.length, 1)
-
-      val hole = receivedHoles.head.holes.head
-      assertEquals(hole.uri, "file://test.effekt")
-    }
-  }
-
-  test("Hole info with custom file URI includes correct URI") {
     withClientAndServer { (client, server) =>
       val source = new TextDocumentItem("file://custom/path/example.effekt", "effekt", 0,
         """def bar(): String = <>""")

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -199,7 +199,7 @@ trait Intelligence {
         case s: TermSymbol => s.decl.span
       })
     }
-    // based on //effekt/kiama/jvm/src/main/scala/kiama/util/Convert.scala toUri, which cannot be accessed in this module
+
     def getSymbolUri(sym: TypeSymbol | TermSymbol): Option[String] = {
       try {
         val sourceName = sym match {
@@ -208,7 +208,6 @@ trait Intelligence {
           case _ => return None
         }
         
-        // Simple URI conversion compatible with shared module
         if (sourceName.startsWith("file:") || sourceName.startsWith("vscode-notebook-cell:")) {
           Some(sourceName)
         } else if (sourceName.startsWith("./") || sourceName.startsWith(".\\")) {

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -239,23 +239,20 @@ trait Intelligence {
       // TODO this is extremely hacky, printing is not defined for all types at the moment
       val signature = try { Some(SignaturePrinter(sym)) } catch { case e: Throwable => None }
       val signatureHtml = signature.map(sig => HtmlHighlight(sig))
-      
-      val uri = getSymbolUri(sym)
       val definitionLocation = getDefinitionLocation(sym)
       
       val out = sym match {
-        case sym: TypeSymbol => List(TypeBinding(path, name, origin, signature, signatureHtml, uri, definitionLocation = definitionLocation))
-        case sym: ValueSymbol => List(TermBinding(path, name, origin, signature, signatureHtml, uri, definitionLocation = definitionLocation))
-        case sym: BlockSymbol => List(TermBinding(path, name, origin, signature, signatureHtml, uri, definitionLocation = definitionLocation))
+        case sym: TypeSymbol => List(TypeBinding(path, name, origin, signature, signatureHtml, definitionLocation = definitionLocation))
+        case sym: ValueSymbol => List(TermBinding(path, name, origin, signature, signatureHtml, definitionLocation = definitionLocation))
+        case sym: BlockSymbol => List(TermBinding(path, name, origin, signature, signatureHtml, definitionLocation = definitionLocation))
       }
       sym match {
         case Interface(name, tparams, ops, decl) if !(ops.length == 1 && ops.head.name.name == name.name) => {
           val opsInfos = ops.map { op =>
             val signature = Some(SignaturePrinter(op))
             val signatureHtml = signature.map(sig => HtmlHighlight(sig))
-            val opUri = getSymbolUri(op)
             val opDefinitionLocation = getDefinitionLocation(op)
-            TermBinding(path, op.name.name, origin, signature, signatureHtml, opUri, definitionLocation = opDefinitionLocation)
+            TermBinding(path, op.name.name, origin, signature, signatureHtml, definitionLocation = opDefinitionLocation)
           }
           out ++ opsInfos
         }
@@ -536,7 +533,6 @@ object Intelligence {
     origin: String,
     signature: Option[String] = None,
     signatureHtml: Option[String],
-    uri: Option[String] = None,
     kind: String = BindingKind.Term,
     definitionLocation: Option[LSPLocation] = None
   ) extends BindingInfo
@@ -546,7 +542,6 @@ object Intelligence {
     origin: String,
     signature: Option[String] = None,
     signatureHtml: Option[String],
-    uri: Option[String] = None,
     kind: String = BindingKind.Type,
     definitionLocation: Option[LSPLocation] = None
   ) extends BindingInfo

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -4,7 +4,7 @@ import effekt.context.{Annotations, Context}
 import effekt.source.Origin.Missing
 import effekt.source.{Doc, FunDef, Include, Maybe, ModuleDecl, Span, Tree}
 import effekt.symbols.{CaptureSet, Hole}
-import kiama.util.{Position, Source}
+import kiama.util.{Convert, Position, Source}
 import effekt.symbols.scopes.Scope
 import effekt.source.sourceOf
 import effekt.util.HtmlHighlight
@@ -199,7 +199,7 @@ trait Intelligence {
         case s: TermSymbol => s.decl.span
       })
     }
-    // based on //effekt/kiama/jvm/src/main/scala/kiama/util/Convert.scala toUri, which cannot be accessed in this module
+
     def getSymbolUri(sym: TypeSymbol | TermSymbol): Option[String] = {
       try {
         val sourceName = sym match {
@@ -207,17 +207,7 @@ trait Intelligence {
           case s: TermSymbol if s.decl != null => s.decl.span.source.name
           case _ => return None
         }
-        
-        // Simple URI conversion compatible with shared module
-        if (sourceName.startsWith("file:") || sourceName.startsWith("vscode-notebook-cell:")) {
-          Some(sourceName)
-        } else if (sourceName.startsWith("./") || sourceName.startsWith(".\\")) {
-          // Remove the "./" or ".\\" prefix and make absolute
-          val relativePath = sourceName.substring(2)
-          Some(s"file://$relativePath")
-        } else {
-          Some(s"file://$sourceName")
-        }
+        Some(Convert.toURI(sourceName))
       } catch {
         case _: Throwable => None
       }

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -235,11 +235,9 @@ trait Intelligence {
           uri <- getSymbolUri(sym)
         } yield DefinitionLocation(
           uri = uri,
-          range = DefinitionRange(
-            startLine = span.range.from.line - 1, // LSP is 0-indexed
-            startCharacter = span.range.from.column - 1, // LSP is 0-indexed  
-            endLine = span.range.to.line - 1,
-            endCharacter = span.range.to.column - 1
+          range = LSPRange(
+            start = LSPPosition(line = span.range.from.line - 1, character = span.range.from.column - 1), // LSP is 0-indexed
+            end = LSPPosition(line = span.range.to.line - 1, character = span.range.to.column - 1)  // LSP is 0-indexed
           )
         )
       } catch {
@@ -529,14 +527,17 @@ object Intelligence {
 
   case class DefinitionLocation(
     uri: String,
-    range: DefinitionRange
+    range: LSPRange
   )
 
-  case class DefinitionRange(
-    startLine: Int,
-    startCharacter: Int,
-    endLine: Int,
-    endCharacter: Int
+  case class LSPPosition(
+    line: Int,
+    character: Int
+  )
+
+  case class LSPRange(
+    start: LSPPosition,
+    end: LSPPosition
   )
 
   case class TermBinding(

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -213,7 +213,7 @@ trait Intelligence {
       }
     }
 
-    def getDefinitionLocation(sym: TypeSymbol | TermSymbol): Option[DefinitionLocation] = {
+    def getDefinitionLocation(sym: TypeSymbol | TermSymbol): Option[LSPLocation] = {
       try {
         val span = sym match {
           case s: TypeSymbol if s.decl != null => s.decl.span
@@ -223,7 +223,7 @@ trait Intelligence {
         
         for {
           uri <- getSymbolUri(sym)
-        } yield DefinitionLocation(
+        } yield LSPLocation(
           uri = uri,
           range = LSPRange(
             start = LSPPosition(line = span.range.from.line - 1, character = span.range.from.column - 1), // LSP is 0-indexed
@@ -512,10 +512,10 @@ object Intelligence {
     val signature: Option[String]
     val signatureHtml: Option[String]
     val kind: String
-    val definitionLocation: Option[DefinitionLocation]
+    val definitionLocation: Option[LSPLocation]
   }
 
-  case class DefinitionLocation(
+  case class LSPLocation(
     uri: String,
     range: LSPRange
   )
@@ -538,7 +538,7 @@ object Intelligence {
     signatureHtml: Option[String],
     uri: Option[String] = None,
     kind: String = BindingKind.Term,
-    definitionLocation: Option[DefinitionLocation] = None
+    definitionLocation: Option[LSPLocation] = None
   ) extends BindingInfo
   case class TypeBinding(
     qualifier: List[String],
@@ -548,7 +548,7 @@ object Intelligence {
     signatureHtml: Option[String],
     uri: Option[String] = None,
     kind: String = BindingKind.Type,
-    definitionLocation: Option[DefinitionLocation] = None
+    definitionLocation: Option[LSPLocation] = None
   ) extends BindingInfo
 
   // These need to be strings (rather than cases of an enum) so that they get serialized correctly

--- a/effekt/shared/src/main/scala/effekt/Intelligence.scala
+++ b/effekt/shared/src/main/scala/effekt/Intelligence.scala
@@ -4,7 +4,7 @@ import effekt.context.{Annotations, Context}
 import effekt.source.Origin.Missing
 import effekt.source.{Doc, FunDef, Include, Maybe, ModuleDecl, Span, Tree}
 import effekt.symbols.{CaptureSet, Hole}
-import kiama.util.{Convert, Position, Source}
+import kiama.util.{Position, Source}
 import effekt.symbols.scopes.Scope
 import effekt.source.sourceOf
 import effekt.util.HtmlHighlight
@@ -199,7 +199,7 @@ trait Intelligence {
         case s: TermSymbol => s.decl.span
       })
     }
-
+    // based on //effekt/kiama/jvm/src/main/scala/kiama/util/Convert.scala toUri, which cannot be accessed in this module
     def getSymbolUri(sym: TypeSymbol | TermSymbol): Option[String] = {
       try {
         val sourceName = sym match {
@@ -207,7 +207,17 @@ trait Intelligence {
           case s: TermSymbol if s.decl != null => s.decl.span.source.name
           case _ => return None
         }
-        Some(Convert.toURI(sourceName))
+        
+        // Simple URI conversion compatible with shared module
+        if (sourceName.startsWith("file:") || sourceName.startsWith("vscode-notebook-cell:")) {
+          Some(sourceName)
+        } else if (sourceName.startsWith("./") || sourceName.startsWith(".\\")) {
+          // Remove the "./" or ".\\" prefix and make absolute
+          val relativePath = sourceName.substring(2)
+          Some(s"file://$relativePath")
+        } else {
+          Some(s"file://$sourceName")
+        }
       } catch {
         case _: Throwable => None
       }


### PR DESCRIPTION
To enable client-side functionalities in the VSCode extension like 'jump-to-definition' for the bindings, we need to also send the file uri 

See : https://github.com/effekt-lang/effekt-vscode/pull/140