### PR TITLE
import io/promise to io tour (#1345)

### DIFF
--- a/examples/tour/IO.effekt.md
+++ b/examples/tour/IO.effekt.md
@@ -9,11 +9,13 @@ permalink: tour/io
 import io
 import io/filesystem
 import io/error
+import io/promise
 ```
 
 ```effekt:prelude:hide
 import io
 import io/error
+import io/promise
 ```
 
 ```effekt:hide


### PR DESCRIPTION
(Rewrite PR #1346, to fix issue #1345)
Added import `io/promise` to:
- the visible `effekt:ignore` import block (documentation for users)
- the hidden `effekt:prelude:hide` block (actual execution context)
