### PR TITLE
Extern type representations

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -1345,7 +1345,24 @@ class ParserTests extends munit.FunSuite {
     val definition = parseToplevel(source.content)
 
     val extType = definition match {
-      case et@ExternType(id, tparams, doc, span) => et
+      case et@ExternType(id, tparams, body, doc, span) => et
+      case other =>
+        throw new IllegalArgumentException(s"Expected ExternType but got ${other.getClass.getSimpleName}")
+    }
+
+    assertEquals(extType.span, span)
+  }
+
+  test("Extern type definition with right hand side parses") {
+    val (source, span) =
+      raw"""extern type Foo = backend "ffiFoo"
+           |↑                                ↑
+           |""".sourceAndSpan
+
+    val definition = parseToplevel(source.content)
+
+    val extType = definition match {
+      case et@ExternType(id, tparams, body, doc, span) => et
       case other =>
         throw new IllegalArgumentException(s"Expected ExternType but got ${other.getClass.getSimpleName}")
     }
@@ -1435,8 +1452,8 @@ class ParserTests extends munit.FunSuite {
         throw new IllegalArgumentException(s"Expected ExternDef but got ${other.getClass.getSimpleName}")
     }
 
-    assertEquals(extDef.bodies.head.span, Span(source, pos(1), pos.last))
-    assertEquals(extDef.bodies.head.featureFlag.span, Span(source, pos(1), pos(2)))
+    assertEquals(extDef.bodies.unspan.head.span, Span(source, pos(1), pos.last))
+    assertEquals(extDef.bodies.unspan.head.featureFlag.span, Span(source, pos(1), pos(2)))
     assertEquals(extDef.span, Span(source, pos(0), pos.last))
   }
 

--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -1379,7 +1379,24 @@ class ParserTests extends munit.FunSuite {
     val definition = parseToplevel(source.content)
 
     val extIfc = definition match {
-      case ei@ExternInterface(id, tparams, doc, span) => ei
+      case ei@ExternInterface(id, tparams, bodies, doc, span) => ei
+      case other =>
+        throw new IllegalArgumentException(s"Expected ExternInterface but got ${other.getClass.getSimpleName}")
+    }
+
+    assertEquals(extIfc.span, span)
+  }
+
+  test("Extern interface definition with right-hand side parses with correct span") {
+    val (source, span) =
+      raw"""extern interface IFace[T] = be "foo"
+           |↑                                  ↑
+           |""".sourceAndSpan
+
+    val definition = parseToplevel(source.content)
+
+    val extIfc = definition match {
+      case ei@ExternInterface(id, tparams, bodies, doc, span) => ei
       case other =>
         throw new IllegalArgumentException(s"Expected ExternInterface but got ${other.getClass.getSimpleName}")
     }

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -214,7 +214,7 @@ object Namer extends Phase[Parsed, NameResolved] {
       }
       Context.define(id, sym)
 
-    case d @source.ExternType(id, tparams, doc, span) =>
+    case d @source.ExternType(id, tparams, body, doc, span) =>
       Context.requireToplevel("Extern type")
       Context.define(id, Context scoped {
         val tps = tparams map resolve
@@ -242,7 +242,7 @@ object Namer extends Phase[Parsed, NameResolved] {
           resolve(ret)
         }
 
-        ExternFunction(name, tps.unspan, vps.unspan, bps.unspan, tpe, eff, capt, bodies, d)
+        ExternFunction(name, tps.unspan, vps.unspan, bps.unspan, tpe, eff, capt, bodies.unspan, d)
       })
 
     case d @ source.ExternResource(id, tpe, doc, span) =>
@@ -435,7 +435,7 @@ object Namer extends Phase[Parsed, NameResolved] {
 
     case source.TypeDef(id, tparams, tpe, doc, span)     => ()
     case source.EffectDef(id, tparams, effs, doc, span)  => ()
-    case source.ExternType(id, tparams, doc, span)       => ()
+    case source.ExternType(id, tparams, body, doc, span) => ()
     case source.ExternInterface(id, tparams, doc, span)  => ()
     case source.ExternResource(id, tpe, doc, span)       => ()
     case source.ExternInclude(ff, path, _, _, doc, span) => ()

--- a/effekt/shared/src/main/scala/effekt/Namer.scala
+++ b/effekt/shared/src/main/scala/effekt/Namer.scala
@@ -221,7 +221,7 @@ object Namer extends Phase[Parsed, NameResolved] {
         ExternType(Context.nameFor(id), tps.unspan, d)
       })
 
-    case decl @ source.ExternInterface(id, tparams, doc, span) =>
+    case decl @ source.ExternInterface(id, tparams, bodies, doc, span) =>
       Context.requireToplevel("Extern interface")
       Context.define(id, Context scoped {
         val tps = tparams map resolve
@@ -436,7 +436,7 @@ object Namer extends Phase[Parsed, NameResolved] {
     case source.TypeDef(id, tparams, tpe, doc, span)     => ()
     case source.EffectDef(id, tparams, effs, doc, span)  => ()
     case source.ExternType(id, tparams, body, doc, span) => ()
-    case source.ExternInterface(id, tparams, doc, span)  => ()
+    case source.ExternInterface(id, tparams, bodies, doc, span) => ()
     case source.ExternResource(id, tpe, doc, span)       => ()
     case source.ExternInclude(ff, path, _, _, doc, span) => ()
   }

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -712,7 +712,9 @@ class Parser(tokens: Seq[Token], source: Source) {
       backtrack(featureFlag()).getOrElse(FeatureFlag.Default(span()))
 
   def externType(info: Info): Def =
-    ExternType(`type` ~> idDef(), maybeTypeParams(), info, span())
+    ExternType(`type` ~> idDef(), maybeTypeParams(),
+      maybeExternBodies(fail("extern type`s do not support Effekt right hand sides.")),
+      info, span())
   def externInterface(info: Info): Def =
     ExternInterface(`interface` ~> idDef(), maybeTypeParams().unspan, info, span())
   def externResource(info: Info): Def =
@@ -731,9 +733,9 @@ class Parser(tokens: Seq[Token], source: Source) {
     }
 
   def externFun(info: Info): Def =
-    (`def` ~> idDef() ~ params() ~ maybeCaptureSet() ~ (returnAnnotation() <~ `=`)) match {
+    (`def` ~> idDef() ~ params() ~ maybeCaptureSet() ~ returnAnnotation()) match {
       case id ~ (tps, vps, bps) ~ cpt ~ ret =>
-        val bodies = manyWhile(externBody{ stmts(inBraces = true)}, isExternBodyStart)
+        val bodies = maybeExternBodies{ stmts(inBraces = true) }
         val captures = cpt.getOrElse(defaultCapture(cpt.span.synthesized))
         ExternDef(id, tps, vps, bps, captures, ret, bodies, info, span())
     }
@@ -746,6 +748,13 @@ class Parser(tokens: Seq[Token], source: Source) {
           case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template().unspan, span())
         }) labelled "extern body (string or block)"
         case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template().unspan, span())
+      }
+
+  def maybeExternBodies[T](of: => T): Many[ExternBody[T]] =
+    nonterminal:
+      peek.kind match {
+        case `=` => `=` ~> Many(manyWhile(externBody(of), isExternBodyStart), span())
+        case _ => Many.empty(span())
       }
 
   private def isExternBodyStart: Boolean =

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -733,16 +733,16 @@ class Parser(tokens: Seq[Token], source: Source) {
   def externFun(info: Info): Def =
     (`def` ~> idDef() ~ params() ~ maybeCaptureSet() ~ (returnAnnotation() <~ `=`)) match {
       case id ~ (tps, vps, bps) ~ cpt ~ ret =>
-        val bodies = manyWhile(externBody(), isExternBodyStart)
+        val bodies = manyWhile(externBody{ stmts(inBraces = true)}, isExternBodyStart)
         val captures = cpt.getOrElse(defaultCapture(cpt.span.synthesized))
         ExternDef(id, tps, vps, bps, captures, ret, bodies, info, span())
     }
 
-  def externBody(): ExternBody =
+  def externBody[T](of: => T): ExternBody[T] =
     nonterminal:
       peek.kind match {
         case _: Ident => (peek(1).kind match {
-          case `{` => ExternBody.EffektExternBody(featureFlag(), `{` ~> stmts(inBraces = true) <~ `}`, span())
+          case `{` => ExternBody.EffektExternBody(featureFlag(), `{` ~> of <~ `}`, span())
           case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template().unspan, span())
         }) labelled "extern body (string or block)"
         case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template().unspan, span())

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -22,6 +22,7 @@ import scala.util.boundary.break
  */
 case class Template[+T](strings: List[String], args: List[T]) {
   def map[R](f: T => R): Template[R] = Template(strings, args.map(f))
+  def fill(f: T => String): String = util.intercalate(strings, args.map(f)).mkString
 }
 
 case class SpannedTemplate[T](strings: List[Spanned[String]], args: List[Spanned[T]]) {

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -717,7 +717,9 @@ class Parser(tokens: Seq[Token], source: Source) {
       maybeExternBodies(fail("extern type's do not support splices"))(fail("extern type`s do not support Effekt right hand sides.")),
       info, span())
   def externInterface(info: Info): Def =
-    ExternInterface(`interface` ~> idDef(), maybeTypeParams().unspan, info, span())
+    ExternInterface(`interface` ~> idDef(), maybeTypeParams().unspan,
+      maybeExternBodies(fail("extern type's do not support splices"))(fail("extern type`s do not support Effekt right hand sides.")),
+      info, span())
   def externResource(info: Info): Def =
     ExternResource(`resource` ~> idDef(), blockTypeAnnotation(), info, span())
   def externInclude(info: Info): Def =

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -713,7 +713,7 @@ class Parser(tokens: Seq[Token], source: Source) {
 
   def externType(info: Info): Def =
     ExternType(`type` ~> idDef(), maybeTypeParams(),
-      maybeExternBodies(fail("extern type`s do not support Effekt right hand sides.")),
+      maybeExternBodies(fail("extern type's do not support splices"))(fail("extern type`s do not support Effekt right hand sides.")),
       info, span())
   def externInterface(info: Info): Def =
     ExternInterface(`interface` ~> idDef(), maybeTypeParams().unspan, info, span())
@@ -735,25 +735,25 @@ class Parser(tokens: Seq[Token], source: Source) {
   def externFun(info: Info): Def =
     (`def` ~> idDef() ~ params() ~ maybeCaptureSet() ~ returnAnnotation()) match {
       case id ~ (tps, vps, bps) ~ cpt ~ ret =>
-        val bodies = maybeExternBodies{ stmts(inBraces = true) }
+        val bodies = maybeExternBodies{ expr() }{ stmts(inBraces = true) }
         val captures = cpt.getOrElse(defaultCapture(cpt.span.synthesized))
         ExternDef(id, tps, vps, bps, captures, ret, bodies, info, span())
     }
 
-  def externBody[T](of: => T): ExternBody[T] =
+  def externBody[S, E](splice: => S)(eff: => E): ExternBody[S, E] =
     nonterminal:
       peek.kind match {
         case _: Ident => (peek(1).kind match {
-          case `{` => ExternBody.EffektExternBody(featureFlag(), `{` ~> of <~ `}`, span())
-          case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template().unspan, span())
+          case `{` => ExternBody.EffektExternBody(featureFlag(), `{` ~> eff <~ `}`, span())
+          case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template(splice).unspan, span())
         }) labelled "extern body (string or block)"
-        case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template().unspan, span())
+        case _ => ExternBody.StringExternBody(maybeFeatureFlag(), template(splice).unspan, span())
       }
 
-  def maybeExternBodies[T](of: => T): Many[ExternBody[T]] =
+  def maybeExternBodies[S, E](splice: => S)(eff: => E): Many[ExternBody[S, E]] =
     nonterminal:
       peek.kind match {
-        case `=` => `=` ~> Many(manyWhile(externBody(of), isExternBodyStart), span())
+        case `=` => `=` ~> Many(manyWhile(externBody(splice)(eff), isExternBodyStart), span())
         case _ => Many.empty(span())
       }
 
@@ -763,12 +763,12 @@ class Parser(tokens: Seq[Token], source: Source) {
       case _                          => false
     }
 
-  def template(): SpannedTemplate[Term] =
+  def template[T](of: => T): SpannedTemplate[T] =
     nonterminal:
       // TODO handle case where the body is not a string, e.g.
       // Expected an extern definition, which can either be a single-line string (e.g., "x + y") or a multi-line string (e.g., """...""")
       val first = spanned(string())
-      val (exprs, strs) = manyWhile((`${` ~> spanned(expr()) <~ `}$`, spanned(string())), `${`).unzip
+      val (exprs, strs) = manyWhile((`${` ~> spanned(of) <~ `}$`, spanned(string())), `${`).unzip
       SpannedTemplate(first :: strs, exprs)
 
   def spanned[T](p: => T): Spanned[T] =
@@ -1429,7 +1429,7 @@ class Parser(tokens: Seq[Token], source: Source) {
   def templateString(): Term =
     nonterminal:
       val start = position
-      backtrack(idRef()) ~ template() match {
+      backtrack(idRef()) ~ template(expr()) match {
         // We do not need to apply any transformation if there are no splices _and_ no custom handler id is given
         case Maybe(None, _) ~ SpannedTemplate(str :: Nil, Nil) => StringLit(str.unspan, str.span)
         // s"a${x}b${y}" ~> s { do write("a"); do splice(x); do write("b"); do splice(y); return () }

--- a/effekt/shared/src/main/scala/effekt/core/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Parser.scala
@@ -310,8 +310,20 @@ class CoreParsers(names: Names) extends EffektLexers {
           ExternBody.StringExternBody(ff, templ)
         )
     }
-    | `extern` ~> `type` ~> id ~ typeParams.? ^^ {
-      case id ~ tparams => Extern.Data(id, tparams.getOrElse(Nil))
+    | `extern` ~> `type` ~> id ~ typeParams.? ~ (`=` ~> ident ~ externBody).? ^^ {
+      case id ~ tparams ~ Some("default" ~ body) =>
+        Extern.Data(id, tparams.getOrElse(Nil),
+          ExternBody.StringExternBody(source.FeatureFlag.Default(source.Span.missing),
+            Template(List(body), Nil)))
+      case id ~ tparams ~ Some(ff ~ body) =>
+        Extern.Data(id, tparams.getOrElse(Nil),
+          ExternBody.StringExternBody(source.FeatureFlag.NamedFeatureFlag(ff, source.Span.missing),
+            Template(List(body), Nil)))
+      case id ~ tparams ~ None =>
+        Extern.Data(id, tparams.getOrElse(Nil),
+          ExternBody.Unsupported(
+            effekt.util.messages.PlainTextError(
+              "Extern has no right-hand side", None, kiama.util.Severities.Error)))
     })
 
   lazy val externBodyTemplate: P[Template[Expr]] =

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -82,7 +82,10 @@ class PrettyPrinter(printDetails: Boolean, printInternalIds: Boolean = true) ext
         case ExternBody.Unsupported(err) => ???
       })
     case Extern.Include(ff, contents) => "extern" <+> toDoc(ff) <+> stringLiteral(contents)
-    case Extern.Data(id, tps) => "extern type" <+> toDoc(id) <> typeParamsDoc(tps)
+    case Extern.Data(id, tps, ExternBody.Unsupported(_)) => "extern type" <+> toDoc(id) <> typeParamsDoc(tps)
+    case Extern.Data(id, tps, ExternBody.StringExternBody(featureFlag, contents)) =>
+      "extern type" <+> toDoc(id) <> typeParamsDoc(tps)
+        <+> "=" <+> toDoc(featureFlag) <+> toDoc(contents)
   }
 
   def toDoc(ff: FeatureFlag): Doc = ff match {

--- a/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/core/PrettyPrinter.scala
@@ -86,6 +86,10 @@ class PrettyPrinter(printDetails: Boolean, printInternalIds: Boolean = true) ext
     case Extern.Data(id, tps, ExternBody.StringExternBody(featureFlag, contents)) =>
       "extern type" <+> toDoc(id) <> typeParamsDoc(tps)
         <+> "=" <+> toDoc(featureFlag) <+> toDoc(contents)
+    case Extern.Interface(id, tps, ExternBody.Unsupported(_)) => "extern interface" <+> toDoc(id) <> typeParamsDoc(tps)
+    case Extern.Interface(id, tps, ExternBody.StringExternBody(featureFlag, contents)) =>
+      "extern interface" <+> toDoc(id) <> typeParamsDoc(tps)
+        <+> "=" <+> toDoc(featureFlag) <+> toDoc(contents)
   }
 
   def toDoc(ff: FeatureFlag): Doc = ff match {

--- a/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
@@ -201,9 +201,9 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
     case Extern.Include(featureFlag, contents) => {
         Extern.Include(featureFlag, contents)
     }
-    case Extern.Data(id, tparams) => {
+    case Extern.Data(id, tparams, body) => {
       withBindings(tparams) {
-        Extern.Data(rewrite(id), tparams map rewrite)
+        Extern.Data(rewrite(id), tparams map rewrite, body)
       }
     }
   }
@@ -288,7 +288,7 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
       } ++ definitions.map(_.id) ++ externs.flatMap {
         case Extern.Def(id, _, _, _, _, _, _, _) => Some(id)
         case Extern.Include(_, _) => None
-        case Extern.Data(id, _) => Some(id)
+        case Extern.Data(id, _, _) => Some(id)
       }
     }
 }

--- a/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
@@ -206,6 +206,11 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
         Extern.Data(rewrite(id), tparams map rewrite, body)
       }
     }
+    case Extern.Interface(id, tparams, body) => {
+      withBindings(tparams) {
+        Extern.Interface(rewrite(id), tparams map rewrite, body)
+      }
+    }
   }
 
   override def rewrite(c: Constructor) = c match {
@@ -289,6 +294,7 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
         case Extern.Def(id, _, _, _, _, _, _, _) => Some(id)
         case Extern.Include(_, _) => None
         case Extern.Data(id, _, _) => Some(id)
+        case Extern.Interface(id, _, _) => Some(id)
       }
     }
 }

--- a/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
@@ -172,10 +172,10 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
       }
   }
 
-  override def rewrite(e: ExternBody) = e match {
+  override def rewrite(e: ExternBody[Expr]) = e match {
     case ExternBody.StringExternBody(featureFlag, contents) =>
       ExternBody.StringExternBody(featureFlag, rewriteTemplate(contents))
-    case ExternBody.Unsupported(err) => ???
+    case ExternBody.Unsupported(err) => ExternBody.Unsupported(err)
   }
 
   def rewriteTemplate(t: Template[Expr]) = t match {

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -108,9 +108,18 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     case d @ source.NamespaceDef(name, defs, doc, span) =>
       defs.flatMap(transformToplevel)
 
-    case e @ source.ExternType(id, _, _, _, _) =>
+    case e @ source.ExternType(id, _, bodies, _, _) =>
+      val tBody = bodies.unspan match {
+        case source.ExternBody.StringExternBody(ff, body, span) :: Nil =>
+          ExternBody.StringExternBody(ff, Template(body.strings, body.args.map { absurd => absurd }))
+        case source.ExternBody.Unsupported(err) :: Nil =>
+          ExternBody.Unsupported(err)
+        case _ =>
+          Context.abort("Externs should be resolved and desugared before core.Transformer")
+      }
+
       val sym@ExternType(name, tps, _) = e.symbol
-      List(Extern.Data(sym, tps))
+      List(Extern.Data(sym, tps, tBody))
 
     // For now we forget about all of the following definitions in core:
     case d: source.Def.Extern => Nil

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -92,7 +92,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       val sym@ExternFunction(name, tps, _, _, ret, effects, capt, _, _) = f.symbol
       assert(effects.isEmpty)
       val cps = bps.map(b => b.symbol.capture)
-      val tBody = bodies match {
+      val tBody = bodies.unspan match {
         case source.ExternBody.StringExternBody(ff, body, span) :: Nil =>
           ExternBody.StringExternBody(ff, Template(body.strings, body.args.map(transformAsExpr)))
         case source.ExternBody.Unsupported(err) :: Nil =>
@@ -108,7 +108,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
     case d @ source.NamespaceDef(name, defs, doc, span) =>
       defs.flatMap(transformToplevel)
 
-    case e @ source.ExternType(id, _, _, _) =>
+    case e @ source.ExternType(id, _, _, _, _) =>
       val sym@ExternType(name, tps, _) = e.symbol
       List(Extern.Data(sym, tps))
 

--- a/effekt/shared/src/main/scala/effekt/core/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Transformer.scala
@@ -858,7 +858,7 @@ object Transformer extends Phase[Typechecked, CoreTransformed] {
       // resolve the preferred body again and hope it's the same
       val body = ResolveExternDefs.findPreferred(bodies)
       body match {
-        case b: source.ExternBody.EffektExternBody => CallingConvention.Control
+        case b: source.ExternBody.EffektExternBody[_] => CallingConvention.Control
         case _ if f.capture.pure => CallingConvention.Pure
         case _ if f.capture.pureOrIO => CallingConvention.Direct
         case _ => CallingConvention.Control

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -132,14 +132,14 @@ case class Property(id: Id, tpe: BlockType) extends Tree
  * FFI external definitions
  */
 enum Extern extends Tree {
-  case Data(id: Id, tparams: List[Id], body: ExternBody)
-  case Def(id: Id, tparams: List[Id], cparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: ValueType, annotatedCapture: Captures, body: ExternBody)
+  case Data(id: Id, tparams: List[Id], body: ExternBody[Nothing])
+  case Def(id: Id, tparams: List[Id], cparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: ValueType, annotatedCapture: Captures, body: ExternBody[Expr])
   case Include(featureFlag: FeatureFlag, contents: String)
 }
-sealed trait ExternBody extends Tree
+sealed trait ExternBody[+T] extends Tree
 object ExternBody {
-  case class StringExternBody(featureFlag: FeatureFlag, contents: Template[Expr]) extends ExternBody
-  case class Unsupported(err: util.messages.EffektError) extends ExternBody {
+  case class StringExternBody[+T](featureFlag: FeatureFlag, contents: Template[T]) extends ExternBody[T]
+  case class Unsupported(err: util.messages.EffektError) extends ExternBody[Nothing] {
     def report(using E: ErrorReporter): Unit = E.report(err)
   }
 }
@@ -439,7 +439,7 @@ object Tree {
     def implementation(using Ctx): PartialFunction[Implementation, Res] = PartialFunction.empty
     def operation(using Ctx): PartialFunction[Operation, Res] = PartialFunction.empty
     def clause(using Ctx): PartialFunction[(Id, BlockLit), Res] = PartialFunction.empty
-    def externBody(using Ctx): PartialFunction[ExternBody, Res] = PartialFunction.empty
+    def externBody(using Ctx): PartialFunction[ExternBody[Expr], Res] = PartialFunction.empty
 
     /**
      * Hook that can be overridden to perform an action at every node in the tree
@@ -460,7 +460,10 @@ object Tree {
       if clause.isDefinedAt(matchClause) then clause.apply(matchClause) else matchClause match {
         case (id, lit) => query(lit)
     }
-    def query(b: ExternBody)(using Ctx): Res = structuralQuery(b, externBody)
+    def query(b: ExternBody[Expr])(using Ctx): Res = visit(b){
+      case ExternBody.StringExternBody(ff, body) => ???
+      case ExternBody.Unsupported(_) => empty
+    }
     def query(m: ModuleDecl)(using Ctx) = structuralQuery(m, PartialFunction.empty)
   }
 
@@ -481,8 +484,16 @@ object Tree {
     def rewrite(o: Operation): Operation = rewriteStructurally(o)
     def rewrite(p: ValueParam): ValueParam = rewriteStructurally(p)
     def rewrite(p: BlockParam): BlockParam = rewriteStructurally(p)
-    def rewrite(b: ExternBody): ExternBody= rewriteStructurally(b)
-    def rewrite(e: Extern): Extern= rewriteStructurally(e)
+    def rewrite(b: ExternBody[Expr]): ExternBody[Expr] = b match {
+      case ExternBody.StringExternBody(ff, Template(strings, args)) =>
+        ExternBody.StringExternBody(ff, Template(strings, args.map(rewrite)))
+      case e: ExternBody.Unsupported => e
+    }
+    def rewrite(e: Extern): Extern= e match {
+      case e @ (Extern.Data(_,_,_) | Extern.Include(_,_)) => e
+      case Extern.Def(id, tps, cps, vps, bps, ret, capts, body) =>
+        Extern.Def(id, tps, cps, vps, bps, ret, capts, rewrite(body))
+    }
     def rewrite(d: Declaration): Declaration = rewriteStructurally(d)
     def rewrite(c: Constructor): Constructor = rewriteStructurally(c)
     def rewrite(f: Field): Field = rewriteStructurally(f)
@@ -694,7 +705,7 @@ object Tree {
       case BlockParam(id, tpe, capt) => BlockParam(rewrite(id), rewrite(tpe), rewrite(capt))
     }
 
-    def rewrite(b: ExternBody): Trampoline[ExternBody] = b match {
+    def rewrite(b: ExternBody[Expr]): Trampoline[ExternBody[Expr]] = b match {
       case ExternBody.StringExternBody(featureFlag, Template(strings, args)) =>
         all(args, rewrite).map { args2 => ExternBody.StringExternBody(featureFlag, Template(strings, args2)) }
       case ExternBody.Unsupported(err) => done(b)
@@ -788,7 +799,7 @@ object Tree {
     def rewrite(o: Operation)(using Ctx): Operation = rewriteStructurally(o)
     def rewrite(p: ValueParam)(using Ctx): ValueParam = rewriteStructurally(p)
     def rewrite(p: BlockParam)(using Ctx): BlockParam = rewriteStructurally(p)
-    def rewrite(b: ExternBody)(using Ctx): ExternBody= rewrite(b)
+    def rewrite(b: ExternBody[Expr])(using Ctx): ExternBody[Expr] = rewrite(b)
 
     def rewrite(b: BlockLit)(using Ctx): BlockLit = if block.isDefinedAt(b) then block(b).asInstanceOf else b match {
       case BlockLit(tparams, cparams, vparams, bparams, body) =>

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -133,6 +133,7 @@ case class Property(id: Id, tpe: BlockType) extends Tree
  */
 enum Extern extends Tree {
   case Data(id: Id, tparams: List[Id], body: ExternBody[Nothing])
+  case Interface(id: Id, tparams: List[Id], body: ExternBody[Nothing])
   case Def(id: Id, tparams: List[Id], cparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: ValueType, annotatedCapture: Captures, body: ExternBody[Expr])
   case Include(featureFlag: FeatureFlag, contents: String)
 }
@@ -490,7 +491,7 @@ object Tree {
       case e: ExternBody.Unsupported => e
     }
     def rewrite(e: Extern): Extern= e match {
-      case e @ (Extern.Data(_,_,_) | Extern.Include(_,_)) => e
+      case e @ (Extern.Data(_,_,_) | Extern.Include(_,_) | Extern.Interface(_,_,_)) => e
       case Extern.Def(id, tps, cps, vps, bps, ret, capts, body) =>
         Extern.Def(id, tps, cps, vps, bps, ret, capts, rewrite(body))
     }
@@ -722,6 +723,7 @@ object Tree {
           rewrite(ret), rewrite(annotatedCapture), rewrite(body).run())
       case Extern.Include(featureFlag, contents) => e
       case Extern.Data(id, tparams, body) => Extern.Data(rewrite(id), tparams.map(rewrite), body)
+      case Extern.Interface(id, tparams, body) => Extern.Interface(rewrite(id), tparams.map(rewrite), body)
     }
 
     def rewrite(d: Declaration): Declaration = d match {

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -132,7 +132,7 @@ case class Property(id: Id, tpe: BlockType) extends Tree
  * FFI external definitions
  */
 enum Extern extends Tree {
-  case Data(id: Id, tparams: List[Id])
+  case Data(id: Id, tparams: List[Id], body: ExternBody)
   case Def(id: Id, tparams: List[Id], cparams: List[Id], vparams: List[ValueParam], bparams: List[BlockParam], ret: ValueType, annotatedCapture: Captures, body: ExternBody)
   case Include(featureFlag: FeatureFlag, contents: String)
 }
@@ -710,7 +710,7 @@ object Tree {
         Extern.Def(rewrite(id), tparams.map(rewrite), cparams.map(rewrite), vparams.map(rewrite), bparams.map(rewrite),
           rewrite(ret), rewrite(annotatedCapture), rewrite(body).run())
       case Extern.Include(featureFlag, contents) => e
-      case Extern.Data(id, tparams) => Extern.Data(rewrite(id), tparams.map(rewrite))
+      case Extern.Data(id, tparams, body) => Extern.Data(rewrite(id), tparams.map(rewrite), body)
     }
 
     def rewrite(d: Declaration): Declaration = d match {

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -379,6 +379,7 @@ object Type {
 
         case Extern.Include(featureFlag, contents) => ()
         case Extern.Data(id, tparams, body) => ()
+        case Extern.Interface(id, tparams, body) => ()
       }
   }
 

--- a/effekt/shared/src/main/scala/effekt/core/Type.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Type.scala
@@ -378,7 +378,7 @@ object Type {
           wellformed(free)
 
         case Extern.Include(featureFlag, contents) => ()
-        case Extern.Data(id, tparams) => ()
+        case Extern.Data(id, tparams, body) => ()
       }
   }
 

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
@@ -52,7 +52,6 @@ class Deadcode(reachable: Map[Id, Usage])
           // We need to keep "show", "showBuiltin" & "infixPlusPlus" for generating show definitions (see #1123)
           case e: Extern.Def if used(e.id) || List("show", "showBuiltin", "infixPlusPlus").contains(e.id.name.name) => e
           case e: Extern.Include => e
-          // We currently do not have usage information on extern types, so we have to keep all of them
           case e: Extern.Data if used(e.id) => e
         },
         // drop unreachable definitions

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
@@ -43,15 +43,17 @@ class Deadcode(reachable: Map[Id, Usage])
   override def rewrite(m: ModuleDecl): ModuleDecl = m match {
     case ModuleDecl(path, includes, declarations, externs, definitions, exports) =>
       ModuleDecl(path, includes,
-        // drop unused constructors and operations
-        declarations.map(rewrite),
+        // drop unused constructors and operations, and types
+        declarations.collect{
+          case d if used(d.id) => rewrite(d)
+        },
         // drop unreachable externs
         m.externs.collect {
           // We need to keep "show", "showBuiltin" & "infixPlusPlus" for generating show definitions (see #1123)
           case e: Extern.Def if used(e.id) || List("show", "showBuiltin", "infixPlusPlus").contains(e.id.name.name) => e
           case e: Extern.Include => e
           // We currently do not have usage information on extern types, so we have to keep all of them
-          case e: Extern.Data => e
+          case e: Extern.Data if used(e.id) => e
         },
         // drop unreachable definitions
         definitions.collect { case d if used(d.id) => rewrite(d) },

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
@@ -53,6 +53,7 @@ class Deadcode(reachable: Map[Id, Usage])
           case e: Extern.Def if used(e.id) || List("show", "showBuiltin", "infixPlusPlus").contains(e.id.name.name) => e
           case e: Extern.Include => e
           case e: Extern.Data if used(e.id) => e
+          case e: Extern.Interface if used(e.id) => e
         },
         // drop unreachable definitions
         definitions.collect { case d if used(d.id) => rewrite(d) },

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
@@ -12,12 +12,12 @@ class Reachable(
 ) {
 
   // TODO we could use [[Binding]] here.
-  type Definitions = Map[Id, Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration | (Property, Declaration.Interface)]
+  type Definitions = Map[Id, Block | Expr | Stmt | Extern.Def | Declaration | (Property, Declaration.Interface)]
 
   private def update(id: Id, u: Usage): Unit = reachable = reachable.updated(id, u)
   private def usage(id: Id): Usage = reachable.getOrElse(id, Usage.Never)
 
-  def processDefinition(id: Id, d: Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration | (Property, Declaration.Interface))(using defs: Definitions): Unit = {
+  def processDefinition(id: Id, d: Block | Expr | Stmt | Extern.Def | Declaration | (Property, Declaration.Interface))(using defs: Definitions): Unit = {
     if stack.contains(id) then { update(id, Usage.Recursive); return }
 
     seen = seen + id
@@ -34,7 +34,6 @@ class Reachable(
       case expr: Expr => process(expr)
       case binding: Stmt => process(binding)
       case extern: Extern.Def => process(extern)
-      case extern: Extern.Data => process(extern)
       case decl: Declaration => process(decl)
       case (p: Property, d: Declaration.Interface) =>
         process(p.tpe); process(d.id)
@@ -81,7 +80,6 @@ class Reachable(
   def process(p: ValueParam)(using defs: Definitions): Unit = process(p.tpe)
   def process(p: BlockParam)(using defs: Definitions): Unit = process(p.tpe)
 
-  def process(e: Extern.Data)(using defs: Definitions): Unit = ()
   def process(d: Declaration)(using defs: Definitions): Unit =
     d match {
       case Declaration.Data(id, tparams, constructors) =>
@@ -189,7 +187,7 @@ class Reachable(
 
 object Reachable {
   def apply(entrypoints: Set[Id], m: ModuleDecl): Map[Id, Usage] = {
-    val definitions: Map[Id, Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration | (Property, Declaration.Interface)] = (m.definitions.map {
+    val definitions: Map[Id, Block | Expr | Stmt | Extern.Def | Declaration | (Property, Declaration.Interface)] = (m.definitions.map {
       case Toplevel.Def(id, block) => id -> block
       case Toplevel.Val(id, binding) => id -> binding
     } ++ m.declarations.flatMap { d =>
@@ -201,7 +199,6 @@ object Reachable {
     }
       ++ m.externs.collect {
       case d @ Extern.Def(id, _, _, _, _, _, _, _) => id -> d
-      case d @ Extern.Data(id, tps, body) => d.id -> d
     }).toMap
     val initialUsage = entrypoints.map { id => id -> Usage.Recursive }.toMap
     val analysis = new Reachable(initialUsage, Nil, Set.empty)

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
@@ -109,7 +109,7 @@ class Reachable(
         vparams.foreach(process)
         bparams.foreach(process)
         process(result)
-      case BlockType.Interface(name, targs) => targs.foreach(process)
+      case BlockType.Interface(name, targs) => process(name); targs.foreach(process)
     }
 
   def process(s: Stmt)(using defs: Definitions): Unit = s match {

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
@@ -12,12 +12,12 @@ class Reachable(
 ) {
 
   // TODO we could use [[Binding]] here.
-  type Definitions = Map[Id, Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration]
+  type Definitions = Map[Id, Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration | (Property, Declaration.Interface)]
 
   private def update(id: Id, u: Usage): Unit = reachable = reachable.updated(id, u)
   private def usage(id: Id): Usage = reachable.getOrElse(id, Usage.Never)
 
-  def processDefinition(id: Id, d: Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration)(using defs: Definitions): Unit = {
+  def processDefinition(id: Id, d: Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration | (Property, Declaration.Interface))(using defs: Definitions): Unit = {
     if stack.contains(id) then { update(id, Usage.Recursive); return }
 
     seen = seen + id
@@ -36,6 +36,8 @@ class Reachable(
       case extern: Extern.Def => process(extern)
       case extern: Extern.Data => process(extern)
       case decl: Declaration => process(decl)
+      case (p: Property, d: Declaration.Interface) =>
+        process(p.tpe); process(d.id)
     }
   }
 
@@ -135,6 +137,7 @@ class Reachable(
       bargs.foreach(process)
     case Stmt.Invoke(callee, method, methodTpe, targs, vargs, bargs) =>
       process(callee)
+      process(callee.tpe)
       process(method)
       process(methodTpe)
       targs.foreach(process)
@@ -186,10 +189,16 @@ class Reachable(
 
 object Reachable {
   def apply(entrypoints: Set[Id], m: ModuleDecl): Map[Id, Usage] = {
-    val definitions: Map[Id, Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration] = (m.definitions.map {
+    val definitions: Map[Id, Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration | (Property, Declaration.Interface)] = (m.definitions.map {
       case Toplevel.Def(id, block) => id -> block
       case Toplevel.Val(id, binding) => id -> binding
-    } ++ m.declarations.map { d => d.id -> d }
+    } ++ m.declarations.flatMap { d =>
+      (d.id -> d) :: (d match {
+        case Declaration.Data(id, tparams, constructors) => Nil
+        case d@Declaration.Interface(id, tparams, properties) =>
+          properties.map { p => p.id -> (p, d) }
+      })
+    }
       ++ m.externs.collect {
       case d @ Extern.Def(id, _, _, _, _, _, _, _) => id -> d
       case d @ Extern.Data(id, tps, body) => d.id -> d

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Reachable.scala
@@ -4,8 +4,6 @@ package optimizer
 
 /**
  * A simple reachability analysis.
- *
- * TODO reachability should also process externs since they now contain splices.
  */
 class Reachable(
   var reachable: Map[Id, Usage],
@@ -14,12 +12,12 @@ class Reachable(
 ) {
 
   // TODO we could use [[Binding]] here.
-  type Definitions = Map[Id, Block | Expr | Stmt]
+  type Definitions = Map[Id, Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration]
 
   private def update(id: Id, u: Usage): Unit = reachable = reachable.updated(id, u)
   private def usage(id: Id): Usage = reachable.getOrElse(id, Usage.Never)
 
-  def processDefinition(id: Id, d: Block | Expr | Stmt)(using defs: Definitions): Unit = {
+  def processDefinition(id: Id, d: Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration)(using defs: Definitions): Unit = {
     if stack.contains(id) then { update(id, Usage.Recursive); return }
 
     seen = seen + id
@@ -35,6 +33,9 @@ class Reachable(
 
       case expr: Expr => process(expr)
       case binding: Stmt => process(binding)
+      case extern: Extern.Def => process(extern)
+      case extern: Extern.Data => process(extern)
+      case decl: Declaration => process(decl)
     }
   }
 
@@ -54,10 +55,59 @@ class Reachable(
 
   def process(b: Block)(using defs: Definitions): Unit =
     b match {
-      case Block.BlockVar(id, annotatedTpe, annotatedCapt) => process(id)
-      case Block.BlockLit(tparams, cparams, vparams, bparams, body) => process(body)
+      case Block.BlockVar(id, annotatedTpe, annotatedCapt) =>
+        process(annotatedTpe); process(id)
+      case Block.BlockLit(tparams, cparams, vparams, bparams, body) =>
+        vparams.foreach(process); bparams.foreach(process); process(body)
       case Block.Unbox(expr) => process(expr)
       case Block.New(impl) => process(impl)
+    }
+
+  def process(e: Extern.Def)(using defs: Definitions): Unit =
+    e match {
+      case Extern.Def(_, tps, cps, vps, bps, ret, capts, body) =>
+        vps.foreach(process)
+        bps.foreach(process)
+        process(ret)
+        body match {
+          case ExternBody.StringExternBody(_, Template(_, args)) =>
+            args.foreach(process)
+          case effekt.core.ExternBody.Unsupported(_) => ()
+        }
+    }
+
+  def process(p: ValueParam)(using defs: Definitions): Unit = process(p.tpe)
+  def process(p: BlockParam)(using defs: Definitions): Unit = process(p.tpe)
+
+  def process(e: Extern.Data)(using defs: Definitions): Unit = ()
+  def process(d: Declaration)(using defs: Definitions): Unit =
+    d match {
+      case Declaration.Data(id, tparams, constructors) =>
+        constructors.foreach {
+          case Constructor(id, tparams, fields) =>
+            fields.foreach {
+              case Field(id, tpe) => process(tpe)
+            }
+        }
+      case Declaration.Interface(id, tparams, properties) =>
+        properties.foreach {
+          case Property(id, tpe) => process(tpe)
+        }
+    }
+
+  def process(t: ValueType)(using defs: Definitions): Unit =
+    t match {
+      case ValueType.Var(name) => ()
+      case ValueType.Data(name, targs) => process(name); targs.foreach(process)
+      case ValueType.Boxed(tpe, capt) => process(tpe)
+    }
+  def process(t: BlockType)(using defs: Definitions): Unit =
+    t match {
+      case BlockType.Function(tparams, cparams, vparams, bparams, result) =>
+        vparams.foreach(process)
+        bparams.foreach(process)
+        process(result)
+      case BlockType.Interface(name, targs) => targs.foreach(process)
     }
 
   def process(s: Stmt)(using defs: Definitions): Unit = s match {
@@ -70,6 +120,7 @@ class Reachable(
       process(body)(using defs + (id -> binding))
     case Stmt.ImpureApp(id, callee, targs, vargs, bargs, body) =>
       process(callee)
+      targs.foreach(process)
       vargs.foreach(process)
       bargs.foreach(process)
       // TODO what to do here?
@@ -79,16 +130,20 @@ class Reachable(
     case Stmt.Val(id, binding, body) => process(binding); process(body)
     case Stmt.App(callee, targs, vargs, bargs) =>
       process(callee)
+      targs.foreach(process)
       vargs.foreach(process)
       bargs.foreach(process)
     case Stmt.Invoke(callee, method, methodTpe, targs, vargs, bargs) =>
       process(callee)
       process(method)
+      process(methodTpe)
+      targs.foreach(process)
       vargs.foreach(process)
       bargs.foreach(process)
     case Stmt.If(cond, thn, els) => process(cond); process(thn); process(els)
     case Stmt.Match(scrutinee, tpe, clauses, default) =>
       process(scrutinee)
+      process(tpe)
       clauses.foreach { case (id, value) => process(value) }
       default.foreach(process)
     case Stmt.Alloc(id, init, region, body) =>
@@ -98,33 +153,47 @@ class Reachable(
     case Stmt.Var(ref, init, capture, body) =>
       process(init)
       process(body)
-    case Stmt.Get(ref, capt, tpe, id, body) => process(ref); process(body)
-    case Stmt.Put(ref, tpe, value, body) => process(ref); process(value); process(body)
+    case Stmt.Get(ref, tpe, id, capt, body) =>
+      process(ref); process(tpe); process(body)
+    case Stmt.Put(ref, capt, value, body) =>
+      process(ref); process(value); process(body)
     case Stmt.Reset(body) => process(body)
-    case Stmt.Shift(prompt, k, body) => process(prompt); process(body)
+    case Stmt.Shift(prompt, k, body) => process(prompt); process(k); process(body)
     case Stmt.Resume(k, body) => process(k); process(body)
     case Stmt.Region(body) => process(body)
-    case Stmt.Hole(tpe, span) => ()
+    case Stmt.Hole(tpe, span) => process(tpe)
   }
 
   def process(e: Expr)(using defs: Definitions): Unit = e match {
-    case Expr.ValueVar(id, annotatedType) => process(id)
-    case Expr.Literal(value, annotatedType) => ()
-    case Expr.PureApp(b, targs, vargs) => process(b); vargs.foreach(process)
-    case Expr.Make(data, tag, targs, vargs) => process(tag); vargs.foreach(process)
+    case Expr.ValueVar(id, annotatedType) => process(id); process(annotatedType)
+    case Expr.Literal(value, annotatedType) => process(annotatedType)
+    case Expr.PureApp(b, targs, vargs) => process(b); targs.foreach(process); vargs.foreach(process)
+    case Expr.Make(data, tag, targs, vargs) =>
+      process(data); process(tag); targs.foreach(process); vargs.foreach(process)
     case Expr.Box(b, annotatedCapture) => process(b)
   }
 
-  def process(i: Implementation)(using defs: Definitions): Unit =
-    i.operations.foreach { op => process(op.body) }
+  def process(i: Implementation)(using defs: Definitions): Unit = {
+    process(i.interface)
+    i.operations.foreach {
+      case Operation(name, tparams, cparams, vparams, bparams, body) =>
+        vparams.foreach(process)
+        bparams.foreach(process)
+        process(body)
+    }
+  }
 }
 
 object Reachable {
   def apply(entrypoints: Set[Id], m: ModuleDecl): Map[Id, Usage] = {
-    val definitions: Map[Id, Block | Expr | Stmt] = m.definitions.map {
+    val definitions: Map[Id, Block | Expr | Stmt | Extern.Def | Extern.Data | Declaration] = (m.definitions.map {
       case Toplevel.Def(id, block) => id -> block
       case Toplevel.Val(id, binding) => id -> binding
-    }.toMap
+    } ++ m.declarations.map { d => d.id -> d }
+      ++ m.externs.collect {
+      case d @ Extern.Def(id, _, _, _, _, _, _, _) => id -> d
+      case d @ Extern.Data(id, tps, body) => d.id -> d
+    }).toMap
     val initialUsage = entrypoints.map { id => id -> Usage.Recursive }.toMap
     val analysis = new Reachable(initialUsage, Nil, Set.empty)
 

--- a/effekt/shared/src/main/scala/effekt/cps/Contify.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Contify.scala
@@ -23,6 +23,8 @@ object Contify {
       Extern.Def(id, vparams, bparams, async, rewrite(body))
     case Extern.Data(id, tps, body) =>
       Extern.Data(id, tps, body)
+    case Extern.Interface(id, tps, body) =>
+      Extern.Interface(id, tps, body)
     case include: Extern.Include => include
   }
 

--- a/effekt/shared/src/main/scala/effekt/cps/Contify.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Contify.scala
@@ -21,10 +21,12 @@ object Contify {
   def rewrite(extern: Extern): Extern = extern match {
     case Extern.Def(id, vparams, bparams, async, body) =>
       Extern.Def(id, vparams, bparams, async, rewrite(body))
+    case Extern.Data(id, tps, body) =>
+      Extern.Data(id, tps, body)
     case include: Extern.Include => include
   }
 
-  def rewrite(body: ExternBody): ExternBody = body match {
+  def rewrite(body: ExternBody[Expr]): ExternBody[Expr] = body match {
     case ExternBody.StringExternBody(ff, template) =>
       ExternBody.StringExternBody(ff, Template(template.strings, template.args.map(rewrite)))
     case unsupported: ExternBody.Unsupported => unsupported

--- a/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
@@ -23,7 +23,7 @@ object Transformer {
   def transform(module: core.ModuleDecl): ModuleDecl = module match {
     case core.ModuleDecl(path, includes, declarations, externs, definitions, exports) =>
       given TransformationContext(Map.empty, Map.empty)
-      ModuleDecl(path, includes, declarations, externs.flatMap(transform), definitions.map(transformToplevel), exports)
+      ModuleDecl(path, includes, declarations, externs.map(transform), definitions.map(transformToplevel), exports)
   }
 
   def transformToplevel(definition: core.Toplevel)(using TransformationContext): ToplevelDefinition = definition match {
@@ -34,11 +34,17 @@ object Transformer {
       ToplevelDefinition.Val(id, ks, k, transform(stmt, ks, Continuation.Dynamic(k)))
   }
 
-  def transform(extern: core.Extern)(using TransformationContext): Option[Extern] = extern match {
+  def transform(extern: core.Extern)(using TransformationContext): Extern = extern match {
     case core.Extern.Def(id, tparams, cparams, vparams, bparams, ret, annotatedCapture, body) =>
-      Some(Extern.Def(id, vparams.map(_.id), bparams.map(_.id), annotatedCapture.contains(symbols.builtins.AsyncCapability.capture), transform(body)))
-    case core.Extern.Include(featureFlag, contents) => Some(Extern.Include(featureFlag, contents))
-    case core.Extern.Data(id, tparams, body) => None
+      Extern.Def(id, vparams.map(_.id), bparams.map(_.id), annotatedCapture.contains(symbols.builtins.AsyncCapability.capture), transform(body))
+    case core.Extern.Include(featureFlag, contents) => Extern.Include(featureFlag, contents)
+    case core.Extern.Data(id, tparams, body) =>
+      val tBody = body match {
+        case core.ExternBody.StringExternBody(ff, Template(strings, args)) =>
+          ExternBody.StringExternBody(ff, Template(strings, args.map { absurd => absurd }))
+        case core.ExternBody.Unsupported(err) => ExternBody.Unsupported(err)
+      }
+      Extern.Data(id, tparams, tBody)
   }
 
   def transform(externBody: core.ExternBody[core.Expr])(using TransformationContext): ExternBody[Expr] = externBody match {

--- a/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
@@ -41,7 +41,7 @@ object Transformer {
     case core.Extern.Data(id, tparams, body) => None
   }
 
-  def transform(externBody: core.ExternBody)(using TransformationContext): ExternBody = externBody match {
+  def transform(externBody: core.ExternBody[core.Expr])(using TransformationContext): ExternBody = externBody match {
     case core.ExternBody.StringExternBody(featureFlag, Template(strings, args)) =>
       ExternBody.StringExternBody(featureFlag, Template(strings, args.map(transform)))
     case core.ExternBody.Unsupported(err) => ExternBody.Unsupported(err)

--- a/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
@@ -45,6 +45,13 @@ object Transformer {
         case core.ExternBody.Unsupported(err) => ExternBody.Unsupported(err)
       }
       Extern.Data(id, tparams, tBody)
+    case core.Extern.Interface(id, tparams, body) =>
+      val tBody = body match {
+        case core.ExternBody.StringExternBody(ff, Template(strings, args)) =>
+          ExternBody.StringExternBody(ff, Template(strings, args.map { absurd => absurd }))
+        case core.ExternBody.Unsupported(err) => ExternBody.Unsupported(err)
+      }
+      Extern.Interface(id, tparams, tBody)
   }
 
   def transform(externBody: core.ExternBody[core.Expr])(using TransformationContext): ExternBody[Expr] = externBody match {

--- a/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
@@ -41,7 +41,7 @@ object Transformer {
     case core.Extern.Data(id, tparams, body) => None
   }
 
-  def transform(externBody: core.ExternBody[core.Expr])(using TransformationContext): ExternBody = externBody match {
+  def transform(externBody: core.ExternBody[core.Expr])(using TransformationContext): ExternBody[Expr] = externBody match {
     case core.ExternBody.StringExternBody(featureFlag, Template(strings, args)) =>
       ExternBody.StringExternBody(featureFlag, Template(strings, args.map(transform)))
     case core.ExternBody.Unsupported(err) => ExternBody.Unsupported(err)

--- a/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Transformer.scala
@@ -38,7 +38,7 @@ object Transformer {
     case core.Extern.Def(id, tparams, cparams, vparams, bparams, ret, annotatedCapture, body) =>
       Some(Extern.Def(id, vparams.map(_.id), bparams.map(_.id), annotatedCapture.contains(symbols.builtins.AsyncCapability.capture), transform(body)))
     case core.Extern.Include(featureFlag, contents) => Some(Extern.Include(featureFlag, contents))
-    case core.Extern.Data(id, tparams) => None
+    case core.Extern.Data(id, tparams, body) => None
   }
 
   def transform(externBody: core.ExternBody)(using TransformationContext): ExternBody = externBody match {

--- a/effekt/shared/src/main/scala/effekt/cps/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Tree.scala
@@ -48,13 +48,14 @@ enum ToplevelDefinition {
  * FFI external definitions
  */
 enum Extern extends Tree {
-  case Def(id: Id, vparams: List[Id], bparams: List[Id], async: Boolean, body: ExternBody)
+  case Def(id: Id, vparams: List[Id], bparams: List[Id], async: Boolean, body: ExternBody[Expr])
+  case Data(id: Id, tparams: List[Id], body: ExternBody[Nothing])
   case Include(featureFlag: FeatureFlag, contents: String)
 }
-sealed trait ExternBody extends Tree
+sealed trait ExternBody[+T] extends Tree
 object ExternBody {
-  case class StringExternBody(featureFlag: FeatureFlag, contents: Template[Expr]) extends ExternBody
-  case class Unsupported(err: util.messages.EffektError) extends ExternBody {
+  case class StringExternBody[+T](featureFlag: FeatureFlag, contents: Template[T]) extends ExternBody[T]
+  case class Unsupported(err: util.messages.EffektError) extends ExternBody[Nothing] {
     def report(using E: ErrorReporter): Unit = E.report(err)
   }
 }

--- a/effekt/shared/src/main/scala/effekt/cps/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/cps/Tree.scala
@@ -50,6 +50,7 @@ enum ToplevelDefinition {
 enum Extern extends Tree {
   case Def(id: Id, vparams: List[Id], bparams: List[Id], async: Boolean, body: ExternBody[Expr])
   case Data(id: Id, tparams: List[Id], body: ExternBody[Nothing])
+  case Interface(id: Id, tparams: List[Id], body: ExternBody[Nothing])
   case Include(featureFlag: FeatureFlag, contents: String)
 }
 sealed trait ExternBody[+T] extends Tree

--- a/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
@@ -138,7 +138,7 @@ trait Transformer {
     case Extern.Include(ff, contents) =>
       Some(RawDef(contents))
 
-    case Extern.Data(id, tparams) =>
+    case Extern.Data(id, tparams, body) =>
       None
   }
 

--- a/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/Transformer.scala
@@ -140,6 +140,9 @@ trait Transformer {
 
     case Extern.Data(id, tparams, body) =>
       None
+
+    case Extern.Interface(id, tparams, body) =>
+      None
   }
 
   def toChez(t: Template[core.Expr]): chez.Expr =

--- a/effekt/shared/src/main/scala/effekt/generator/chez/TransformerCPS.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/TransformerCPS.scala
@@ -65,11 +65,17 @@ object TransformerCPS {
     case Extern.Def(id, vparams, bparams, _, body) =>
       val params = (vparams ++ bparams).map(nameDef)
       chez.Function(nameDef(id), params, toChez(body))
+    case Extern.Data(id, tps, body) =>
+      val ttps = tps match {
+        case Nil => ""
+        case tps => tps.map { x => x.show }.mkString(", ")
+      }
+      chez.RawDef(s";; extern type ${id.show}${ttps} = ${body}")
     case Extern.Include(_, contents) =>
       chez.RawDef(contents)
   }
 
-  def toChez(externBody: cps.ExternBody)(using ErrorReporter): chez.Expr = externBody match {
+  def toChez(externBody: cps.ExternBody[cps.Expr])(using ErrorReporter): chez.Expr = externBody match {
     case ExternBody.StringExternBody(_, contents) =>
       RawExpr(contents.strings, contents.args.map(toChez))
     case unsupported: ExternBody.Unsupported =>

--- a/effekt/shared/src/main/scala/effekt/generator/chez/TransformerCPS.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/TransformerCPS.scala
@@ -65,12 +65,14 @@ object TransformerCPS {
     case Extern.Def(id, vparams, bparams, _, body) =>
       val params = (vparams ++ bparams).map(nameDef)
       chez.Function(nameDef(id), params, toChez(body))
-    case Extern.Data(id, tps, body) =>
+    case Extern.Data(id, tps, ExternBody.StringExternBody(_, body)) =>
       val ttps = tps match {
         case Nil => ""
         case tps => tps.map { x => x.show }.mkString(", ")
       }
       chez.RawDef(s";; extern type ${id.show}${ttps} = ${body}")
+    case Extern.Data(id, tps, ExternBody.Unsupported(err)) =>
+      chez.RawDef(s";; unsupported extern type ${id.show}: ${err}")
     case Extern.Include(_, contents) =>
       chez.RawDef(contents)
   }

--- a/effekt/shared/src/main/scala/effekt/generator/chez/TransformerCPS.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/TransformerCPS.scala
@@ -73,6 +73,14 @@ object TransformerCPS {
       chez.RawDef(s";; extern type ${id.show}${ttps} = ${body}")
     case Extern.Data(id, tps, ExternBody.Unsupported(err)) =>
       chez.RawDef(s";; unsupported extern type ${id.show}: ${err}")
+    case Extern.Interface(id, tps, ExternBody.StringExternBody(_, body)) =>
+      val ttps = tps match {
+        case Nil => ""
+        case tps => tps.map { x => x.show }.mkString(", ")
+      }
+      chez.RawDef(s";; extern interface ${id.show}${ttps} = ${body}")
+    case Extern.Interface(id, tps, ExternBody.Unsupported(err)) =>
+      chez.RawDef(s";; unsupported extern interface ${id.show}: ${err}")
     case Extern.Include(_, contents) =>
       chez.RawDef(contents)
   }

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -128,12 +128,15 @@ object TransformerCps extends Transformer {
           js.Function(nameDef(id), (vps ++ bps) map toJSParam, List(js.Return($effekt.call("unreachable"))))
       }
 
-    case cps.Extern.Data(id, tps, body) =>
+    case cps.Extern.Data(id, tps, ExternBody.StringExternBody(_, body)) =>
       val ttps = tps match {
         case Nil => ""
         case tps => tps.map { x => x.show }.mkString(", ")
       }
       js.RawStmt(s"// extern type ${id.show}${ttps} = ${body}")
+
+    case cps.Extern.Data(id, tps, ExternBody.Unsupported(err)) =>
+      js.RawStmt(s"// unsupported extern type ${id.show}: ${err}")
 
     case cps.Extern.Include(ff, contents) =>
       js.RawStmt(contents)

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -138,6 +138,16 @@ object TransformerCps extends Transformer {
     case cps.Extern.Data(id, tps, ExternBody.Unsupported(err)) =>
       js.RawStmt(s"// unsupported extern type ${id.show}: ${err}")
 
+    case cps.Extern.Interface(id, tps, ExternBody.StringExternBody(_, body)) =>
+      val ttps = tps match {
+        case Nil => ""
+        case tps => tps.map { x => x.show }.mkString(", ")
+      }
+      js.RawStmt(s"// extern type ${id.show}${ttps} = ${body}")
+
+    case cps.Extern.Interface(id, tps, ExternBody.Unsupported(err)) =>
+      js.RawStmt(s"// unsupported extern type ${id.show}: ${err}")
+
     case cps.Extern.Include(ff, contents) =>
       js.RawStmt(contents)
   }

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -128,6 +128,13 @@ object TransformerCps extends Transformer {
           js.Function(nameDef(id), (vps ++ bps) map toJSParam, List(js.Return($effekt.call("unreachable"))))
       }
 
+    case cps.Extern.Data(id, tps, body) =>
+      val ttps = tps match {
+        case Nil => ""
+        case tps => tps.map { x => x.show }.mkString(", ")
+      }
+      js.RawStmt(s"// extern type ${id.show}${ttps} = ${body}")
+
     case cps.Extern.Include(ff, contents) =>
       js.RawStmt(contents)
   }

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -67,9 +67,9 @@ object Transformer {
         |""".stripMargin
     }
 
-  def transform(template: Template[machine.Variable]): String = "; variable\n    " ++ intercalate(template.strings, template.args.map {
+  def transform(template: Template[machine.Variable]): String = "; variable\n    " ++ template.fill {
     case machine.Variable(name, tpe) => PrettyPrinter.localName(name)
-  }).mkString
+  }
 
   def transform(definition: machine.Definition)(using ModuleContext): Unit = definition match {
    case machine.Definition(machine.Label(name, environment), body) =>

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -45,11 +45,19 @@ object Transformer {
         } else {
           VerbatimFunction(Ccc(), transform(returnType), functionName, transformedParameters, transform(body))
         }
+      case machine.ExternType(name, tps, machine.ExternBody.StringExternBody(_, body)) =>
+        val ttps = tps match {
+          case Nil => ""
+          case tps => tps.mkString(", ")
+        }
+        Verbatim(s"; declaration extern type ${name}${ttps} = ${body}")
+      case machine.ExternType(name, tps, machine.ExternBody.Unsupported(err)) =>
+        Verbatim(s"; unsupported extern type ${name}: ${err}")
       case machine.Include(ff, content) =>
         Verbatim("; declaration include" ++ content)
     }
 
-  def transform(body: machine.ExternBody)(using ErrorReporter): String = body match {
+  def transform(body: machine.ExternBody[machine.Variable])(using ErrorReporter): String = body match {
     case machine.ExternBody.StringExternBody(_, contents) =>
       "; declaration extern\n    " ++ transform(contents)
     case u: machine.ExternBody.Unsupported =>

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -53,6 +53,14 @@ object Transformer {
         Verbatim(s"; declaration extern type ${name}${ttps} = ${body}")
       case machine.ExternType(name, tps, machine.ExternBody.Unsupported(err)) =>
         Verbatim(s"; unsupported extern type ${name}: ${err}")
+      case machine.ExternInterface(name, tps, machine.ExternBody.StringExternBody(_, body)) =>
+        val ttps = tps match {
+          case Nil => ""
+          case tps => tps.mkString(", ")
+        }
+        Verbatim(s"; declaration extern interface ${name}${ttps} = ${body}")
+      case machine.ExternInterface(name, tps, machine.ExternBody.Unsupported(err)) =>
+        Verbatim(s"; unsupported extern interface ${name}: ${err}")
       case machine.Include(ff, content) =>
         Verbatim("; declaration include" ++ content)
     }

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -31,7 +31,7 @@ object Transformer {
     given DC: DeclarationContext = core.DeclarationContext(mod.declarations, mod.externs)
 
     // collect all information
-    val declarations = mod.externs.flatMap(transform)
+    val declarations = mod.externs.map(transform)
     val definitions = mod.definitions
     val mainEntry = Label(mainName, Nil)
 
@@ -54,7 +54,7 @@ object Transformer {
     Program(declarations, toplevelDefinitions ++ localDefinitions, mainEntry)
   }
 
-  def transform(extern: core.Extern)(using BlocksParamsContext, ErrorReporter): Option[Declaration] = extern match {
+  def transform(extern: core.Extern)(using BlocksParamsContext, ErrorReporter): Declaration = extern match {
     case core.Extern.Def(name, tps, cparams, vparams, bparams, ret, capture, body) =>
       // TODO delete, and/or enforce at call site (ImpureApp)
       if bparams.nonEmpty then ErrorReporter.abort("Foreign functions currently cannot take block arguments.")
@@ -65,10 +65,10 @@ object Transformer {
       val transformedRet = transformUnboxed(ret)
       val isExternAsync = capture.contains(symbols.builtins.AsyncCapability.capture)
       noteDefinition(name, transformedParams, Nil, isExternAsync)
-      Some(Extern(transform(name), transformedParams, transformedRet, isExternAsync, transform(body)))
+      Extern(transform(name), transformedParams, transformedRet, isExternAsync, transform(body))
 
     case core.Extern.Include(ff, contents) =>
-      Some(Include(ff, contents))
+      Include(ff, contents)
     
     case core.Extern.Data(id, tparams, body) =>
       val tBody = body match {
@@ -76,7 +76,7 @@ object Transformer {
           ExternBody.StringExternBody(featureFlag, Template(strings, args.map{ absurd => absurd }))
         case core.ExternBody.Unsupported(err) => ExternBody.Unsupported(err)
       }
-      Some(ExternType(transform(id), tparams.map(transform), tBody))
+      ExternType(transform(id), tparams.map(transform), tBody)
   }
 
   def transform(body: core.ExternBody[core.Expr])(using ErrorReporter): machine.ExternBody[Variable] = body match {

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -70,7 +70,7 @@ object Transformer {
     case core.Extern.Include(ff, contents) =>
       Some(Include(ff, contents))
     
-    case core.Extern.Data(id, tparams) =>
+    case core.Extern.Data(id, tparams, body) =>
       None
   }
 

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -71,10 +71,15 @@ object Transformer {
       Some(Include(ff, contents))
     
     case core.Extern.Data(id, tparams, body) =>
-      None
+      val tBody = body match {
+        case core.ExternBody.StringExternBody(featureFlag, Template(strings, args)) =>
+          ExternBody.StringExternBody(featureFlag, Template(strings, args.map{ absurd => absurd }))
+        case core.ExternBody.Unsupported(err) => ExternBody.Unsupported(err)
+      }
+      Some(ExternType(transform(id), tparams.map(transform), tBody))
   }
 
-  def transform(body: core.ExternBody[core.Expr])(using ErrorReporter): machine.ExternBody = body match {
+  def transform(body: core.ExternBody[core.Expr])(using ErrorReporter): machine.ExternBody[Variable] = body match {
     case core.ExternBody.StringExternBody(ff, Template(strings, args)) =>
       ExternBody.StringExternBody(ff, Template(strings, args map {
         case core.ValueVar(id, tpe) => Variable(transform(id), transform(tpe))

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -77,6 +77,14 @@ object Transformer {
         case core.ExternBody.Unsupported(err) => ExternBody.Unsupported(err)
       }
       ExternType(transform(id), tparams.map(transform), tBody)
+
+    case core.Extern.Interface(id, tparams, body) =>
+      val tBody = body match {
+        case core.ExternBody.StringExternBody(featureFlag, Template(strings, args)) =>
+          ExternBody.StringExternBody(featureFlag, Template(strings, args.map{ absurd => absurd }))
+        case core.ExternBody.Unsupported(err) => ExternBody.Unsupported(err)
+      }
+      ExternInterface(transform(id), tparams.map(transform), tBody)
   }
 
   def transform(body: core.ExternBody[core.Expr])(using ErrorReporter): machine.ExternBody[Variable] = body match {

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -74,7 +74,7 @@ object Transformer {
       None
   }
 
-  def transform(body: core.ExternBody)(using ErrorReporter): machine.ExternBody = body match {
+  def transform(body: core.ExternBody[core.Expr])(using ErrorReporter): machine.ExternBody = body match {
     case core.ExternBody.StringExternBody(ff, Template(strings, args)) =>
       ExternBody.StringExternBody(ff, Template(strings, args map {
         case core.ValueVar(id, tpe) => Variable(transform(id), transform(tpe))

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -38,15 +38,16 @@ case class Program(declarations: List[Declaration], program: List[Definition], e
  * Toplevel declarations for FFI
  */
 enum Declaration {
-  case Extern(name: String, parameters: Environment, returnType: Type, async: Boolean, body: ExternBody)
+  case Extern(name: String, parameters: Environment, returnType: Type, async: Boolean, body: ExternBody[Variable])
+  case ExternType(name: String, tparams: List[String], body: ExternBody[Nothing])
   case Include(featureFlag: FeatureFlag, contents: String)
 }
 export Declaration.*
 
-sealed trait ExternBody
+sealed trait ExternBody[+S]
 object ExternBody {
-  case class StringExternBody(featureFlag: FeatureFlag, contents: Template[Variable]) extends ExternBody
-  case class Unsupported(err: util.messages.EffektError) extends ExternBody {
+  case class StringExternBody[+S](featureFlag: FeatureFlag, contents: Template[S]) extends ExternBody[S]
+  case class Unsupported(err: util.messages.EffektError) extends ExternBody[Nothing] {
     def report(using E: util.messages.ErrorReporter): Unit = E.report(err)
   }
 }

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -40,6 +40,7 @@ case class Program(declarations: List[Declaration], program: List[Definition], e
 enum Declaration {
   case Extern(name: String, parameters: Environment, returnType: Type, async: Boolean, body: ExternBody[Variable])
   case ExternType(name: String, tparams: List[String], body: ExternBody[Nothing])
+  case ExternInterface(name: String, tparams: List[String], body: ExternBody[Nothing])
   case Include(featureFlag: FeatureFlag, contents: String)
 }
 export Declaration.*

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -130,7 +130,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       source.BlockLiteral(tps, vps, bps ++ capParams, rewrite(body), span)
   }
 
-  override def rewrite(body: ExternBody)(using context.Context): ExternBody =
+  override def rewrite(body: ExternBody[Stmt])(using context.Context): ExternBody[Stmt] =
     body match {
       case b @ source.ExternBody.StringExternBody(ff, body, span) =>
         val rewrittenTemplate =

--- a/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ExplicitCapabilities.scala
@@ -130,7 +130,7 @@ object ExplicitCapabilities extends Phase[Typechecked, Typechecked], Rewrite {
       source.BlockLiteral(tps, vps, bps ++ capParams, rewrite(body), span)
   }
 
-  override def rewrite(body: ExternBody[Stmt])(using context.Context): ExternBody[Stmt] =
+  override def rewrite(body: ExternBody[Term, Stmt])(using context.Context): ExternBody[Term, Stmt] =
     body match {
       case b @ source.ExternBody.StringExternBody(ff, body, span) =>
         val rewrittenTemplate =

--- a/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
@@ -15,7 +15,7 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
 
   def supported(using Context): List[String] = Context.compiler.supportedFeatureFlags
 
-  def defaultExternBody(warning: String)(using Context): ExternBody[Stmt] =
+  def defaultExternBody(warning: String)(using Context): ExternBody[Nothing] =
     ExternBody.Unsupported(Context.plainMessage(warning, kiama.util.Severities.Warning))
 
   def rewrite(decl: ModuleDecl)(using Context): ModuleDecl = decl match {
@@ -23,7 +23,7 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
       ModuleDecl(path, includes, defs.flatMap(rewrite), doc, span)
   }
 
-  def findPreferred(bodies: List[ExternBody[Stmt]])(using Context): ExternBody[Stmt] = {
+  def findPreferred[T](bodies: List[ExternBody[T]])(using Context): ExternBody[T] = {
     // IMPORTANT: Should be deterministic.
     bodies.filter { b => b.featureFlag.matches(supported) }
       .minByOption { b =>
@@ -57,6 +57,23 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
             Some(d)
           case u: ExternBody.Unsupported =>
             val d = Def.ExternDef(id, tparams, vparams, bparams, capture, ret, Many(List(u), bodies.span), doc, span)
+            Context.copyAnnotations(defn, d)
+            Some(d)
+        }
+
+      case Def.ExternType(id, tparams, bodies, info, span) =>
+        findPreferred(bodies.unspan) match {
+          case body@ExternBody.StringExternBody(featureFlag, template, span) =>
+            if (featureFlag.isDefault) {
+              Context.warning(s"Extern definition ${id} contains extern string without feature flag. This will likely not work in other backends, "
+                + s"please annotate it with a feature flag (Supported by the current backend: ${Context.compiler.supportedFeatureFlags.mkString(", ")})")
+            }
+
+            val d = Def.ExternType(id, tparams, Many(List(body), bodies.span), info, span)
+            Context.copyAnnotations(defn, d)
+            Some(d)
+          case u: ExternBody.Unsupported =>
+            val d = Def.ExternType(id, tparams, Many(List(u), bodies.span), info, span)
             Context.copyAnnotations(defn, d)
             Some(d)
         }

--- a/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
@@ -78,6 +78,23 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
             Some(d)
         }
 
+      case Def.ExternInterface(id, tparams, bodies, info, span) =>
+        findPreferred(bodies.unspan) match {
+          case body@ExternBody.StringExternBody(featureFlag, template, span) =>
+            if (featureFlag.isDefault) {
+              Context.warning(s"Extern definition ${id} contains extern string without feature flag. This will likely not work in other backends, "
+                + s"please annotate it with a feature flag (Supported by the current backend: ${Context.compiler.supportedFeatureFlags.mkString(", ")})")
+            }
+
+            val d = Def.ExternInterface(id, tparams, Many(List(body), bodies.span), info, span)
+            Context.copyAnnotations(defn, d)
+            Some(d)
+          case u: ExternBody.Unsupported =>
+            val d = Def.ExternInterface(id, tparams, Many(List(u), bodies.span), info, span)
+            Context.copyAnnotations(defn, d)
+            Some(d)
+        }
+
       case Def.ExternInclude(featureFlag, path, contents, id, doc, span) if featureFlag.matches(supported) =>
         if (featureFlag.isDefault) {
           val supported = Context.compiler.supportedFeatureFlags.mkString(", ")

--- a/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
@@ -40,14 +40,14 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
 
   def rewrite(defn: Def)(using Context): Option[Def] = Context.focusing(defn) {
       case Def.ExternDef(id, tparams, vparams, bparams, capture, ret, bodies, doc, span) =>
-        findPreferred(bodies) match {
+        findPreferred(bodies.unspan) match {
           case body@ExternBody.StringExternBody(featureFlag, template, span) =>
             if (featureFlag.isDefault) {
               Context.warning(s"Extern definition ${id} contains extern string without feature flag. This will likely not work in other backends, "
                 + s"please annotate it with a feature flag (Supported by the current backend: ${Context.compiler.supportedFeatureFlags.mkString(", ")})")
             }
 
-            val d = Def.ExternDef(id, tparams, vparams, bparams, capture, ret, List(body), doc, span)
+            val d = Def.ExternDef(id, tparams, vparams, bparams, capture, ret, Many(List(body), bodies.span), doc, span)
             Context.copyAnnotations(defn, d)
             Some(d)
           case ExternBody.EffektExternBody(featureFlag, body, span) =>
@@ -56,7 +56,7 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
             Context.annotate(Annotations.BoundCapabilities, d, Nil) // TODO ??
             Some(d)
           case u: ExternBody.Unsupported =>
-            val d = Def.ExternDef(id, tparams, vparams, bparams, capture, ret, List(u), doc, span)
+            val d = Def.ExternDef(id, tparams, vparams, bparams, capture, ret, Many(List(u), bodies.span), doc, span)
             Context.copyAnnotations(defn, d)
             Some(d)
         }

--- a/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
@@ -15,7 +15,7 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
 
   def supported(using Context): List[String] = Context.compiler.supportedFeatureFlags
 
-  def defaultExternBody(warning: String)(using Context): ExternBody =
+  def defaultExternBody(warning: String)(using Context): ExternBody[Stmt] =
     ExternBody.Unsupported(Context.plainMessage(warning, kiama.util.Severities.Warning))
 
   def rewrite(decl: ModuleDecl)(using Context): ModuleDecl = decl match {
@@ -23,7 +23,7 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
       ModuleDecl(path, includes, defs.flatMap(rewrite), doc, span)
   }
 
-  def findPreferred(bodies: List[ExternBody])(using Context): ExternBody = {
+  def findPreferred(bodies: List[ExternBody[Stmt]])(using Context): ExternBody[Stmt] = {
     // IMPORTANT: Should be deterministic.
     bodies.filter { b => b.featureFlag.matches(supported) }
       .minByOption { b =>

--- a/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
+++ b/effekt/shared/src/main/scala/effekt/source/ResolveExternDefs.scala
@@ -15,7 +15,7 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
 
   def supported(using Context): List[String] = Context.compiler.supportedFeatureFlags
 
-  def defaultExternBody(warning: String)(using Context): ExternBody[Nothing] =
+  def defaultExternBody(warning: String)(using Context): ExternBody[Nothing, Nothing] =
     ExternBody.Unsupported(Context.plainMessage(warning, kiama.util.Severities.Warning))
 
   def rewrite(decl: ModuleDecl)(using Context): ModuleDecl = decl match {
@@ -23,7 +23,7 @@ object ResolveExternDefs extends Phase[Typechecked, Typechecked] {
       ModuleDecl(path, includes, defs.flatMap(rewrite), doc, span)
   }
 
-  def findPreferred[T](bodies: List[ExternBody[T]])(using Context): ExternBody[T] = {
+  def findPreferred[S, E](bodies: List[ExternBody[S, E]])(using Context): ExternBody[S, E] = {
     // IMPORTANT: Should be deterministic.
     bodies.filter { b => b.featureFlag.matches(supported) }
       .minByOption { b =>

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -911,6 +911,8 @@ object Tree {
       visit(b){
         case ExternBody.EffektExternBody(ff, body, span) =>
           ExternBody.EffektExternBody(ff, rewrite(body), span)
+        case ExternBody.StringExternBody(ff, template, span) =>
+          ExternBody.StringExternBody(ff, template.map(rewrite), span)
         case other => other
       }
     def rewrite(a: ValueArg)(using Context): ValueArg = structuralVisit(a)
@@ -979,7 +981,8 @@ object Tree {
     def query(b: ExternBody[Term, Stmt])(using Context, Ctx): Res =
       visit(b){
         case ExternBody.EffektExternBody(ff, body, span) => query(body)
-        case ExternBody.StringExternBody(ff, tmpl, span) => empty
+        case ExternBody.StringExternBody(ff, tmpl, span) =>
+          combineAll(tmpl.args.map(query))
         case ExternBody.Unsupported(msg) => empty
       }
     def query(a: ValueArg)(using Context, Ctx): Res = structuralQuery(a)

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -219,7 +219,7 @@ enum FeatureFlag extends Tree {
   }
 }
 object FeatureFlag {
-  extension[T](self: List[ExternBody[T]]) {
+  extension[S, E](self: List[ExternBody[S, E]]) {
     @tailrec
     def supportedByFeatureFlags(names: List[String]): Boolean = names match {
       case Nil => false
@@ -232,12 +232,12 @@ object FeatureFlag {
   }
 }
 
-sealed trait ExternBody[+T] extends Tree {
+sealed trait ExternBody[+S, +E] extends Tree {
   def featureFlag: FeatureFlag
 }
 object ExternBody {
-  case class StringExternBody(featureFlag: FeatureFlag, template: Template[source.Term], span: Span) extends ExternBody[Nothing]
-  case class EffektExternBody[+T](featureFlag: FeatureFlag, body: T, span: Span) extends ExternBody[T]
+  case class StringExternBody[+S](featureFlag: FeatureFlag, template: Template[S], span: Span) extends ExternBody[S, Nothing]
+  case class EffektExternBody[+T](featureFlag: FeatureFlag, body: T, span: Span) extends ExternBody[Nothing, T]
   case class Unsupported(message: util.messages.EffektError) extends ExternBody {
     val span: Span = Span.missing
     override def featureFlag: FeatureFlag = FeatureFlag.Default(Span.missing)
@@ -423,11 +423,11 @@ enum Def extends Definition {
   /**
    * Only valid on the toplevel!
    */
-  case ExternType(id: IdDef, tparams: Many[Id], body: Many[ExternBody[Nothing]], info: Info, span: Span)
+  case ExternType(id: IdDef, tparams: Many[Id], body: Many[ExternBody[Nothing, Nothing]], info: Info, span: Span)
 
   case ExternDef(id: IdDef,
                  tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], captures: CaptureSet, ret: Effectful,
-                 bodies: Many[ExternBody[Stmt]], info: Info, span: Span) extends Def
+                 bodies: Many[ExternBody[Term, Stmt]], info: Info, span: Span) extends Def
 
   case ExternResource(id: IdDef, tpe: BlockType, info: Info, span: Span)
 
@@ -907,7 +907,7 @@ object Tree {
     def rewrite(c: MatchClause)(using Context): MatchClause = structuralVisit(c)
     def rewrite(c: MatchGuard)(using Context): MatchGuard = structuralVisit(c)
     def rewrite(t: source.CallTarget)(using Context): source.CallTarget = structuralVisit(t)
-    def rewrite(b: ExternBody[Stmt])(using Context): source.ExternBody[Stmt] =
+    def rewrite(b: ExternBody[Term, Stmt])(using Context): source.ExternBody[Term, Stmt] =
       visit(b){
         case ExternBody.EffektExternBody(ff, body, span) =>
           ExternBody.EffektExternBody(ff, rewrite(body), span)
@@ -976,7 +976,7 @@ object Tree {
     def query(h: OpClause)(using Context, Ctx): Res = structuralQuery(h)
     def query(c: MatchClause)(using Context, Ctx): Res = structuralQuery(c)
     def query(c: MatchGuard)(using Context, Ctx): Res = structuralQuery(c)
-    def query(b: ExternBody[Stmt])(using Context, Ctx): Res =
+    def query(b: ExternBody[Term, Stmt])(using Context, Ctx): Res =
       visit(b){
         case ExternBody.EffektExternBody(ff, body, span) => query(body)
         case ExternBody.StringExternBody(ff, tmpl, span) => empty

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -219,7 +219,7 @@ enum FeatureFlag extends Tree {
   }
 }
 object FeatureFlag {
-  extension (self: List[ExternBody]) {
+  extension[T](self: List[ExternBody[T]]) {
     @tailrec
     def supportedByFeatureFlags(names: List[String]): Boolean = names match {
       case Nil => false
@@ -232,12 +232,12 @@ object FeatureFlag {
   }
 }
 
-sealed trait ExternBody extends Tree {
+sealed trait ExternBody[+T] extends Tree {
   def featureFlag: FeatureFlag
 }
 object ExternBody {
-  case class StringExternBody(featureFlag: FeatureFlag, template: Template[source.Term], span: Span) extends ExternBody
-  case class EffektExternBody(featureFlag: FeatureFlag, body: source.Stmt, span: Span) extends ExternBody
+  case class StringExternBody(featureFlag: FeatureFlag, template: Template[source.Term], span: Span) extends ExternBody[Nothing]
+  case class EffektExternBody[+T](featureFlag: FeatureFlag, body: T, span: Span) extends ExternBody[T]
   case class Unsupported(message: util.messages.EffektError) extends ExternBody {
     val span: Span = Span.missing
     override def featureFlag: FeatureFlag = FeatureFlag.Default(Span.missing)
@@ -427,7 +427,7 @@ enum Def extends Definition {
 
   case ExternDef(id: IdDef,
                  tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], captures: CaptureSet, ret: Effectful,
-                 bodies: List[ExternBody], info: Info, span: Span) extends Def
+                 bodies: List[ExternBody[Stmt]], info: Info, span: Span) extends Def
 
   case ExternResource(id: IdDef, tpe: BlockType, info: Info, span: Span)
 
@@ -907,7 +907,12 @@ object Tree {
     def rewrite(c: MatchClause)(using Context): MatchClause = structuralVisit(c)
     def rewrite(c: MatchGuard)(using Context): MatchGuard = structuralVisit(c)
     def rewrite(t: source.CallTarget)(using Context): source.CallTarget = structuralVisit(t)
-    def rewrite(b: ExternBody)(using Context): source.ExternBody = structuralVisit(b)
+    def rewrite(b: ExternBody[Stmt])(using Context): source.ExternBody[Stmt] =
+      visit(b){
+        case ExternBody.EffektExternBody(ff, body, span) =>
+          ExternBody.EffektExternBody(ff, rewrite(body), span)
+        case other => other
+      }
     def rewrite(a: ValueArg)(using Context): ValueArg = structuralVisit(a)
 
     /**
@@ -971,7 +976,12 @@ object Tree {
     def query(h: OpClause)(using Context, Ctx): Res = structuralQuery(h)
     def query(c: MatchClause)(using Context, Ctx): Res = structuralQuery(c)
     def query(c: MatchGuard)(using Context, Ctx): Res = structuralQuery(c)
-    def query(b: ExternBody)(using Context, Ctx): Res = structuralQuery(b)
+    def query(b: ExternBody[Stmt])(using Context, Ctx): Res =
+      visit(b){
+        case ExternBody.EffektExternBody(ff, body, span) => query(body)
+        case ExternBody.StringExternBody(ff, tmpl, span) => empty
+        case ExternBody.Unsupported(msg) => empty
+      }
     def query(a: ValueArg)(using Context, Ctx): Res = structuralQuery(a)
 
     def query(t: Template[Term])(using Context, Ctx): Res =

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -431,7 +431,7 @@ enum Def extends Definition {
 
   case ExternResource(id: IdDef, tpe: BlockType, info: Info, span: Span)
 
-  case ExternInterface(id: IdDef, tparams: List[Id], info: Info, span: Span)
+  case ExternInterface(id: IdDef, tparams: List[Id], bodies: Many[ExternBody[Nothing, Nothing]], info: Info, span: Span)
 
   /**
    * Namer resolves the path and loads the contents in field [[contents]]

--- a/effekt/shared/src/main/scala/effekt/source/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/source/Tree.scala
@@ -423,11 +423,11 @@ enum Def extends Definition {
   /**
    * Only valid on the toplevel!
    */
-  case ExternType(id: IdDef, tparams: Many[Id], info: Info, span: Span)
+  case ExternType(id: IdDef, tparams: Many[Id], body: Many[ExternBody[Nothing]], info: Info, span: Span)
 
   case ExternDef(id: IdDef,
                  tparams: Many[Id], vparams: Many[ValueParam], bparams: Many[BlockParam], captures: CaptureSet, ret: Effectful,
-                 bodies: List[ExternBody[Stmt]], info: Info, span: Span) extends Def
+                 bodies: Many[ExternBody[Stmt]], info: Info, span: Span) extends Def
 
   case ExternResource(id: IdDef, tpe: BlockType, info: Info, span: Span)
 

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -439,7 +439,7 @@ case class ExternFunction(
   result: ValueType,
   effects: Effects,
   capture: CaptureSet,
-  bodies: List[source.ExternBody[source.Stmt]],
+  bodies: List[source.ExternBody[source.Term, source.Stmt]],
   decl: source.Tree
 ) extends Callable {
   def annotatedCaptures = Some(capture)

--- a/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/symbols.scala
@@ -439,7 +439,7 @@ case class ExternFunction(
   result: ValueType,
   effects: Effects,
   capture: CaptureSet,
-  bodies: List[source.ExternBody],
+  bodies: List[source.ExternBody[source.Stmt]],
   decl: source.Tree
 ) extends Callable {
   def annotatedCaptures = Some(capture)

--- a/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
+++ b/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
@@ -256,7 +256,7 @@ trait DocumentationGenerator {
       "span" -> generate(span),
     ))
 
-    case Def.ExternType(id, tparams, info, span) => obj(HashMap(
+    case Def.ExternType(id, tparams, body, info, span) => obj(HashMap(
       "kind" -> str("ExternType"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams.unspan),

--- a/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
+++ b/effekt/shared/src/main/scala/effekt/util/DocumentationGenerator.scala
@@ -284,7 +284,7 @@ trait DocumentationGenerator {
       "span" -> generate(span),
     ))
 
-    case Def.ExternInterface(id, tparams, info, span) => obj(HashMap(
+    case Def.ExternInterface(id, tparams, bodies, info, span) => obj(HashMap(
       "kind" -> str("ExternInterface"),
       "id" -> generate(id),
       "tparams" -> generateTparams(tparams),

--- a/examples/pos/bidirectional/typeparametric.effekt
+++ b/examples/pos/bidirectional/typeparametric.effekt
@@ -1,4 +1,7 @@
-extern interface Cap[U, V]
+extern interface Cap[U, V] =
+  js   "number"
+  chez "int"
+  llvm "%Pos"
 
 extern def cap[U, V]() at {}: Cap[U, V] at {} =
   js   "42"

--- a/examples/pos/capture/resources.effekt
+++ b/examples/pos/capture/resources.effekt
@@ -8,7 +8,9 @@ extern resource stack: StackLocal
 
 // this does not really implement arrays, but tests whether `makeArray`
 // will be in direct style.
-extern interface Array[T]
+extern interface Array[T] =
+  js   "Array"
+  chez "vector"
 extern def makeArray[T](size: Int) at stack: Array[T] at stack =
   js   "${size}"
   chez "${size}"

--- a/libraries/common/args.effekt
+++ b/libraries/common/args.effekt
@@ -7,7 +7,7 @@ extern def commandLineArgs() at io: List[String] =
   vm { Nil() }
 
 namespace js {
-  extern type Args // = Array[String]
+  extern type Args = js "Array[String]"
 
   extern def nativeArgs() at io: Args = js "process.argv.slice(1)"
 
@@ -26,7 +26,7 @@ namespace js {
 }
 
 namespace chez {
-  extern type Args // = CSList[String]
+  extern type Args = chez "CSList[String]"
 
   extern def nativeArgs() at io: Args =
     chez "(cdr (command-line))"

--- a/libraries/common/array.effekt
+++ b/libraries/common/array.effekt
@@ -8,7 +8,10 @@ import list
 import exception
 
 /// A mutable 0-indexed fixed-sized array.
-extern type Array[T]
+extern type Array[T] =
+  js "Array"
+  chez "vector"
+  llvm "%Pos"
 
 /// We represent arrays like positive types.
 /// The tag is 0 and the obj points to memory with the following layout:

--- a/libraries/common/bytearray.effekt
+++ b/libraries/common/bytearray.effekt
@@ -19,10 +19,10 @@ import array
  *
  * The eraser does nothing.
  */
-extern type ByteArray
-  // = llvm "%Pos"
-  // = js "Uint8Array"
-  // = chez "bytevector"
+extern type ByteArray =
+  llvm "%Pos"
+  js "Uint8Array"
+  chez "bytevector"
 
 /// Allocates a new bytearray with the given `size`, its values are zero bytes.
 extern def allocate(size: Int) at global: ByteArray =

--- a/libraries/common/io/console.effekt
+++ b/libraries/common/io/console.effekt
@@ -26,7 +26,8 @@ namespace js {
     const readline = require('node:readline');
   """
 
-  extern type JSConsole
+  extern type JSConsole =
+    js "readline.createInterface return type"
 
   extern def newConsole() at io: JSConsole =
     jsNode """readline.createInterface({

--- a/libraries/common/io/signal.effekt
+++ b/libraries/common/io/signal.effekt
@@ -5,7 +5,9 @@ module io/signal
 
 /// Must be fired exactly once with an A receiving a B,
 /// and must be waited for exactly once with a B receiving an A.
-extern type Signal[A, B]
+extern type Signal[A, B] =
+  js "{ state: int, value, stack }"
+  llvm "%Pos"
 
 extern def signal[A, B]() at global: Signal[A, B] =
   js "signal$make()"

--- a/libraries/common/process.effekt
+++ b/libraries/common/process.effekt
@@ -25,7 +25,9 @@ extern llvm """
   declare %Pos @c_spawn(%Pos, %Pos, %Pos)
 """
 
-extern type SpawnOptions
+extern type SpawnOptions =
+  jsNode "{ stdio: list[int], onSpawn: fn => {} }"
+  llvm "%Pos"
 extern def default() at {}: SpawnOptions =
   jsNode """{ stdio: [0,1,2], onSpawn: (p) => {} }"""
   llvm """
@@ -64,7 +66,9 @@ extern def onStderr(opts: SpawnOptions, callback: String => Unit at {io, global}
     %opts = call %Pos @c_spawn_options_on_stderr(%Pos ${opts}, %Pos ${callback})
     ret %Pos %opts
   """
-extern type WritableStream
+extern type WritableStream =
+  jsNode "stream.Writable"
+  llvm "%Pos"
 extern def withStdin(opts: SpawnOptions, callback: WritableStream => Unit at {io, global}) at {}: SpawnOptions =
   jsNode """(function () {
     let old = ${opts};

--- a/libraries/common/ref.effekt
+++ b/libraries/common/ref.effekt
@@ -18,7 +18,10 @@ define void @c_ref_erase_field(ptr %0) {
 """
 
 /// Global, mutable references
-extern type Ref[T]
+extern type Ref[T] =
+  js "{ value: T }"
+  chez "box"
+  llvm "%Pos"
 
 /** We represent references like positive types in LLVM
  *  The tag is 0 and the obj points to memory with the following layout:

--- a/libraries/common/regex.effekt
+++ b/libraries/common/regex.effekt
@@ -25,9 +25,9 @@ namespace internal {
 
   /// The type RegexMatch is used internally to represent platform
   /// dependent results of matching a regex.
-  extern type RegexMatch
-    // js: { matched: String, index: Int } | undefined
-    // vm: scala.util.matching.Regex.Match | null
+  extern type RegexMatch =
+    js "{ matched: String, index: Int } | undefined"
+    vm "scala.util.matching.Regex.Match | null"
 
   extern def matched(r: RegexMatch) at {}: String =
     js "${r}.matched"

--- a/libraries/common/regex.effekt
+++ b/libraries/common/regex.effekt
@@ -4,7 +4,9 @@ import string
 
 extern include chez "text/pregexp.scm"
 
-extern type Regex
+extern type Regex =
+  js "RegExp"
+  chez "pregexp"
 
 record Match(matched: String, index: Int)
 


### PR DESCRIPTION
This parses right hand sides for external types and threads them through to the backends.
In the backends, currently just generates a comment with the type declaration.

Resolves #1132.

Drivebys:
- Disallows `extern def ...() =` without right hand sides and with a `=` (allows it without a `=`)
- Does reachability analysis and deadcode for externs and extern types
- Some other minor stuff