### PR TITLE
Delete redundant jvm option

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,3 @@
 -Xms1g
--Xmx4g
 -Xss32m
 -Xmx8g


### PR DESCRIPTION
The option `Xms` specifies the initial amount of reserved memory the JVM is starting with. The option `Xmx` specifies the maximum amount of memory the JVM is allowed to use. `Xmx` is given with `Xmx4g` and `Xmx8g` and are thereby contradictory.