### PR TITLE
Keep information about extern data types

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/DeclarationContext.scala
+++ b/effekt/shared/src/main/scala/effekt/core/DeclarationContext.scala
@@ -22,6 +22,10 @@ class DeclarationContext(
     case d: Extern.Def => (d.id.name.name, d.vparams.map(_.tpe)) -> d
   }.toMap
 
+  lazy val externDatas: Map[Id, Extern.Data] = externs.collect {
+    case d: Extern.Data => d.id -> d
+  }.toMap
+
   // Maps to speed-up lookup. Assumes that, if we ever lookup a Constructor/Field/Interface/...,
   // we will eventually lookup most of them (and caches all in a respective map).
 
@@ -77,6 +81,8 @@ class DeclarationContext(
   def findExternDef(id: Id): Option[Extern.Def] = externDefs.get(id)
   def findExternDef(name: String, params: List[ValueType]): Option[Extern.Def] = externDefsName.get((name, params))
 
+  def findExternData(id: Id): Option[Extern.Data] = externDatas.get(id)
+
   def getDeclaration(id: Id)(using context: ErrorReporter): Declaration = findDeclaration(id).getOrElse {
     context.panic(s"No declaration found for ${id}.")
   }
@@ -115,6 +121,9 @@ class DeclarationContext(
   }
   def getExternDef(id: Id)(using context: ErrorReporter): Extern.Def = findExternDef(id).getOrElse{
     context.panic(s"No extern definition found for ${id}")
+  }
+  def getExternData(id: Id)(using context: ErrorReporter): Extern.Data = findExternData(id).getOrElse{
+    context.panic(s"No extern data found for ${id}")
   }
 
   extension(field: Field) {

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -82,6 +82,7 @@ class PrettyPrinter(printDetails: Boolean, printInternalIds: Boolean = true) ext
         case ExternBody.Unsupported(err) => ???
       })
     case Extern.Include(ff, contents) => "extern" <+> toDoc(ff) <+> stringLiteral(contents)
+    case Extern.Data(id, tps) => "extern type" <+> toDoc(id) <> typeParamsDoc(tps)
   }
 
   def toDoc(ff: FeatureFlag): Doc = ff match {

--- a/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
@@ -201,6 +201,11 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
     case Extern.Include(featureFlag, contents) => {
         Extern.Include(featureFlag, contents)
     }
+    case Extern.Data(id, tparams) => {
+      withBindings(tparams) {
+        Extern.Data(rewrite(id), tparams map rewrite)
+      }
+    }
   }
 
   override def rewrite(c: Constructor) = c match {
@@ -283,6 +288,7 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
       } ++ definitions.map(_.id) ++ externs.flatMap {
         case Extern.Def(id, _, _, _, _, _, _, _) => Some(id)
         case Extern.Include(_, _) => None
+        case Extern.Data(id, _) => Some(id)
       }
     }
 }

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -121,6 +121,10 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     case d @ source.NamespaceDef(name, defs, doc, span) =>
       defs.flatMap(transformToplevel)
 
+    case e @ source.ExternType(id, _, _, _) =>
+      val sym@ExternType(name, tps, _) = e.symbol
+      List(Extern.Data(sym, tps))
+
     // For now we forget about all of the following definitions in core:
     case d: source.Def.Extern => Nil
     case d: source.Def.Alias => Nil

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -132,6 +132,7 @@ case class Property(id: Id, tpe: BlockType) extends Tree
  * FFI external definitions
  */
 enum Extern extends Tree {
+  case Data(id: Id, tparams: List[Id])
   case Def(id: Id, tparams: List[Id], cparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: ValueType, annotatedCapture: Captures, body: ExternBody)
   case Include(featureFlag: FeatureFlag, contents: String)
 }
@@ -692,6 +693,7 @@ object Tree {
         Extern.Def(rewrite(id), tparams.map(rewrite), cparams.map(rewrite), vparams.map(rewrite), bparams.map(rewrite),
           rewrite(ret), rewrite(annotatedCapture), rewrite(body).run())
       case Extern.Include(featureFlag, contents) => e
+      case Extern.Data(id, tparams) => Extern.Data(rewrite(id), tparams.map(rewrite))
     }
 
     def rewrite(d: Declaration): Declaration = d match {

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -378,6 +378,7 @@ object Type {
           wellformed(free)
 
         case Extern.Include(featureFlag, contents) => ()
+        case Extern.Data(id, tparams) => ()
       }
   }
 

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
@@ -50,6 +50,8 @@ class Deadcode(reachable: Map[Id, Usage])
           // We need to keep "show", "showBuiltin" & "infixConcat" for generating show definitions (see #1123)
           case e: Extern.Def if used(e.id) || List("show", "showBuiltin", "infixConcat").contains(e.id.name.name) => e
           case e: Extern.Include => e
+          // We currently do not have usage information on extern types, so we have to keep all of them
+          case e: Extern.Data => e
         },
         // drop unreachable definitions
         definitions.collect { case d if used(d.id) => rewrite(d) },


### PR DESCRIPTION
We were throwing away information about extern data types when transforming to core.
This info is relevant for some Core -> Core phases (like Monomorphization #1024), so we know whether a type is Extern instead of guessing.