### PR TITLE
Fix wrong entry in test suite

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -244,7 +244,7 @@ lazy val effekt: CrossProject = crossProject(JSPlatform, JVMPlatform).in(file("e
         "effekt.ChezSchemeCPSTests",
         "effekt.StdlibChezSchemeMonadicTests",
         "effekt.StdlibChezSchemeCallCCTests",
-        "effekt.StdlibChezCPSTests",
+        "effekt.StdlibChezSchemeCPSTests",
         "effekt.LLVMTests",
         "effekt.LLVMNoValgrindTests",
         "effekt.StdlibLLVMTests"


### PR DESCRIPTION
Follow-up from #1268:

<img width="486" height="401" alt="Screenshot 2025-12-17 at 15 36 51" src="https://github.com/user-attachments/assets/a21cd213-862c-4576-9be0-16104bcbe495" />


`separateTests` has `"effekt.StdlibChezCPSTests",` but it's stdlibchez**SCHEME**cpstests.