### PR TITLE
Fix position for unreachable case warning in irrefutable 'val-else' #1339

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -581,6 +581,45 @@ class ParserTests extends munit.FunSuite {
     assertEquals(parseStmts(source.content), expected)
   }
 
+  test("val-else") {
+    val (source, pos) =
+      raw"""val (left, right) = list else { return 0 }; return left
+           |    ↑↑   ↑ ↑    ↑↑  ↑   ↑     ↑ ↑      ↑↑ ↑ ↑      ↑   ↑
+           |""".sourceAndPositions
+    val expected = Return(Match(
+      List(Var(IdRef(List(), "list", Span(source, pos(6), pos(7))), Span(source, pos(6), pos(7)))),
+      List(
+        MatchClause(
+          TagPattern(
+            IdRef(List("effekt"), "Tuple2", Span(source, pos(0), pos(5), Synthesized)),
+            List(
+              AnyPattern(IdDef("left", Span(source, pos(1), pos(2))), Span(source, pos(1), pos(2))),
+              AnyPattern(IdDef("right", Span(source, pos(3), pos(4))), Span(source, pos(3), pos(4)))
+            ),
+            Span(source, pos(0), pos(5))
+          ),
+          List(),
+          Return(
+            Var(IdRef(List(), "left", Span(source, pos(14), pos(15))), Span(source, pos(14), pos(15))),
+            Span(source, pos(13), pos(15))
+          ),
+          Span(source, pos(0), pos(7))
+        )
+      ),
+      Some(
+        BlockStmt(
+          Return(
+            IntLit(0, Span(source, pos(10), pos(11))),
+            Span(source, pos(9), pos(11))
+          ),
+          Span(source, pos(8), pos(12))
+        )
+      ),
+      Span(source, 0, pos(12))
+    ), Span(source, 0, pos.last, Synthesized));
+    assertEquals(parseStmts(source.content), expected)
+  }
+
   test("Semicolon insertion") {
     parseStmts("f(); return x")
     parseStmts(

--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -576,7 +576,7 @@ class ParserTests extends munit.FunSuite {
         )
       ),
       None,
-      Span(source,0,pos(7), Synthesized)
+      Span(source,0,pos(7))
     ),Span(source,0,pos.last, Synthesized));
     assertEquals(parseStmts(source.content), expected)
   }

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -356,7 +356,7 @@ class Parser(tokens: Seq[Token], source: Source) {
       }
 
       val clause = MatchClause(pattern, guards, body, Span(source, pattern.span.from, body.span.to, Synthesized))
-      val matchExpr = Match(scrutinees, List(clause), fallback, withSpan.synthesized)
+      val matchExpr = Match(scrutinees, List(clause), fallback, withSpan)
       val matchBody = Return(matchExpr, withSpan.synthesized)
       BlockLiteral(Nil, vparams, Nil, matchBody, withSpan.synthesized)
     }
@@ -572,11 +572,11 @@ class Parser(tokens: Seq[Token], source: Source) {
           case p ~ guards =>
             // matches do not support doc comments, so we ignore `info`
             val sc = expr()
-            val endPos = pos()
             val default = when(`else`) { Some(stmt()) } { None }
+            val endPos = pos()
             val body = semi() ~> stmts(inBraces)
             val clause = MatchClause(p, guards, body, Span(source, p.span.from, sc.span.to))
-            val matching = Match(List(sc), List(clause), default, Span(source, startPos, endPos, Synthesized))
+            val matching = Match(List(sc), List(clause), default, Span(source, startPos, endPos))
             Return(matching, span().synthesized)
         }
 
@@ -1279,9 +1279,9 @@ class Parser(tokens: Seq[Token], source: Source) {
                     names.zip(argSpans).map{ (name, span) => Var(IdRef(Nil, name, span.synthesized), span.synthesized) },
                     cs.unspan,
                     None,
-                    span().synthesized
+                    span()
                   ), span().synthesized),
-                span().synthesized
+                span()
               )
 
           case _ =>

--- a/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
+++ b/effekt/shared/src/main/scala/effekt/typer/ExhaustivityChecker.scala
@@ -191,7 +191,11 @@ object ExhaustivityChecker {
     }
 
     def reportRedundant()(using C: ErrorReporter): Unit = redundant.foreach { p =>
-      C.at(p) { C.warning(pp"Unreachable case.") }
+      val target = p.pattern match {
+        case AnyPattern(_, _) | IgnorePattern(_) => p.body
+        case _ => p
+      }
+      C.at(target) { C.warning(pp"Unreachable case.") }
     }
 
     def report()(using C: ErrorReporter): Unit = {


### PR DESCRIPTION
### Problem
```scala
def main() = {
  val (a, b) = (1, 2) else panic("unreachable")
}
```
report `Unreachable case` at `main` instead of else (see #1339)

---

### Fix
- `Parser.scala`: Changed the `endPos` of the Match expression to get position after the `else` branch. Removed `Synthesized` flag from the span so `ErrorReporter` do not skips it.
- `Exhaustivity.scala`: Changed the reporter to anchor the error to the body of clauses instead of whole match pattern