### PR TITLE
Output the CPS IR when setting `ir-write-all`

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
+++ b/effekt/jvm/src/main/scala/effekt/EffektConfig.scala
@@ -145,7 +145,7 @@ class EffektConfig(args: Seq[String]) extends REPLConfig(args.takeWhile(_ != "--
   )
 
   val showIR: ScallopOption[Option[Stage]] = choice(
-    choices = List("none", "cps", "core", "machine", "target"),
+    choices = List("none", "core", "cps", "machine", "target"),
     name = "ir-show",
     descr = "The intermediate presentation that should be printed.",
     default = Some("none"),

--- a/effekt/shared/src/main/scala/effekt/Compiler.scala
+++ b/effekt/shared/src/main/scala/effekt/Compiler.scala
@@ -60,7 +60,7 @@ enum PhaseResult {
 }
 export PhaseResult.*
 
-enum Stage { case CPS; case Core; case Machine; case Target; }
+enum Stage { case Core; case CPS; case Machine; case Target; }
 
 /**
  * The compiler for the Effekt language.

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezScheme.scala
@@ -36,15 +36,15 @@ trait ChezScheme extends Compiler[String] {
   override def supportedFeatureFlags: List[String] = List("chez")
 
   override def prettyIR(source: Source, stage: Stage)(using Context): Option[Document] = stage match {
-    case Stage.CPS => None
     case Stage.Core => Core(source).map { res => core.PrettyPrinter.format(res.core) }
+    case Stage.CPS => None
     case Stage.Machine => None
     case Stage.Target => Separate(source).map { res => pretty(res) }
   }
 
   override def treeIR(source: Source, stage: Stage)(using Context): Option[Any] = stage match {
-    case Stage.CPS => None
     case Stage.Core => Core(source).map { res => res.core }
+    case Stage.CPS => None
     case Stage.Machine => None
     case Stage.Target => Separate(source)
   }

--- a/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/JavaScript.scala
@@ -18,16 +18,16 @@ class JavaScript(additionalFeatureFlags: List[String] = Nil) extends Compiler[St
   override def supportedFeatureFlags: List[String] = additionalFeatureFlags ++ TransformerCps.jsFeatureFlags
 
   override def prettyIR(source: Source, stage: Stage)(using C: Context): Option[Document] = stage match {
-    case Stage.CPS => CPSTransformed(source).map { (_, _, _, res) => cps.PrettyPrinter.format(res) }
     case Stage.Core if C.config.optimize() => Optimized(source).map { (_, _, res) => core.PrettyPrinter.format(res) }
+    case Stage.CPS => CPSTransformed(source).map { (_, _, _, res) => cps.PrettyPrinter.format(res) }
     case Stage.Core => Core(source).map { res => core.PrettyPrinter.format(res.core) }
     case Stage.Machine => None
     case Stage.Target => CompileLSP(source).map { pretty }
   }
 
   override def treeIR(source: Source, stage: Stage)(using Context): Option[Any] = stage match {
-    case Stage.CPS => None
     case Stage.Core => Core(source).map { res => res.core }
+    case Stage.CPS => None
     case Stage.Machine => None
     case Stage.Target => CompileLSP(source)
   }

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/LLVM.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/LLVM.scala
@@ -18,15 +18,15 @@ class LLVM extends Compiler[String] {
   override def supportedFeatureFlags: List[String] = Transformer.llvmFeatureFlags
 
   override def prettyIR(source: Source, stage: Stage)(using Context): Option[Document] = stage match {
-    case Stage.CPS => None
     case Stage.Core => steps.afterCore(source).map { res => core.PrettyPrinter.format(res.core) }
+    case Stage.CPS => None
     case Stage.Machine => steps.afterMachine(source).map { res => machine.PrettyPrinter.format(res.program) }
     case Stage.Target => steps.afterLLVM(source).map { res => pretty(res) }
   }
 
   override def treeIR(source: Source, stage: Stage)(using Context): Option[Any] = stage match {
-    case Stage.CPS => None
     case Stage.Core => steps.afterCore(source).map { res => res.core }
+    case Stage.CPS => None
     case Stage.Machine => steps.afterMachine(source).map { res => res.program }
     case Stage.Target => steps.afterLLVM(source)
   }


### PR DESCRIPTION
When setting `ir-write-all` the CPS IR now also gets written to a file when used by a compiler (so only the JS compiler right now).

Note that I did not add the CPS case in the `publishIR` method of `Server` because I am not sure if this breaks something as I don't know what's going on there.

Related to #935 and #573 and of course only fixes a small portion of the issue.