### PR TITLE
Fix printing of literals with escape sequences in core

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Parser.scala
@@ -170,7 +170,9 @@ class EffektLexers extends Parsers {
           case '"'  => sb.append('"');  i += 2
           case 'r'  => sb.append('\r'); i += 2
           case 't'  => sb.append('\t'); i += 2
+          case 'n'  => sb.append('\n'); i += 2
           case other =>
+            sb.append('\\')
             sb.append(other)
             i += 2
         }

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -333,12 +333,18 @@ object PrettyPrinter extends ParenPrettyPrinter {
       case '"'  => "\\\""
       case '\r' => "\\r"
       case '\t' => "\\t"
+      case '\n' => "\\n"
       case c    => c.toString
     }
   }
 
+  // If we encounter any of the following characters, we print a single-line string literal with escape sequences
+  // instead of a multi-line string literal.
+  // This is because multi-line string literals cannot currently contain escape sequences.
+  val mustEscape: Set[Char] = Set('"', '\r', '\t')
+
   def stringLiteral(s: String): Doc =
-    if s.contains("\n") then multilineStringLiteral(s)
+    if !s.exists(mustEscape.contains) then multilineStringLiteral(s)
     else "\"" <> escapeString(s) <> "\""
 
   def multilineStringLiteral(s: String): Doc = {


### PR DESCRIPTION
Previously, translating the following source program to core:

```
def main() = println("\"\ta\n\ra\"")
```

and printing it, led to the following output

```
def main() = {
    let ! v_r = println: (String) => Unit @ {io}("""" a
a"""")
    return v_r: Unit
}
```

which tripped the core parser because it contains unescaped quotes immediately preceding the multiline end string literal marker.

This parser code cannot handle this because (presumably) it eagerly consumes the first three quotes at the end of the string literal, leaving an orphan `"` behind:

```scala
  // Delimiter for multiline strings
  val multi = "\"\"\""

  // multi-line strings `(?s)` sets multi-line mode.
  lazy val multilineString: P[String] = regex(s"(?s)${ multi }[\t\n\r ]*(.*?)[\t\n\r ]*${ multi }".r) ^^ {
    contents => contents.strip().stripPrefix(multi).stripSuffix(multi)
  }
```

This PR currently contains a conservative fix: we just print single-line string literals with escape sequences whenever the string contains "problematic" characters.

Other suggestions are welcome!