### PR TITLE
Code position effect

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -62,9 +62,6 @@ object Typer extends Phase[NameResolved, Typechecked] {
         Context in {
           Context.withUnificationScope {
             flowingInto(builtins.toplevelCaptures) {
-              // first, annotate root terms
-              Context.bind(builtins.Codepos.codepos, builtins.Codepos.codepos.toType)
-
               // We split the type-checking of definitions into "pre-check" and "check"
               // to allow mutually recursive defs
               tree.defs.foreach { d => precheckDef(d) }
@@ -1514,7 +1511,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
 
     // We add return effects last to have more information at this point to
     // concretize the effect.
-    effs = effs ++ Effects(retEffs.filterNot { p => p.typeConstructor == builtins.Codepos.interface })
+    effs = effs ++ Effects(retEffs.filterNot { p => p.name.name == "Codepos" })
 
     // annotate call node with inferred type arguments
     Context.annotateTypeArgs(call, typeArgs)

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -62,6 +62,9 @@ object Typer extends Phase[NameResolved, Typechecked] {
         Context in {
           Context.withUnificationScope {
             flowingInto(builtins.toplevelCaptures) {
+              // first, annotate root terms
+              Context.bind(builtins.Codepos.codepos, builtins.Codepos.codepos.toType)
+
               // We split the type-checking of definitions into "pre-check" and "check"
               // to allow mutually recursive defs
               tree.defs.foreach { d => precheckDef(d) }
@@ -1511,7 +1514,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
 
     // We add return effects last to have more information at this point to
     // concretize the effect.
-    effs = effs ++ Effects(retEffs)
+    effs = effs ++ Effects(retEffs.filterNot { p => p.typeConstructor == builtins.Codepos.interface })
 
     // annotate call node with inferred type arguments
     Context.annotateTypeArgs(call, typeArgs)

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -314,7 +314,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
             val allImplicit = capabilities.forall { c => !(explicitCapabilities contains c) }
             val used = effs.exists(e => e == effect)
 
-            if (allImplicit && !used)
+            if (allImplicit && !used && effect.name.name != "codepos")
               Context.warning(pp"Handling effect ${effect}, which seems not to be used by the program.")
         }
 

--- a/effekt/shared/src/main/scala/effekt/Typer.scala
+++ b/effekt/shared/src/main/scala/effekt/Typer.scala
@@ -1511,7 +1511,7 @@ object Typer extends Phase[NameResolved, Typechecked] {
 
     // We add return effects last to have more information at this point to
     // concretize the effect.
-    effs = effs ++ Effects(retEffs.filterNot { p => p.name.name == "Codepos" })
+    effs = effs ++ Effects(retEffs.filterNot { p => p.name.name == "codepos" })
 
     // annotate call node with inferred type arguments
     Context.annotateTypeArgs(call, typeArgs)

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -23,6 +23,7 @@ import effekt.source.SpannedOps._
 object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
   val phaseName = "explicit-capabilities"
+  val shouldForward = scala.util.DynamicVariable[Boolean](false)
 
   def run(input: Typechecked)(using C: Context) =
     val rewritten = C.timed(phaseName, input.source.name) { rewrite(input.tree) }
@@ -33,7 +34,9 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
     case f @ FunDef(id, tps, vps, bps, ret, cpt, body, doc, span) =>
       val capabilities = Context.annotation(Annotations.BoundCapabilities, f)
       val capParams = capabilities.map(definitionFor)
-      f.copy(bparams = (bps.unspan ++ capParams).spanned(bps.span), body = rewrite(body))
+      shouldForward.withValue(capParams.exists { p => p.id.name == "codepos" }) {
+        f.copy(bparams = (bps.unspan ++ capParams).spanned(bps.span), body = rewrite(body))
+      }
     case extDef @ ExternDef(capture, id, tparams, vparams, bparams, ret, bodies, doc, span) =>
       val rewrittenBodies = bodies.map { rewrite }
       extDef.copy(bodies = rewrittenBodies)
@@ -76,7 +79,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       // the remaining capabilities are provided as arguments
       val capabilityArgs = others.map{
-        case p if p.name.name == "codepos" =>
+        case p if p.name.name == "codepos" && !shouldForward.value =>
           codeposImplFor(span, p)
         case p => referenceToCapability(p)
       }
@@ -97,7 +100,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       val capabilities = Context.annotation(Annotations.CapabilityArguments, c)
       val capabilityArgs = capabilities.map{
-        case p if p.name.name == "codepos" =>
+        case p if p.name.name == "codepos" && !shouldForward.value =>
           codeposImplFor(span, p)
         case p => referenceToCapability(p)
       }
@@ -116,7 +119,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       val capabilities = Context.annotation(Annotations.CapabilityArguments, c)
       val capabilityArgs = capabilities.map{
-        case p if p.name.name == "codepos" =>
+        case p if p.name.name == "codepos" && !shouldForward.value =>
           codeposImplFor(span, p)
         case p =>
           referenceToCapability(p)

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -168,7 +168,10 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
     case b @ source.BlockLiteral(tps, vps, bps, body, span) =>
       val capabilities = Context.annotation(Annotations.BoundCapabilities, b)
       val capParams = capabilities.map(definitionFor)
-      source.BlockLiteral(tps, vps, bps ++ capParams, rewrite(body), span)
+
+      shouldForward.withValue(capabilities.exists { p => p.name.name == "codepos" }) {
+        source.BlockLiteral(tps, vps, bps ++ capParams, rewrite(body), span)
+      }
   }
 
   override def rewrite(body: ExternBody)(using context.Context): ExternBody =

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -34,7 +34,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
     case f @ FunDef(id, tps, vps, bps, ret, cpt, body, doc, span) =>
       val capabilities = Context.annotation(Annotations.BoundCapabilities, f)
       val capParams = capabilities.map(definitionFor)
-      shouldForward.withValue(capParams.exists { p => p.id.name == "codepos" }) {
+      shouldForward.withValue(shouldForward.value || capParams.exists { p => p.id.name == "codepos" }) {
         f.copy(bparams = (bps.unspan ++ capParams).spanned(bps.span), body = rewrite(body))
       }
     case extDef @ ExternDef(capture, id, tparams, vparams, bparams, ret, bodies, doc, span) =>
@@ -133,7 +133,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
     case h @ TryHandle(prog, handlers, span) =>
       val capabilities = Context.annotation(Annotations.BoundCapabilities, h)
 
-      val body = shouldForward.withValue(capabilities.exists { p => p.name.name == "codepos" }) {
+      val body = shouldForward.withValue(shouldForward.value || capabilities.exists { p => p.name.name == "codepos" }) {
         rewrite(prog)
       }
 
@@ -169,7 +169,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       val capabilities = Context.annotation(Annotations.BoundCapabilities, b)
       val capParams = capabilities.map(definitionFor)
 
-      shouldForward.withValue(capabilities.exists { p => p.name.name == "codepos" }) {
+      shouldForward.withValue(shouldForward.value || capabilities.exists { p => p.name.name == "codepos" }) {
         source.BlockLiteral(tps, vps, bps ++ capParams, rewrite(body), span)
       }
   }

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -39,20 +39,25 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       extDef.copy(bodies = rewrittenBodies)
   }
 
-  def codeposImplFor(span: Span)(using Context): Term = {
+  def codeposImplFor(span: Span, p: TrackedParam.BlockParam)(using Context): Term = {
     val pos = s"${span.source.name}:${span.from}-${span.to}"
     val sp = span.synthesized
+    val (ifce, op, tpe) = p.tpe match {
+      case Some(tpe @ BlockType.InterfaceType(ifce @ BlockTypeConstructor.Interface(name, Nil, List(op), decl), Nil)) =>
+        (ifce, op, tpe)
+      case _ => Context.abort("Could not find Codepos interface with compatible type")
+    }
     // now, synthesize an object that always returns the current position
-    val idIfce = IdRef(Nil, builtins.Codepos.interface.name.name, sp)
-    Context.annotate(Annotations.Symbol, idIfce, builtins.Codepos.interface)
-    val idOp = IdRef(Nil, builtins.Codepos.codepos.name.name, sp)
-    Context.annotate(Annotations.Symbol, idOp, builtins.Codepos.codepos)
+    val idIfce = IdRef(Nil, "Codepos", sp)
+    Context.annotate(Annotations.Symbol, idIfce, ifce)
+    val idOp = IdRef(Nil, op.name.name, sp)
+    Context.annotate(Annotations.Symbol, idOp, op)
     val impl = Implementation(TypeRef(idIfce, Many(Nil, sp), sp),
       List(OpClause(idOp,
         Nil, Nil, Nil, Some(Effectful(ValueTypeTree(builtins.TString, sp), source.Effects(Nil, sp), sp)),
         Stmt.Return(Term.Literal(pos, builtins.TString, sp), sp),
         IdDef("resume", sp), sp)), sp)
-    Context.annotate(Annotations.InferredBlockType, impl, builtins.Codepos.tpe)
+    Context.annotate(Annotations.InferredBlockType, impl, tpe)
     New(impl, sp)
   }
 
@@ -71,8 +76,8 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       // the remaining capabilities are provided as arguments
       val capabilityArgs = others.map{
-        case p if p.tpe.contains(builtins.Codepos.tpe) =>
-          codeposImplFor(span)
+        case p if p.name.name == "Codepos" =>
+          codeposImplFor(span, p)
         case p => referenceToCapability(p)
       }
 
@@ -92,8 +97,8 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       val capabilities = Context.annotation(Annotations.CapabilityArguments, c)
       val capabilityArgs = capabilities.map{
-        case p if p.tpe.contains(builtins.Codepos.tpe) =>
-          codeposImplFor(span)
+        case p if p.name.name == "Codepos" =>
+          codeposImplFor(span, p)
         case p => referenceToCapability(p)
       }
 
@@ -111,8 +116,8 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       val capabilities = Context.annotation(Annotations.CapabilityArguments, c)
       val capabilityArgs = capabilities.map{
-        case p if p.tpe.contains(builtins.Codepos.tpe) =>
-          codeposImplFor(span)
+        case p if p.name.name == "Codepos" =>
+          codeposImplFor(span, p)
         case p =>
           referenceToCapability(p)
       }

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -43,7 +43,9 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
   }
 
   def codeposImplFor(span: Span, p: TrackedParam.BlockParam)(using Context): Term = {
-    val pos = s"${span.source.name}:${span.from}-${span.to}"
+    val from = span.source.offsetToPosition(span.from)
+    val to = span.source.offsetToPosition(span.to)
+    val pos = s"${span.source.name}:${from.line}:${from.column}-${to.line}:${to.column}"
     val sp = span.synthesized
     val (ifce, op, tpe) = p.tpe match {
       case Some(tpe @ BlockType.InterfaceType(ifce @ BlockTypeConstructor.Interface(name, Nil, List(op), decl), Nil)) =>

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -131,9 +131,12 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       Call(receiver, typeArgs, valueArgs, blockArgs ++ capabilityArgs, span)
 
     case h @ TryHandle(prog, handlers, span) =>
-      val body = rewrite(prog)
-
       val capabilities = Context.annotation(Annotations.BoundCapabilities, h)
+
+      val body = shouldForward.withValue(capabilities.exists { p => p.name.name == "codepos" }) {
+        rewrite(prog)
+      }
+
 
       assert(capabilities.size == handlers.size)
 

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -45,10 +45,10 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
     val (ifce, op, tpe) = p.tpe match {
       case Some(tpe @ BlockType.InterfaceType(ifce @ BlockTypeConstructor.Interface(name, Nil, List(op), decl), Nil)) =>
         (ifce, op, tpe)
-      case _ => Context.abort("Could not find Codepos interface with compatible type")
+      case _ => Context.abort("Could not find codepos interface with compatible type")
     }
     // now, synthesize an object that always returns the current position
-    val idIfce = IdRef(Nil, "Codepos", sp)
+    val idIfce = IdRef(Nil, "codepos", sp)
     Context.annotate(Annotations.Symbol, idIfce, ifce)
     val idOp = IdRef(Nil, op.name.name, sp)
     Context.annotate(Annotations.Symbol, idOp, op)
@@ -76,7 +76,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       // the remaining capabilities are provided as arguments
       val capabilityArgs = others.map{
-        case p if p.name.name == "Codepos" =>
+        case p if p.name.name == "codepos" =>
           codeposImplFor(span, p)
         case p => referenceToCapability(p)
       }
@@ -97,7 +97,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       val capabilities = Context.annotation(Annotations.CapabilityArguments, c)
       val capabilityArgs = capabilities.map{
-        case p if p.name.name == "Codepos" =>
+        case p if p.name.name == "codepos" =>
           codeposImplFor(span, p)
         case p => referenceToCapability(p)
       }
@@ -116,7 +116,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
 
       val capabilities = Context.annotation(Annotations.CapabilityArguments, c)
       val capabilityArgs = capabilities.map{
-        case p if p.name.name == "Codepos" =>
+        case p if p.name.name == "codepos" =>
           codeposImplFor(span, p)
         case p =>
           referenceToCapability(p)

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -39,6 +39,23 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       extDef.copy(bodies = rewrittenBodies)
   }
 
+  def codeposImplFor(span: Span)(using Context): Term = {
+    val pos = s"${span.source.name}:${span.from}-${span.to}"
+    val sp = span.synthesized
+    // now, synthesize an object that always returns the current position
+    val idIfce = IdRef(Nil, builtins.Codepos.interface.name.name, sp)
+    Context.annotate(Annotations.Symbol, idIfce, builtins.Codepos.interface)
+    val idOp = IdRef(Nil, builtins.Codepos.codepos.name.name, sp)
+    Context.annotate(Annotations.Symbol, idOp, builtins.Codepos.codepos)
+    val impl = Implementation(TypeRef(idIfce, Many(Nil, sp), sp),
+      List(OpClause(idOp,
+        Nil, Nil, Nil, Some(Effectful(ValueTypeTree(builtins.TString, sp), source.Effects(Nil, sp), sp)),
+        Stmt.Return(Term.Literal(pos, builtins.TString, sp), sp),
+        IdDef("resume", sp), sp)), sp)
+    Context.annotate(Annotations.InferredBlockType, impl, builtins.Codepos.tpe)
+    New(impl, sp)
+  }
+
   override def expr(using Context) = {
 
     // an effect call -- translate to method call on the inferred capability
@@ -53,7 +70,11 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       val others = Context.annotation(Annotations.CapabilityArguments, c)
 
       // the remaining capabilities are provided as arguments
-      val capabilityArgs = others.map(referenceToCapability)
+      val capabilityArgs = others.map{
+        case p if p.tpe.contains(builtins.Codepos.tpe) =>
+          codeposImplFor(span)
+        case p => referenceToCapability(p)
+      }
 
       val typeArguments = Context.annotation(Annotations.TypeArguments, c)
       val typeArgs = typeArguments.map { e => ValueTypeTree(e, Span.missing) }
@@ -70,7 +91,11 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       val blockArgs = bargs.map { a => rewrite(a) }
 
       val capabilities = Context.annotation(Annotations.CapabilityArguments, c)
-      val capabilityArgs = capabilities.map(referenceToCapability)
+      val capabilityArgs = capabilities.map{
+        case p if p.tpe.contains(builtins.Codepos.tpe) =>
+          codeposImplFor(span)
+        case p => referenceToCapability(p)
+      }
 
       val typeArguments = Context.annotation(Annotations.TypeArguments, c)
       val typeArgs = typeArguments.map { e => ValueTypeTree(e, Span.missing) }
@@ -85,7 +110,12 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       val blockArgs = bargs.map { a => rewrite(a) }
 
       val capabilities = Context.annotation(Annotations.CapabilityArguments, c)
-      val capabilityArgs = capabilities.map(referenceToCapability)
+      val capabilityArgs = capabilities.map{
+        case p if p.tpe.contains(builtins.Codepos.tpe) =>
+          codeposImplFor(span)
+        case p =>
+          referenceToCapability(p)
+      }
 
       val typeArguments = Context.annotation(Annotations.TypeArguments, c)
       val typeArgs = typeArguments.map { e => ValueTypeTree(e, Span.missing) }

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -56,15 +56,6 @@ object builtins {
   val GlobalSymbol = Interface(Name.local("Global"), Nil, Nil, decl = NoSource)
   val GlobalCapability = ExternResource(name("global"), InterfaceType(GlobalSymbol, Nil), Resource(name("global")), decl = NoSource)
 
-  object Codepos {
-    val interface: Interface = Interface(Name.local("Codepos"), Nil, Nil, decl = NoSource)
-    val tpe: BlockType.InterfaceType = BlockType.InterfaceType(interface, Nil)
-    val codepos = Operation(name("codepos"), Nil, Nil, Nil, TString, Effects.Pure, interface, decl = NoSource)
-    val capture: Capture = Capture.Resource(Name.local("codepos"))
-    val param = BlockParam(Name.local("codeposCap"), Some(tpe), capture, decl = NoSource)
-    interface.operations = List(codepos)
-  }
-
   object TState {
     val S: TypeParam = TypeParam(Name.local("S"))
     val interface: Interface = Interface(Name.local("Ref"), List(S), Nil, decl = NoSource)
@@ -95,8 +86,7 @@ object builtins {
     "Any" -> TopSymbol,
     "Nothing" -> BottomSymbol,
     "IO" -> IOSymbol,
-    "Region" -> RegionSymbol,
-    "Codepos" -> Codepos.interface
+    "Region" -> RegionSymbol
   )
 
   val rootCaptures: Map[String, Capture] = Map(
@@ -105,15 +95,11 @@ object builtins {
     "global" -> GlobalCapability.capture
   )
 
-  val rootTerms: Map[String, Set[TermSymbol]] = Map(
-    "codepos" -> Set(Codepos.codepos)
-  )
-
   // captures which are allowed on the toplevel
   val toplevelCaptures: CaptureSet = CaptureSet() // CaptureSet(IOCapability.capture, GlobalCapability.capture)
 
   lazy val rootBindings: Bindings =
-    Bindings(rootTerms, rootTypes, rootCaptures, Map("effekt" -> Bindings(Map.empty, rootTypes, rootCaptures, Map.empty)))
+    Bindings(Map.empty, rootTypes, rootCaptures, Map("effekt" -> Bindings(Map.empty, rootTypes, rootCaptures, Map.empty)))
 
   // All built-in symbols that can occur in core programs
   val coreBuiltins: Map[String, symbols.Symbol] = {

--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -56,6 +56,15 @@ object builtins {
   val GlobalSymbol = Interface(Name.local("Global"), Nil, Nil, decl = NoSource)
   val GlobalCapability = ExternResource(name("global"), InterfaceType(GlobalSymbol, Nil), Resource(name("global")), decl = NoSource)
 
+  object Codepos {
+    val interface: Interface = Interface(Name.local("Codepos"), Nil, Nil, decl = NoSource)
+    val tpe: BlockType.InterfaceType = BlockType.InterfaceType(interface, Nil)
+    val codepos = Operation(name("codepos"), Nil, Nil, Nil, TString, Effects.Pure, interface, decl = NoSource)
+    val capture: Capture = Capture.Resource(Name.local("codepos"))
+    val param = BlockParam(Name.local("codeposCap"), Some(tpe), capture, decl = NoSource)
+    interface.operations = List(codepos)
+  }
+
   object TState {
     val S: TypeParam = TypeParam(Name.local("S"))
     val interface: Interface = Interface(Name.local("Ref"), List(S), Nil, decl = NoSource)
@@ -86,7 +95,8 @@ object builtins {
     "Any" -> TopSymbol,
     "Nothing" -> BottomSymbol,
     "IO" -> IOSymbol,
-    "Region" -> RegionSymbol
+    "Region" -> RegionSymbol,
+    "Codepos" -> Codepos.interface
   )
 
   val rootCaptures: Map[String, Capture] = Map(
@@ -95,11 +105,15 @@ object builtins {
     "global" -> GlobalCapability.capture
   )
 
+  val rootTerms: Map[String, Set[TermSymbol]] = Map(
+    "codepos" -> Set(Codepos.codepos)
+  )
+
   // captures which are allowed on the toplevel
   val toplevelCaptures: CaptureSet = CaptureSet() // CaptureSet(IOCapability.capture, GlobalCapability.capture)
 
   lazy val rootBindings: Bindings =
-    Bindings(Map.empty, rootTypes, rootCaptures, Map("effekt" -> Bindings(Map.empty, rootTypes, rootCaptures, Map.empty)))
+    Bindings(rootTerms, rootTypes, rootCaptures, Map("effekt" -> Bindings(Map.empty, rootTypes, rootCaptures, Map.empty)))
 
   // All built-in symbols that can occur in core programs
   val coreBuiltins: Map[String, symbols.Symbol] = {

--- a/effekt/shared/src/main/scala/effekt/typer/CapabilityScope.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/CapabilityScope.scala
@@ -19,8 +19,15 @@ case object GlobalCapabilityScope extends CapabilityScope {
   def parent: CapabilityScope = sys error "No parent"
   // If we try to find a capability for an effect that is known to be unhandled (that is no outer scope could
   // potentially handle it, then we raise an error.
-  def capabilityFor(tpe: symbols.InterfaceType)(using C: Context): symbols.BlockParam =
-    C.abort(pretty"Effect ${tpe} is not allowed in this context.")
+  def capabilityFor(tpe: symbols.InterfaceType)(using C: Context): symbols.BlockParam = {
+    if (tpe.typeConstructor.name.name == "codepos") {
+      symbols.BlockParam(symbols.Name.local("codepos"), Some(tpe),
+        symbols.Resource(symbols.Name.local("codepos")), decl = source.NoSource)
+    } else {
+      C.abort(pretty"Effect ${tpe} is not allowed in this context.")
+    }
+  }
+
   def relevantInScopeFor(tpe: symbols.InterfaceType)(using C: Context): Set[symbols.InterfaceType] = Set.empty
 }
 

--- a/effekt/shared/src/main/scala/effekt/typer/CapabilityScope.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/CapabilityScope.scala
@@ -19,13 +19,8 @@ case object GlobalCapabilityScope extends CapabilityScope {
   def parent: CapabilityScope = sys error "No parent"
   // If we try to find a capability for an effect that is known to be unhandled (that is no outer scope could
   // potentially handle it, then we raise an error.
-  def capabilityFor(tpe: symbols.InterfaceType)(using C: Context): symbols.BlockParam = {
-    if (tpe.typeConstructor == symbols.builtins.Codepos.interface) {
-      symbols.builtins.Codepos.param 
-    } else {
-      C.abort(pretty"Effect ${tpe} is not allowed in this context.")
-    }
-  }
+  def capabilityFor(tpe: symbols.InterfaceType)(using C: Context): symbols.BlockParam =
+    C.abort(pretty"Effect ${tpe} is not allowed in this context.")
   def relevantInScopeFor(tpe: symbols.InterfaceType)(using C: Context): Set[symbols.InterfaceType] = Set.empty
 }
 

--- a/effekt/shared/src/main/scala/effekt/typer/CapabilityScope.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/CapabilityScope.scala
@@ -19,8 +19,13 @@ case object GlobalCapabilityScope extends CapabilityScope {
   def parent: CapabilityScope = sys error "No parent"
   // If we try to find a capability for an effect that is known to be unhandled (that is no outer scope could
   // potentially handle it, then we raise an error.
-  def capabilityFor(tpe: symbols.InterfaceType)(using C: Context): symbols.BlockParam =
-    C.abort(pretty"Effect ${tpe} is not allowed in this context.")
+  def capabilityFor(tpe: symbols.InterfaceType)(using C: Context): symbols.BlockParam = {
+    if (tpe.typeConstructor == symbols.builtins.Codepos.interface) {
+      symbols.builtins.Codepos.param 
+    } else {
+      C.abort(pretty"Effect ${tpe} is not allowed in this context.")
+    }
+  }
   def relevantInScopeFor(tpe: symbols.InterfaceType)(using C: Context): Set[symbols.InterfaceType] = Set.empty
 }
 

--- a/examples/pos/codepos.check
+++ b/examples/pos/codepos.check
@@ -1,6 +1,6 @@
-examples/pos/codepos.effekt:222-236
-examples/pos/codepos.effekt:239-253
-examples/pos/codepos.effekt:256-275
-examples/pos/codepos.effekt:256-275
+examples/pos/codepos.effekt:13:3-13:17
+examples/pos/codepos.effekt:14:3-14:17
+examples/pos/codepos.effekt:15:3-15:22
+examples/pos/codepos.effekt:15:3-15:22
 X
-examples/pos/codepos.effekt:196-202
+examples/pos/codepos.effekt:10:3-10:9

--- a/examples/pos/codepos.check
+++ b/examples/pos/codepos.check
@@ -1,6 +1,6 @@
-examples/pos/codepos.effekt:82-96
-examples/pos/codepos.effekt:99-113
-examples/pos/codepos.effekt:197-216
-examples/pos/codepos.effekt:197-216
+examples/pos/codepos.effekt:222-236
+examples/pos/codepos.effekt:239-253
+examples/pos/codepos.effekt:256-275
+examples/pos/codepos.effekt:256-275
 X
 examples/pos/codepos.effekt:196-202

--- a/examples/pos/codepos.check
+++ b/examples/pos/codepos.check
@@ -2,3 +2,4 @@ examples/pos/codepos.effekt:82-96
 examples/pos/codepos.effekt:99-113
 examples/pos/codepos.effekt:197-216
 examples/pos/codepos.effekt:197-216
+END

--- a/examples/pos/codepos.check
+++ b/examples/pos/codepos.check
@@ -2,4 +2,5 @@ examples/pos/codepos.effekt:82-96
 examples/pos/codepos.effekt:99-113
 examples/pos/codepos.effekt:197-216
 examples/pos/codepos.effekt:197-216
-END
+X
+examples/pos/codepos.effekt:196-202

--- a/examples/pos/codepos.check
+++ b/examples/pos/codepos.check
@@ -1,2 +1,4 @@
 examples/pos/codepos.effekt:82-96
 examples/pos/codepos.effekt:99-113
+examples/pos/codepos.effekt:197-216
+examples/pos/codepos.effekt:197-216

--- a/examples/pos/codepos.check
+++ b/examples/pos/codepos.check
@@ -1,0 +1,2 @@
+examples/pos/codepos.effekt:82-96
+examples/pos/codepos.effekt:99-113

--- a/examples/pos/codepos.effekt
+++ b/examples/pos/codepos.effekt
@@ -6,9 +6,13 @@ def printCodeposTwice(): Unit / codepos = {
   printCodepos()
   printCodepos()
 }
+def atHere{ body: => Unit / codepos }: Unit = {
+  body()
+}
 def main() = {
   printCodepos()
   printCodepos()
   printCodeposTwice()
-  try { printCodepos() } with codepos { () => resume("END") }
+  try { printCodepos() } with codepos { () => resume("X") }
+  atHere{ printCodepos() }
 }

--- a/examples/pos/codepos.effekt
+++ b/examples/pos/codepos.effekt
@@ -1,7 +1,13 @@
 def printCodepos(): Unit / codepos = {
   println(do codepos())
 }
+
+def printCodeposTwice(): Unit / codepos = {
+  printCodepos()
+  printCodepos()
+}
 def main() = {
   printCodepos()
   printCodepos()
+  printCodeposTwice()
 }

--- a/examples/pos/codepos.effekt
+++ b/examples/pos/codepos.effekt
@@ -1,5 +1,5 @@
-def printCodepos(): Unit / Codepos = {
-  println(do Codepos())
+def printCodepos(): Unit / codepos = {
+  println(do codepos())
 }
 def main() = {
   printCodepos()

--- a/examples/pos/codepos.effekt
+++ b/examples/pos/codepos.effekt
@@ -10,4 +10,5 @@ def main() = {
   printCodepos()
   printCodepos()
   printCodeposTwice()
+  try { printCodepos() } with codepos { () => resume("END") }
 }

--- a/examples/pos/codepos.effekt
+++ b/examples/pos/codepos.effekt
@@ -1,0 +1,7 @@
+def printCodepos(): Unit / Codepos = {
+  println(do codepos())
+}
+def main() = {
+  printCodepos()
+  printCodepos()
+}

--- a/examples/pos/codepos.effekt
+++ b/examples/pos/codepos.effekt
@@ -1,5 +1,5 @@
 def printCodepos(): Unit / Codepos = {
-  println(do codepos())
+  println(do Codepos())
 }
 def main() = {
   printCodepos()

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -832,4 +832,8 @@ effect write(s: String): Unit
 
 effect splice[A](x: A): Unit
 
-effect Codepos(): String
+// Code positions
+// ==============
+// 
+/// Allows to get the code position of the callsite of the current function
+effect codepos(): String

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -832,4 +832,4 @@ effect write(s: String): Unit
 
 effect splice[A](x: A): Unit
 
-
+effect Codepos(): String


### PR DESCRIPTION
This allows functions (and effects etc) to require a `codepos` effect from their context, which is implicitly handled at each call site of such a function and returns a unique string for that call site.

This is (ab-)using effects for something similar to the implicit parameters in 
> Daan Leijen, Tim Whiting: Syntactic Implicit Parameters with Static Overloading