### PR TITLE
Delegate platform error code mapping to node's getSystemErrorName

### DIFF
--- a/libraries/common/io/error.effekt
+++ b/libraries/common/io/error.effekt
@@ -362,97 +362,110 @@ namespace internal {
     declare %Int @c_error_number(%Int)
   """
 
-  extern jsNode """
-    const os = require('node:os');
+extern jsNode """
+    const { getSystemErrorName } = require('node:util');
 
     /**
      * Maps the error code to a Effekt-stable (platform independent) numeric value.
      *
      * Tries to use most common errno integer values, but introduces fresh values (> 200)
      * for those without common errno values.
+     *
+     * The mapping from platfrom-specific error codes to Effekt error codes is handled by
+     * getSystemErrorName from 'node:util', which in turn uses the error code conventions from libuv.
+     * For reference, see the following Deno code which is more readable than the NodeJS implementation:
+     * https://github.com/denoland/deno/blob/8fb073d7b4ea83b57fd1bf9875681347b414bbe6/ext/node/polyfills/internal_binding/uv.ts
      */
     function errorNumber(errno) {
-      const errnoMap = {
-        [os.constants.errno.EPERM]: 1,
-        [os.constants.errno.ENOENT]: 2,
-        [os.constants.errno.ESRCH]: 3,
-        [os.constants.errno.EINTR]: 4,
-        [os.constants.errno.EIO]: 5,
-        [os.constants.errno.ENXIO]: 6,
-        [os.constants.errno.E2BIG]: 7,
-        [os.constants.errno.EBADF]: 9,
-        [os.constants.errno.EAGAIN]: 11,
-        [os.constants.errno.ENOMEM]: 12,
-        [os.constants.errno.EACCES]: 13,
-        [os.constants.errno.EFAULT]: 14,
-        [os.constants.errno.EBUSY]: 16,
-        [os.constants.errno.EEXIST]: 17,
-        [os.constants.errno.EXDEV]: 18,
-        [os.constants.errno.ENODEV]: 19,
-        [os.constants.errno.ENOTDIR]: 20,
-        [os.constants.errno.EISDIR]: 21,
-        [os.constants.errno.EINVAL]: 22,
-        [os.constants.errno.ENFILE]: 23,
-        [os.constants.errno.EMFILE]: 24,
-        [os.constants.errno.ENOTTY]: 25,
-        [os.constants.errno.ETXTBSY]: 26,
-        [os.constants.errno.EFBIG]: 27,
-        [os.constants.errno.ENOSPC]: 28,
-        [os.constants.errno.ESPIPE]: 29,
-        [os.constants.errno.EROFS]: 30,
-        [os.constants.errno.EMLINK]: 31,
-        [os.constants.errno.EPIPE]: 32,
-        [os.constants.errno.ERANGE]: 34,
-        [os.constants.errno.ENAMETOOLONG]: 36,
-        [os.constants.errno.ELOOP]: 40,
-        [os.constants.errno.EOVERFLOW]: 75,
-        [os.constants.errno.EFTYPE]: 79,
-        [os.constants.errno.EILSEQ]: 84,
-        [os.constants.errno.ENOTSOCK]: 88,
-        [os.constants.errno.EDESTADDRREQ]: 89,
-        [os.constants.errno.EMSGSIZE]: 90,
-        [os.constants.errno.EPROTOTYPE]: 91,
-        [os.constants.errno.ENOPROTOOPT]: 92,
-        [os.constants.errno.EPROTONOSUPPORT]: 93,
-        [os.constants.errno.ESOCKTNOSUPPORT]: 94,
-        [os.constants.errno.ENOTSUP]: 95,
-        [os.constants.errno.EAFNOSUPPORT]: 97,
-        [os.constants.errno.EADDRINUSE]: 98,
-        [os.constants.errno.EADDRNOTAVAIL]: 99,
-        [os.constants.errno.ENETDOWN]: 100,
-        [os.constants.errno.ENETUNREACH]: 101,
-        [os.constants.errno.ECONNABORTED]: 103,
-        [os.constants.errno.ECONNRESET]: 104,
-        [os.constants.errno.ENOBUFS]: 105,
-        [os.constants.errno.EISCONN]: 106,
-        [os.constants.errno.ENOTCONN]: 107,
-        [os.constants.errno.ETIMEDOUT]: 110,
-        [os.constants.errno.ECONNREFUSED]: 111,
-        [os.constants.errno.EHOSTUNREACH]: 113,
-        [os.constants.errno.EALREADY]: 114,
-        [os.constants.errno.ECANCELED]: 125,
-        [os.constants.errno.EAI_ADDRFAMILY]: 200,
-        [os.constants.errno.EAI_AGAIN]: 201,
-        [os.constants.errno.EAI_BADFLAGS]: 202,
-        [os.constants.errno.EAI_BADHINTS]: 203,
-        [os.constants.errno.EAI_CANCELED]: 204,
-        [os.constants.errno.EAI_FAIL]: 205,
-        [os.constants.errno.EAI_FAMILY]: 206,
-        [os.constants.errno.EAI_MEMORY]: 207,
-        [os.constants.errno.EAI_NODATA]: 208,
-        [os.constants.errno.EAI_NONAME]: 209,
-        [os.constants.errno.EAI_OVERFLOW]: 210,
-        [os.constants.errno.EAI_PROTOCOL]: 211,
-        [os.constants.errno.EAI_SERVICE]: 212,
-        [os.constants.errno.EAI_SOCKTYPE]: 213,
-        [os.constants.errno.ECHARSET]: 215,
-        [os.constants.errno.ENONET]: 216,
-        [os.constants.errno.UNKNOWN]: 217,
-        [os.constants.errno.EOF]: 218,
-        [os.constants.errno.EUNATCH]: 219,
-        [os.constants.errno.ESHUTDOWN]: 220
+      const mapByName = {
+        EPERM: 1,
+        ENOENT: 2,
+        ESRCH: 3,
+        EINTR: 4,
+        EIO: 5,
+        ENXIO: 6,
+        E2BIG: 7,
+        EBADF: 9,
+        EAGAIN: 11,
+        ENOMEM: 12,
+        EACCES: 13,
+        EFAULT: 14,
+        EBUSY: 16,
+        EEXIST: 17,
+        EXDEV: 18,
+        ENODEV: 19,
+        ENOTDIR: 20,
+        EISDIR: 21,
+        EINVAL: 22,
+        ENFILE: 23,
+        EMFILE: 24,
+        ENOTTY: 25,
+        ETXTBSY: 26,
+        EFBIG: 27,
+        ENOSPC: 28,
+        ESPIPE: 29,
+        EROFS: 30,
+        EMLINK: 31,
+        EPIPE: 32,
+        ERANGE: 34,
+        ENAMETOOLONG: 36,
+        ELOOP: 40,
+        EOVERFLOW: 75,
+        EFTYPE: 79,
+        EILSEQ: 84,
+        ENOTSOCK: 88,
+        EDESTADDRREQ: 89,
+        EMSGSIZE: 90,
+        EPROTOTYPE: 91,
+        ENOPROTOOPT: 92,
+        EPROTONOSUPPORT: 93,
+        ESOCKTNOSUPPORT: 94,
+        ENOTSUP: 95,
+        EAFNOSUPPORT: 97,
+        EADDRINUSE: 98,
+        EADDRNOTAVAIL: 99,
+        ENETDOWN: 100,
+        ENETUNREACH: 101,
+        ECONNABORTED: 103,
+        ECONNRESET: 104,
+        ENOBUFS: 105,
+        EISCONN: 106,
+        ENOTCONN: 107,
+        ETIMEDOUT: 110,
+        ECONNREFUSED: 111,
+        EHOSTUNREACH: 113,
+        EALREADY: 114,
+        ECANCELED: 125,
+
+        EAI_ADDRFAMILY: 200,
+        EAI_AGAIN: 201,
+        EAI_BADFLAGS: 202,
+        EAI_BADHINTS: 203,
+        EAI_CANCELED: 204,
+        EAI_FAIL: 205,
+        EAI_FAMILY: 206,
+        EAI_MEMORY: 207,
+        EAI_NODATA: 208,
+        EAI_NONAME: 209,
+        EAI_OVERFLOW: 210,
+        EAI_PROTOCOL: 211,
+        EAI_SERVICE: 212,
+        EAI_SOCKTYPE: 213,
+        ECHARSET: 215,
+        ENONET: 216,
+        UNKNOWN: 217,
+        EOF: 218,
+        EUNATCH: 219,
+        ESHUTDOWN: 220
       };
-      return errnoMap[-errno] || -1; // Default to -1 for unknown error names
+
+      // When the error code is not known, we return 217 (UNKNOWN).
+      try {
+        const name = getSystemErrorName(errno);
+        return mapByName[name] ?? 217;
+      } catch {
+        return 217;
+      }
     }
   """
 


### PR DESCRIPTION
I checked that this fixes #702 on Windows, where the provided reproducing example now returns

```console
$ effekt issue702.effekt 
File not found
```

I have not tested this on other platforms, yet.
