### PR TITLE
Assign symbol ids strictly rather than lazily

### DIFF
--- a/effekt/shared/src/main/scala/effekt/symbols/Symbol.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/Symbol.scala
@@ -25,7 +25,7 @@ trait Symbol {
   /**
    * The unique id of this symbol
    */
-  lazy val id: Int = Symbol.fresh.next()
+  val id: Int = Symbol.fresh.next()
 
   /**
    * Is this symbol synthesized? (e.g. a constructor or field access)


### PR DESCRIPTION
This is a small change, but it should make the behavior a bit easier to predict.