### PR TITLE
Refactor TransformerOps into a helper to operate on state in Context

### DIFF
--- a/effekt/shared/src/main/scala/effekt/context/Context.scala
+++ b/effekt/shared/src/main/scala/effekt/context/Context.scala
@@ -3,7 +3,7 @@ package context
 
 import effekt.namer.NamerOps
 import effekt.typer.{TyperOps, Unification}
-import effekt.core.TransformerOps
+import effekt.core.{BindingDB, TransformerOps}
 import effekt.source.Tree
 import effekt.util.messages.{EffektMessages, ErrorReporter}
 import effekt.util.Timers
@@ -42,11 +42,13 @@ abstract class Context
     extends NamerOps
     with TyperOps
     with ModuleDB
-    with TransformerOps
     with Timers {
 
   // bring the context itself in scope
   implicit val context: Context = this
+
+  // Storage for bindings
+  var bindingDB: BindingDB = new BindingDB
 
   // the currently processed module
   var module: Module = _

--- a/effekt/shared/src/main/scala/effekt/core/BindingDB.scala
+++ b/effekt/shared/src/main/scala/effekt/core/BindingDB.scala
@@ -1,0 +1,15 @@
+package effekt.core
+
+
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Storage for bindings
+ */
+final class BindingDB {
+
+  /**
+   * A _mutable_ ListBuffer that stores all bindings to be inserted at the current scope
+   */
+  var bindings: ListBuffer[Binding] = ListBuffer()
+}


### PR DESCRIPTION
I want to remove the Cake Pattern from the Context class, starting with `TransformerOps`

In this PR i only did 3 simple things: 
1. Moved the `bindings` list into a separate `BindingDB` class.
   *(1 new file, 1 line modified)*
2. Converted the `TransformerOps` into a helper that operates on the `BindingDB`.
   *(~8 lines modified)*
3. Replaced the corresponding calls of `Context.F(..)` with `TransformerOps.F(...)`
   *(~27 single words modified)*

This paves the way to refactor all the remaining 10 traits and to improve handling of state later on, which should improve the onboarding process of new contributors.  

I have many arguments on why this refactoring should be done, but just consider this:

There are 245 methods accessible through the `Context` class and 18 of them are just called `bind` with different signatures