### PR TITLE
Improve missing function/method error when using dot syntax

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -1262,7 +1262,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
 
     failures match {
       case Nil =>
-        Context.abort("Cannot typecheck call.")
+        Context.abort(pretty"Cannot typecheck call to ${id}. Does a function/method with that name exist?")
 
       // exactly one error
       case List((sym, errs)) =>


### PR DESCRIPTION
An example from @marvinborner:

```scala
val l: List[Int] = [1, 2, 3].delete(4)
//                 ^^^^^^^^^^^^^^^^^^^ error: Cannot typecheck call.
```

This message originates from:
https://github.com/effekt-lang/effekt/blob/73e46d261bd67060c31687172e6d4026f70bbd0f/effekt/shared/src/main/scala/effekt/Typer.scala#L1263-L1265

If I understood the code correctly, this triggers iff: at the same time _don't succeed in finding an overload, but also don't fail_ [?!]. In my opinion, writing this at thirty to midnight on a Friday, this is the case where we use UFCS to call a method that does not actually exist, hence the attempt at a better error message.