### PR TITLE
Add test::{assertFail, assertNoFail}

### DIFF
--- a/examples/stdlib/bytestream.effekt
+++ b/examples/stdlib/bytestream.effekt
@@ -12,33 +12,33 @@ def main() = {
     test("int back-and-forth (17), explicit BE"){ assert(x"${17.BE}", 17) }
     test("int back-and-forth (17), explicit LE"){ assert(x"${17.LE}", 17 * 256 * 256 * 256) }
     test("byte 00101010"){
-      with onFail { do assert(false, "Unexpected Failure") }
+      with assertNoFail
       assert(first[Byte]{groupBytesBE{ bit"00101010${()}" }}.toInt, 42)
     }
-    test("to bits and back LE bitorder"){ 
-      with onFail { do assert(false, "Unexpected Failure") }
+    test("to bits and back LE bitorder"){
+      with assertNoFail
       [42.toByte, 12.toByte, 113.toByte, 0.toByte, 255.toByte].foreach{ v =>
         assert(first[Byte]{ groupBytesLE{ bitsLE(v) } }, v)
       }
     }
-    test("to bits and back BE bitorder"){ 
-      with onFail { do assert(false, "Unexpected Failure") }
+    test("to bits and back BE bitorder"){
+      with assertNoFail
       [42.toByte, 12.toByte, 113.toByte, 0.toByte, 255.toByte].foreach{ v =>
         assert(first[Byte]{ groupBytesBE{ bitsBE(v) } }, v)
       }
     }
     test("append 0 means *2"){
-      with onFail { do assert(false, "Unexpected Failure") }
+      with assertNoFail
       [42.toByte, 12.toByte, 127.toByte].foreach{ v =>
         assert(nth[Byte](1){ groupBytesBE{ repeat(7){ do emit(B0()) }; bitsBE(v); do emit(B0()) } }, (v.toInt * 2).toByte)
       }
     }
     test("LE 2s-complement"){
-      with onFail { do assert(false, "Unexpected Failure") }
+      with assertNoFail
       assert(first[Byte]{ groupBytesLE{ twoscomplementLE{ bitsLE(6.toByte) } } }, 250.toByte)
     }
     test("BE 2s-complement"){
-      with onFail { do assert(false, "Unexpected Failure") }
+      with assertNoFail
       assert(first[Byte]{ groupBytesBE{ bit"${-6.Signed.BE.OfWidth(8)}" } }, 250.toByte)
     }
   }

--- a/examples/stdlib/test/onfail.check
+++ b/examples/stdlib/test/onfail.check
@@ -1,0 +1,11 @@
+Test test suite on 'fail'ures
+✕ Test test assertFail pass
+  Expected 'fail', but exited normally
+✓ Test test assertFail fail
+✓ Test test assertNoFail pass
+✕ Test test assertNoFail fail
+  Unexpected 'fail'
+
+ 2 pass
+ 2 fail
+ 4 tests total

--- a/examples/stdlib/test/onfail.effekt
+++ b/examples/stdlib/test/onfail.effekt
@@ -1,0 +1,20 @@
+import test
+
+def main() = {
+  // Don't print out times in CI.
+  suite("Test test suite on 'fail'ures", false) {
+    test("Test test assertFail pass") {
+      assertFail { do fail() }
+    }
+    test("Test test assertFail fail") {
+      assertFail { () }
+    }
+    test("Test test assertNoFail pass") {
+      assertNoFail { () }
+    }
+    test("Test test assertNoFail fail") {
+      assertNoFail { do fail() }
+    }
+  };
+  ()
+}

--- a/libraries/common/test.effekt
+++ b/libraries/common/test.effekt
@@ -71,6 +71,13 @@ def assertThrown[E](ex: on[E]) { body: => Unit / Exception[E] }: Unit / Assertio
 def assertThrows[E] { body: => Unit / Exception[E] }: Unit / Assertion =
   do assert(on[E].default { true } { body(); false }, "Expected Exception, but exited normally")
 
+def assertFail { body: => Unit / fail }: Unit / Assertion =
+  do assert(succeeds {body}, "Expected 'fail', but exited normally")
+
+def assertNoFail { body: => Unit / fail }: Unit / Assertion =
+  onFail { do assert(false, "Unexpected 'fail'") } {body}
+
+
 interface Test {
   def success(name: String, duration: Int): Unit
   def failure(name: String, msg: String, duration: Int): Unit


### PR DESCRIPTION
From @marvinborner's comment on #923:

> We should really have some `assertNoFail` instead, no?

---

Well, now we do. :)