### PR TITLE
Experiment: Lazy arena allocation on JS

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -24,6 +24,7 @@ object TransformerCps extends Transformer {
   val DEALLOC = Variable(JSName("DEALLOC"))
   val TRAMPOLINE = Variable(JSName("TRAMPOLINE"))
   val VAR = Variable(JSName("VAR"))
+  val REGION = Variable(JSName("REGION"))
 
   class RecursiveUsage(var jumped: Boolean)
   case class RecursiveDefInfo(id: Id, label: Id, vparams: List[Id], bparams: List[Id], ks: Id, k: Id, used: RecursiveUsage)
@@ -398,16 +399,17 @@ object TransformerCps extends Transformer {
       val args = vargs.map(toJS) ++ bargs.map(argumentToJS) ++ List(toJS(ks), toJS(k))
       pure(js.Return(MethodCall(toJS(callee), memberNameRef(method), args:_*)) :: Nil)
 
-    // const r = ks.arena.newRegion(); body
+    // const r = REGION(ks); body
     case cps.Stmt.Region(id, ks, body) =>
       Binding { k =>
-        js.Const(nameDef(id), js.MethodCall(js.Member(toJS(ks), JSName("arena")), JSName("newRegion"))) ::
+        js.Const(nameDef(id), js.Call(REGION, List(toJS(ks)))) ::
           toJS(body).run(k)
       }
 
     // const x = r.alloc(init); body
     case cps.Stmt.Alloc(id, init, region, body) =>
       Binding { k =>
+        // region should be non-null here as it's constructed via `REGION`
         js.Const(nameDef(id), js.MethodCall(nameRef(region), JSName("fresh"), toJS(init))) ::
           toJS(body).run(k)
       }

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -23,6 +23,7 @@ object TransformerCps extends Transformer {
   val THUNK = Variable(JSName("THUNK"))
   val DEALLOC = Variable(JSName("DEALLOC"))
   val TRAMPOLINE = Variable(JSName("TRAMPOLINE"))
+  val VAR = Variable(JSName("VAR"))
 
   class RecursiveUsage(var jumped: Boolean)
   case class RecursiveDefInfo(id: Id, label: Id, vparams: List[Id], bparams: List[Id], ks: Id, k: Id, used: RecursiveUsage)
@@ -411,10 +412,10 @@ object TransformerCps extends Transformer {
           toJS(body).run(k)
       }
 
-    // const x = ks.arena.fresh(1); body
+    // const x = VAR(1, ks); body
     case cps.Stmt.Var(id, init, ks, body) =>
       Binding { k =>
-        js.Const(nameDef(id), js.MethodCall(js.Member(toJS(ks), JSName("arena")), JSName("fresh"), toJS(init))) ::
+        js.Const(nameDef(id), js.Call(VAR, List(toJS(init), toJS(ks)))) ::
           toJS(body).run(k)
       }
 

--- a/libraries/js/effekt_runtime.js
+++ b/libraries/js/effekt_runtime.js
@@ -82,6 +82,9 @@ function restore(store, snap) {
   store.generation = snap.generation + 1
 }
 
+// Sentinel snapshot used for null arenas — restoring it is always a no-op.
+const NULL_SNAP = { root: { value: Mem }, generation: -1 }
+
 // Common Runtime
 // --------------
 let _prompt = 1;
@@ -92,6 +95,11 @@ const TOPLEVEL_KS = { prompt: 0, arena: Arena(), rest: null }
 function THUNK(f) {
   f.thunk = true
   return f
+}
+
+function VAR(init, ks) {
+  if (ks.arena === null) ks.arena = Arena()
+  return ks.arena.fresh(init)
 }
 
 function CAPTURE(body) {
@@ -108,7 +116,8 @@ const RETURN = (x, ks) => ks.rest.stack(x, ks.rest)
 function RESET(prog, ks, k) {
   const prompt = _prompt++;
   const rest = { stack: k, prompt: ks.prompt, arena: ks.arena, rest: ks.rest }
-  return prog(prompt, { prompt, arena: Arena([]), rest }, RETURN)
+  // arena: null; only materialised on first VAR in this handler scope
+  return prog(prompt, { stack: null, prompt, arena: null, rest }, RETURN)
 }
 
 function SHIFT(p, body, ks, k) {
@@ -119,14 +128,20 @@ function SHIFT(p, body, ks, k) {
 
   while (!!meta && meta.prompt !== p) {
     let store = meta.arena
-    cont = { stack: meta.stack, prompt: meta.prompt, arena: store, backup: snapshot(store), rest: cont }
+    // If this handler scope never called VAR, its arena is null.
+    // We still capture the frame, but use a no-op sentinel snapshot.
+    cont = { stack: meta.stack, prompt: meta.prompt, arena: store,
+             backup: store !== null ? snapshot(store) : NULL_SNAP,
+             rest: cont }
     meta = meta.rest
   }
   if (!meta) { throw `Prompt not found ${p}` }
 
   // package the prompt itself
   let store = meta.arena
-  cont = { stack: meta.stack, prompt: meta.prompt, arena: store, backup: snapshot(store), rest: cont }
+  cont = { stack: meta.stack, prompt: meta.prompt, arena: store,
+           backup: store !== null ? snapshot(store) : NULL_SNAP,
+           rest: cont }
   meta = meta.rest
 
   const k1 = meta.stack
@@ -139,7 +154,10 @@ function RESUME(cont, c, ks, k) {
   let meta = { stack: k, prompt: ks.prompt, arena: ks.arena, rest: ks.rest }
   let toRewind = cont
   while (!!toRewind) {
-    restore(toRewind.arena, toRewind.backup)
+    // arena is null when this handler scope never called VAR ~> skip restore entirely
+    if (toRewind.arena !== null) {
+      restore(toRewind.arena, toRewind.backup)
+    }
     meta = { stack: toRewind.stack, prompt: toRewind.prompt, arena: toRewind.arena, rest: meta }
     toRewind = toRewind.rest
   }

--- a/libraries/js/effekt_runtime.js
+++ b/libraries/js/effekt_runtime.js
@@ -102,6 +102,11 @@ function VAR(init, ks) {
   return ks.arena.fresh(init)
 }
 
+function REGION(ks) {
+  if (ks.arena === null) ks.arena = Arena()
+  return ks.arena.newRegion()
+}
+
 function CAPTURE(body) {
   return (ks, k) => {
     const res = body(x => TRAMPOLINE(() => k(x, ks)))


### PR DESCRIPTION
On LLVM, we allocate the arena for mutable variables only on demand. Why not do the same in JS?

---

The implementation is a bit ugly, I think this could be improved if we merge #1332 first.
I left in a lot of comments so that _I_ understand what the heck is going on, these should be tidied up a bit before merging.

Speedup in total is some 3-4% (geomean), everything that _sometimes_ allocates got much faster. 
Below are the significant changes (ran with hyperfine, warmup = 5, N ≥ 10, inputs from the `config_js.txt` file), everything else is negligible as per the Welch t-test (using mean, stddev & number of runs; the tests where hyperfine complained about outliers are deemed as not significant):

Benchmark | main after #1330 | this PR | Δ
-- | -- | -- | --
mandelbrot | 177.1 ms | 129.3 ms | **−27.0%**
parsing_dollars | 1234.4 ms | 1129.0 ms | −8.5%
triples | 374.9 ms | 357.2 ms | −4.7%
iterator | 115.4 ms | 112.3 ms | −2.7%
sieve | 150.2 ms | 146.6 ms | −2.4%
word_count_ascii | 576.8 ms | 563.1 ms | −2.4%
erase_unused | 242.0 ms | 237.3 ms | −1.9%
word_count_utf8 | 371.4 ms | 364.3 ms | −1.9%
nqueens | 199.0 ms | 196.8 ms | −1.1%
factorial_accumulator | 2354.2 ms | 2341.3 ms | −0.5%
nbody | 497.0 ms | 494.4 ms | −0.5%
storage | 689.6 ms | 695.5 ms | **+0.9%**