### PR TITLE
JS runtime: Use classes for Ref and Arena instead of closures

### DIFF
--- a/libraries/js/effekt_runtime.js
+++ b/libraries/js/effekt_runtime.js
@@ -1,46 +1,60 @@
-// Complexity of state:
-//
-//  get: O(1)
-//  set: O(1)
-//  capture: O(1)
-//  restore: O(|write operations since capture|)
+
+// Sentinel: a node whose .value is Mem is the current root.
 const Mem = null
 
 // reusable buffer for rerooting
 const _rerootPath = []
 
-function Arena() {
-  const s = {
-    root: { value: Mem },
-    generation: 0,
-    fresh: (v) => {
-      const r = {
-        value: v,
-        generation: s.generation,
-        store: s,
-        set: (v) => {
-          const s = r.store
-          const r_gen = r.generation
-          const s_gen = s.generation
+/**
+ * A mutable reference inside an `Arena`.
+ */
+class Ref {
+  constructor(v, s) {
+    this.value = v;
+    this.generation = s.generation;
+    this.store = s;
+  }
 
-          if (r_gen == s_gen) {
-            r.value = v;
-          } else {
-            const root = { value: Mem }
-            // update store
-            s.root.value = { ref: r, value: r.value, generation: r_gen, root: root }
-            s.root = root
-            r.value = v
-            r.generation = s_gen
-          }
-        }
-      };
-      return r
-    },
-    // not implemented
-    newRegion: () => s
-  };
-  return s
+  set(v) {
+    const s     = this.store;
+    const r_gen = this.generation;
+    const s_gen = s.generation;
+    if (r_gen === s_gen) {
+      this.value = v;
+    } else {
+      const root   = { value: Mem };
+      s.root.value = { ref: this, value: this.value, generation: r_gen, root };
+
+      s.root          = root;
+      this.value      = v;
+      this.generation = s_gen;
+    }
+  }
+}
+
+/**
+ * A snapshottable arena: a bag of `Ref`s whose collective state can be
+ * captured in O(1) and restored in O(#writes since capture).
+ */
+class Arena {
+  constructor() {
+    this.root       = { value: Mem };
+    this.generation = 0;
+  }
+
+  /**
+   * Allocate a new reference with initial value v.
+   */
+  fresh(v) {
+    return new Ref(v, this);
+  }
+
+  /**
+   * Region support (not implemented!).
+   */
+  newRegion() {
+    return this;
+  }
 }
 
 function snapshot(s) {
@@ -87,7 +101,7 @@ function restore(store, snap) {
 let _prompt = 1;
 
 const TOPLEVEL_K = (x, ks) => { throw { computationIsDone: true, result: x } }
-const TOPLEVEL_KS = { prompt: 0, arena: Arena(), rest: null }
+const TOPLEVEL_KS = { stack: null, prompt: 0, arena: new Arena(), rest: null }
 
 function THUNK(f) {
   f.thunk = true
@@ -108,7 +122,7 @@ const RETURN = (x, ks) => ks.rest.stack(x, ks.rest)
 function RESET(prog, ks, k) {
   const prompt = _prompt++;
   const rest = { stack: k, prompt: ks.prompt, arena: ks.arena, rest: ks.rest }
-  return prog(prompt, { prompt, arena: Arena([]), rest }, RETURN)
+  return prog(prompt, { stack: null, prompt, arena: new Arena(), rest }, RETURN)
 }
 
 function SHIFT(p, body, ks, k) {


### PR DESCRIPTION
Previously, we:
1. for each `var`, we allocated a new closure for its own `set` method
2. for each `RESET`, we allocated two closures for their `fresh` and `arena` methods

... what if we, uh, didn't do that?

---

This could have been resolved both with prototypes and classes, but I chose to use classes since intent is important and classes are better recognisable by tooling. (and by JSDoc which is relevant for #1218)

The benchmark results are pretty strong: geomean is like a **4-5% speedup** on my machine, and _all benchmarks_ got faster, yet!

These are the biggest changes (ran with hyperfine, warmup = 5, N ≥ 10, inputs from the `config_js.txt` file), everything else is negligible as per the Welch t-test (using mean, stddev & number of runs; the tests where hyperfine complained about outliers are deemed as not significant):

Benchmark | main after #1330 | this PR | Δ
-- | -- | -- | --
mandelbrot | 177 ms | 108 ms | −38.8%
sieve | 150 ms | 134 ms | −10.6%
bounce | 120 ms | 114 ms | −5.2%
storage | 690 ms | 672 ms | −2.5%
product_early | 248 ms | 241 ms | −2.7%
triples | 375 ms | 366 ms | −2.4%
dyck_one | 404 ms | 385 ms | −4.8%
number_matrix | 357 ms | 344 ms | −3.7%
financial_format | 294 ms | 284 ms | −3.4%