### PR TITLE
Change default branch to main

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -19,10 +19,10 @@ jobs:
       
       - name: Verify repository state
         run: |
-          # Ensure we're on master
+          # Ensure we're on main
           current_branch=$(git rev-parse --abbrev-ref HEAD)
-          if [ "$current_branch" != "master" ]; then
-            echo "ERROR: Not on master branch! Current branch: $current_branch"
+          if [ "$current_branch" != "main" ]; then
+            echo "ERROR: Not on main branch! Current branch: $current_branch"
             exit 1
           fi
           
@@ -110,7 +110,7 @@ jobs:
       with:
         full-test: 'true'
         use-retry: 'true'
-          # Since we're on 'master', we can assume that the tests already passed.
+          # Since we're on 'main', we can assume that the tests already passed.
           # Therefore retrying is OK (to prevent flaky tests from cancelling the deploy).
 
   set-version:
@@ -159,7 +159,7 @@ jobs:
     needs: [set-version]
     runs-on: ubuntu-latest
     steps:
-      # Login as a GitHub App in order to bypass rules about committing to `master` directly
+      # Login as a GitHub App in order to bypass rules about committing to `main` directly
       - name: Get GitHub App token
         uses: actions/create-github-app-token@v2
         id: app-token

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,9 +1,9 @@
-name: Master CI
+name: Main CI
 
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   full-test-suite:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ play with it and give us your feedback :)
 
 ## Examples
 
-If you are looking for examples of the Effekt language, we invite you to look at the [casestudies](https://github.com/effekt-lang/effekt/tree/master/examples/casestudies) and the [language tour](https://effekt-lang.org/tour).
+If you are looking for examples of the Effekt language, we invite you to look at the [casestudies](https://github.com/effekt-lang/effekt/tree/main/examples/casestudies) and the [language tour](https://effekt-lang.org/tour).
 
 ## Installation
 

--- a/examples/tour/IO.effekt.md
+++ b/examples/tour/IO.effekt.md
@@ -157,4 +157,4 @@ concurrentSwap("test1.txt", "test2.txt")
 
 ## References
 
-- [IO in the standard library](https://github.com/effekt-lang/effekt/tree/master/libraries/common/io)
+- [IO in the standard library](https://github.com/effekt-lang/effekt/tree/main/libraries/common/io)

--- a/examples/tour/ffi.effekt.md
+++ b/examples/tour/ffi.effekt.md
@@ -144,5 +144,5 @@ now()
 
 ## Reference
 
-[`effekt.effekt`](https://github.com/effekt-lang/effekt/blob/master/libraries/common/effekt.effekt) is the main stdlib file defining things like primitive addition for each backend.
+[`effekt.effekt`](https://github.com/effekt-lang/effekt/blob/main/libraries/common/effekt.effekt) is the main stdlib file defining things like primitive addition for each backend.
 We highly recommend reading through the source code of the standard library to see how FFI is used.


### PR DESCRIPTION
Checklist:

* [x] Temporarily create `main` branch and check that CI runs through (ensure no release-related workflows run before doing so)
* [x] Use the GitHub rename branch feature to rename `master` to `main`
   This should make the following steps redundant (do verify before proceeding):
   * [x] Change default branch in GitHub settings to `main`
   * [x] Change target branch of all open PRs from `master` to `main` 
* [ ] Merge this PR into `main`
* [ ] Execute migration in the other repositories: [effekt-vscode](https://github.com/effekt-lang/effekt-vscode/pull/166), [effekt-website](https://github.com/effekt-lang/effekt-website/pull/129) 

> [!note]
> I did not create the `main` branch yet to prevent cronjobs to run twice, i.e. both on `master` and on the newly created `main`.
