### PR TITLE
Experiment: objects instead of stack frames

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -242,36 +242,38 @@ object Transformer {
         transform(rest)
 
       case machine.PushFrame(frame, rest) =>
-        val frameEnvironment = freeVariables(frame).toList;
+        val oldCont = freshName("oldCont")
+        val frameEnvironment = freeVariables(frame).toList ++ List(machine.Variable(oldCont, machine.Negative()));
 
         val returnAddressName = freshName("returnAddress");
-        val parameters = frame.parameters.map { case machine.Variable(name, tpe) => Parameter(transform(tpe), name) }
-        defineLabel(returnAddressName, parameters) {
-          emit(Comment(s"pushFrame / return address, ${frameEnvironment.length} free variables"))
-          emit(Call("", Ccc(), VoidType(), ConstantGlobal("assumeFrameHeaderWasPopped"), List(getStack())))
-          popEnvironmentFrom(getStack(), frameEnvironment);
-          // eraseValues(frameEnvironment, frameEnvironment) (unnecessary)
-          eraseValues(frame.parameters, freeVariables(frame.body))
 
+        val parameters = frame.parameters.map { case machine.Variable(name, tpe) => Parameter(transform(tpe), name) }
+        defineLabel(returnAddressName, Parameter(objectType, "closure") +: parameters) {
+          emit(Comment(s"pushFrame / return address, ${frameEnvironment.length} free variables"))
+          consumeObject(LocalReference(objectType, "closure"), frameEnvironment, frameEnvironment.toSet);
+          eraseValues(frame.parameters, freeVariables(frame.body))
+          emit(Call("_", Ccc(), VoidType(), setCont, List(LocalReference(negativeType, oldCont), getStack())))
           transform(frame.body);
         }
 
-        val sharer = getSharer(frameEnvironment, StackFrameSharer)
-        val eraser = getEraser(frameEnvironment, StackFrameEraser)
+        val vtableName = freshName("vtable")
+        emit(GlobalConstant(vtableName, ConstantArray(methodType, List(ConstantGlobal(returnAddressName)))))
 
-        shareValues(frameEnvironment, freeVariables(rest));
-        pushFrameOnto(getStack(), frameEnvironment, returnAddressName, sharer, eraser);
+        emit(Call(oldCont, Ccc(), negativeType, getCont, List(getStack())))
+        val vtable = produceObject(frameEnvironment, freeVariables(rest));
+        val temporaryName = freshName("vtable_temporary");
+        val newCont = LocalReference(negativeType, freshName("newCont"));
+        emit(InsertValue(temporaryName, ConstantAggregateZero(negativeType), ConstantGlobal(vtableName), 0));
+        emit(InsertValue(newCont.name, LocalReference(negativeType, temporaryName), vtable, 1));
 
+        emit(Call("_", Ccc(), VoidType(), setCont, List(newCont, getStack())))
         transform(rest)
 
       case machine.Return(values) =>
-        emit(Comment(s"return, ${values.length} values"))
-        shareValues(values, Set())
+        val cont = machine.Variable(freshName("cont"), machine.Type.Negative())
+        emit(Call(cont.name, Ccc(), negativeType, getCont, List(getStack())))
+        transform(machine.Invoke(cont, 0, values))
 
-        val returnAddress = LocalReference(returnAddressType, freshName("returnAddress"));
-        popReturnAddressFrom(getStack(), returnAddress.name);
-        emit(callLabel(returnAddress, values.map(transform)))
-        RetVoid()
 
       case machine.Reset(prompt, frame, rest) =>
         emit(Comment(s"Reset ${prompt.name}"))
@@ -279,17 +281,17 @@ object Transformer {
         val newStack = LocalReference(stackType, freshName("stack"))
         emit(Call(newStack.name, Ccc(), stackType, reset, List(getStack())));
         setStack(newStack)
+        pushFrameOnto(getStack(), Nil, "topLevel", getSharer(Nil, StackSharer), getEraser(Nil, StackEraser))
 
         emit(Call(prompt.name, Ccc(), promptType, currentPrompt, List(getStack())))
 
         val frameEnvironment = freeVariables(frame).toList;
 
-        val returnAddressName = freshName("returnAddress");
+        val returnAddressName = freshName("returnAddressReset");
         val parameters = frame.parameters.map { case machine.Variable(name, tpe) => Parameter(transform(tpe), name) }
-        defineLabel(returnAddressName, parameters) {
+        defineLabel(returnAddressName, Parameter(objectType, "closure") +: parameters) {
           emit(Comment(s"Reset / return address, ${frameEnvironment.length} free variables"))
-          popEnvironmentFrom(getStack(), frameEnvironment);
-          // eraseValues(frameEnvironment, frameEnvironment) (unnecessary)
+          consumeObject(LocalReference(objectType, "closure"), frameEnvironment, freeVariables(frame));
           eraseValues(frame.parameters, freeVariables(frame.body));
 
           val nextStack = LocalReference(stackType, freshName("stack"));
@@ -299,12 +301,15 @@ object Transformer {
           transform(frame.body);
         }
 
-        val sharer = getSharer(frameEnvironment, StackSharer)
-        val eraser = getEraser(frameEnvironment, StackEraser)
+        val vtableName = freshName("vtable")
+        emit(GlobalConstant(vtableName, ConstantArray(methodType, List(ConstantGlobal(returnAddressName)))))
 
-        shareValues(frameEnvironment, freeVariables(rest));
-
-        pushFrameOnto(getStack(), frameEnvironment, returnAddressName, sharer, eraser);
+        val vtable = produceObject(frameEnvironment, freeVariables(rest));
+        val temporaryName = freshName("vtable_temporary");
+        val cont = LocalReference(negativeType, freshName("vtable_temporary"));
+        emit(InsertValue(temporaryName, ConstantAggregateZero(negativeType), ConstantGlobal(vtableName), 0));
+        emit(InsertValue(cont.name, LocalReference(negativeType, temporaryName), vtable, 1));
+        emit(Call("_", Ccc(), VoidType(), setCont, List(cont, getStack())))
 
         transform(rest)
 
@@ -990,6 +995,9 @@ object Transformer {
   val checkLimit = ConstantGlobal("checkLimit")
   val stackAllocate = ConstantGlobal("stackAllocate");
   val stackDeallocate = ConstantGlobal("stackDeallocate");
+  val setCont = ConstantGlobal("setCont");
+  val getCont = ConstantGlobal("getCont");
+
 
   /**
    * Extra info in context

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -69,7 +69,7 @@
 ; This is used for two purposes:
 ;   - a refied first-class list of stacks (cyclic linked-list)
 ;   - as part of an intrusive linked-list of stacks (meta stack)
-%StackValue = type { %ReferenceCount, %StackPointer, %Limit, %Prompt, %Stack }
+%StackValue = type { %ReferenceCount, %StackPointer, %Limit, %Prompt, %Stack, %Neg }
 
 
 
@@ -439,6 +439,18 @@ define private void @assumeFrameHeaderWasPopped(%Stack %stack) alwaysinline {
     ret void
 }
 
+define private %Neg @getCont(%Stack %stack) alwaysinline {
+    %cont_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 5
+    %cont = load %Neg, ptr %cont_pointer
+    ret %Neg %cont
+}
+
+define private void @setCont(%Neg %cont, %Stack %stack) alwaysinline {
+    %cont_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 5
+    store %Neg %cont, ptr %cont_pointer
+    ret void
+}
+
 ; Meta-stack management
 
 define private %Stack @reset(%Stack %oldStack) {
@@ -590,9 +602,11 @@ define private void @nop(%Stack %stack) {
 define private %Stack @copyStack(%Stack %stack) alwaysinline {
     %stackPointer_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 1
     %limit_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
+    %cont_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 5
 
     %stackPointer = load %StackPointer, ptr %stackPointer_pointer, !alias.scope !11, !noalias !21
     %limit = load %Limit, ptr %limit_pointer, !alias.scope !11, !noalias !21
+    %cont = load %Neg, ptr %cont_pointer, !alias.scope !11, !noalias !21
 
     %intStackPointer = ptrtoint %StackPointer %stackPointer to i64
     %intBase = ptrtoint %Stack %stack to i64
@@ -613,6 +627,7 @@ define private %Stack @copyStack(%Stack %stack) alwaysinline {
     store %Limit %newLimit, ptr %newLimit_pointer, !alias.scope !11, !noalias !21
 
     call void @shareFrames(%StackPointer %newStackPointer)
+    call void @shareNegative(%Neg %cont)
 
     %prompt_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
     %prompt = load %Prompt, ptr %prompt_pointer, !alias.scope !11, !noalias !21
@@ -701,10 +716,12 @@ define void @eraseStack(%Stack %stack) alwaysinline {
     %stackPointer_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 1
     %prompt_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 3
     %rest_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 4
+    %cont_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 5
 
     %stackPointer = load %StackPointer, ptr %stackPointer_pointer, !alias.scope !11, !noalias !21
     %prompt = load %Stack, ptr %prompt_pointer, !alias.scope !11, !noalias !21
     %rest = load %Stack, ptr %rest_pointer, !alias.scope !11, !noalias !21
+    %cont = load %Neg, ptr %cont_pointer, !alias.scope !11, !noalias !21
 
     %promptStack_pointer = getelementptr %PromptValue, %Prompt %prompt, i64 0, i32 1
     %promptStack = load %Stack, ptr %promptStack_pointer, !alias.scope !13, !noalias !23
@@ -716,6 +733,7 @@ clearPrompt:
     br label %free
 
 free:
+    call void @eraseNegative(%Neg %cont)
     call void @eraseFrames(%StackPointer %stackPointer)
     call void @erasePrompt(%Prompt %prompt)
 
@@ -754,7 +772,7 @@ define private void @freeStack(%StackPointer %stackPointer) alwaysinline {
 
 ; RTS initialization
 
-define private tailcc void @topLevel(%Pos %val, %Stack %stack) {
+define private tailcc void @topLevel(ptr %obj, %Pos %val, %Stack %stack) {
     call %Stack @underflowStack(%Stack %stack)
     ret void
 }
@@ -769,23 +787,11 @@ define private void @topLevelEraser(%Environment %environment) {
     ret void
 }
 
+@topLevelVTable =  global [ 1 x ptr ] [ ptr @topLevel ]
+
 define private %Stack @withEmptyStack() {
     %stack = call %Stack @reset(%Stack null)
-
-    %stackStackPointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 1
-    %stackPointer = load %StackPointer, ptr %stackStackPointer, !alias.scope !11, !noalias !21
-
-    %returnAddressPointer = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 0
-    %sharerPointer = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 1
-    %eraserPointer = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 2
-
-    store %ReturnAddress @topLevel, ptr %returnAddressPointer, !alias.scope !12, !noalias !22
-    store %Sharer @topLevelSharer, ptr %sharerPointer, !alias.scope !12, !noalias !22
-    store %Eraser @topLevelEraser, ptr %eraserPointer, !alias.scope !12, !noalias !22
-
-    %stackPointer_2 = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 1
-    store %StackPointer %stackPointer_2, ptr %stackStackPointer, !alias.scope !11, !noalias !21
-
+    call void @setCont(%Neg { ptr @topLevelVTable, ptr null }, %Stack %stack)
     ret %Stack %stack
 }
 
@@ -796,10 +802,11 @@ define ccc void @resume_Int(%Stack %stack, %Int %integer) {
 }
 
 define ccc void @resume_Pos(%Stack %stack, %Pos %argument) {
-    %stackPointer = call ccc %StackPointer @stackDeallocate(%Stack %stack, i64 24)
-    %returnAddressPointer = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 0
-    %returnAddress = load %ReturnAddress, ptr %returnAddressPointer, !alias.scope !12, !noalias !22
-    tail call tailcc void %returnAddress(%Pos %argument, %Stack %stack)
+    %cont = call %Neg @getCont(%Stack %stack)
+    %returnAddress_pointer = extractvalue %Neg %cont, 0
+    %object = extractvalue %Neg %cont, 1
+    %returnAddress = load ptr, ptr %returnAddress_pointer
+    tail call tailcc void %returnAddress(%Object %object, %Pos %argument, %Stack %stack)
     ret void
 }
 


### PR DESCRIPTION
This mimics cps for benchmarking purposes.
Stack frames are allocated as closures, which are called when returning.
Stacks are still allocated as before, and used by `var`s.

cc @phischu 

<img width="1500" height="750" alt="benchmarks_normalized" src="https://github.com/user-attachments/assets/d79c7527-e4fb-4c6b-8348-7d9c1ba6c948" />

