### PR TITLE
Experiment: namespaced fields / accessors

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -585,11 +585,18 @@ object Namer extends Phase[Parsed, NameResolved] {
         val fieldId = paramTree.id.clone
         val name = Context.nameFor(fieldId)
         val fieldSym = Field(name, paramSym, constructor, paramTree)
-        if (defineAccessors) {
-          Context.define(fieldId, fieldSym)
-        } else {
-          Context.assignSymbol(fieldId, fieldSym)
+
+        // Constructor::field
+        Context.namespace(constructor.name.name) {
+          if (defineAccessors) {
+            Context.define(fieldId, fieldSym)
+          } else {
+            Context.assignSymbol(fieldId, fieldSym)
+          }
         }
+
+        // export Constructor::fieldName
+        Context.bind(fieldSym)
         fieldSym
     }
   }


### PR DESCRIPTION
This is just an experiment, I'm interested to see if this breaks any existing code 👀 

Example:
```scala
////////////////////////
module testey

def age[A](x: A): Int = 100
record Person(name: String, age: Int)

/////////////////////////
module main

import testey

def main() = {
  val p = Person(name = "Jolene", age = 42)
  val a: Int = age(p) // can now be qualified as `Person::age`!
  // error: Ambiguous overload.
  // There are multiple overloads, which all would type check:
  //  - testey::age: [A](A) => Int
  //  - testey::age: Person => Int
  println(a)
}
```