### PR TITLE
Reduce special cases in Deadcode

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/Show.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Show.scala
@@ -14,6 +14,19 @@ object Show extends Phase[CoreTransformed, CoreTransformed] {
   override val phaseName: String = "show"
 
   private final val FUNCTION_NAME: String = "show"
+  private final val FUNCTION_BUILTIN_NAME: String = "showBuiltin"
+  private final val STRING_CONCAT_NAME: String = "infixPlusPlus"
+
+  /** Names that [[Deadcode]] must preserve for the [[Show]] pass to function correctly. */
+  def requiredNames(core: ModuleDecl)(using Context): Set[Id] = {
+    val dctx = DeclarationContext(core.declarations, core.externs)
+
+    val requiredExternNames = Set(FUNCTION_NAME, FUNCTION_BUILTIN_NAME, STRING_CONCAT_NAME)
+
+    dctx.externs.collect {
+      case Extern.Def(id, _, _, _, _, _, _, _) if requiredExternNames.contains(id.name.name) => id
+    }.toSet
+  }
 
   case class ShowContext(showNames: collection.mutable.Map[ValueType, Id], showDefns: collection.mutable.Map[ValueType, Toplevel.Def], tparamLookup: collection.mutable.Map[Id, ValueType]) {
 
@@ -270,7 +283,7 @@ object Show extends Phase[CoreTransformed, CoreTransformed] {
     }
 
   def findExternShowDef(valueType: ValueType)(using dctx: DeclarationContext)(using Context): Block.BlockVar =
-    findExternDef("showBuiltin", List(valueType))
+    findExternDef(FUNCTION_BUILTIN_NAME, List(valueType))
 
   def findExternDef(name: String, vts: List[ValueType])(using dctx: DeclarationContext)(using Context): Block.BlockVar =
     dctx.findExternDef(name, vts) match
@@ -334,7 +347,7 @@ object Show extends Phase[CoreTransformed, CoreTransformed] {
 
   def constructorStmt(constr: Constructor)(using ctx: ShowContext, dctx: DeclarationContext)(using Context): Stmt = constr match
     case Constructor(id, tparams, fields) =>
-      val infixConcatBlockVar: Block.BlockVar = findExternDef("infixPlusPlus", List(TString, TString))
+      val infixConcatBlockVar: Block.BlockVar = findExternDef(STRING_CONCAT_NAME, List(TString, TString))
       val pureFields = fields map fieldPure
       val concatenated = PureApp(infixConcatBlockVar, List.empty, List(Literal(id.name.name ++ "(", TString), concatPure(pureFields)))
 
@@ -351,7 +364,7 @@ object Show extends Phase[CoreTransformed, CoreTransformed] {
   //  =>
   // PureApp(concat, List(Literal("Just("), PureApp(concat, List(PureApp(show, x), PureApp(concat, List(Literal(", "), ...))))
   def concatPure(pures: List[(Id, Stmt.App)])(using ctx: ShowContext)(using Context, DeclarationContext): Expr =
-    val infixConcatDef = findExternDef("infixPlusPlus", List(TString, TString))
+    val infixConcatDef = findExternDef(STRING_CONCAT_NAME, List(TString, TString))
     pures match
       case (fieldId, _) :: next :: rest => PureApp(infixConcatDef, List.empty, List(Expr.ValueVar(fieldId, TString), PureApp(infixConcatDef, List.empty, List(Literal(", ", TString), concatPure(next :: rest)))))
       case (fieldId, _) :: Nil => PureApp(infixConcatDef, List.empty, List(Expr.ValueVar(fieldId, TString), Literal(")", TString)))

--- a/effekt/shared/src/main/scala/effekt/core/Show.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Show.scala
@@ -18,12 +18,10 @@ object Show extends Phase[CoreTransformed, CoreTransformed] {
   private final val STRING_CONCAT_NAME: String = "infixPlusPlus"
 
   /** Names that [[Deadcode]] must preserve for the [[Show]] pass to function correctly. */
-  def requiredNames(core: ModuleDecl)(using Context): Set[Id] = {
-    val dctx = DeclarationContext(core.declarations, core.externs)
-
+  def requiredNames(core: ModuleDecl): Set[Id] = {
     val requiredExternNames = Set(FUNCTION_NAME, FUNCTION_BUILTIN_NAME, STRING_CONCAT_NAME)
 
-    dctx.externs.collect {
+    core.externs.collect {
       case Extern.Def(id, _, _, _, _, _, _, _) if requiredExternNames.contains(id.name.name) => id
     }.toSet
   }

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/Deadcode.scala
@@ -49,8 +49,7 @@ class Deadcode(reachable: Map[Id, Usage])
         },
         // drop unreachable externs
         m.externs.collect {
-          // We need to keep "show", "showBuiltin" & "infixPlusPlus" for generating show definitions (see #1123)
-          case e: Extern.Def if used(e.id) || List("show", "showBuiltin", "infixPlusPlus").contains(e.id.name.name) => e
+          case e: Extern.Def if used(e.id) => e
           case e: Extern.Include => e
           case e: Extern.Data if used(e.id) => e
           case e: Extern.Interface if used(e.id) => e
@@ -80,8 +79,11 @@ object Deadcode extends Phase[CoreTransformed, CoreTransformed] {
     input match {
       case CoreTransformed(source, tree, mod, core) =>
         val term = Context.ensureMainExists(mod)
+        // when ran "directly" (i.e., before the 'Show' pass),
+        // we add the functions required by subsequent passes
+        val required = Set(term) ++ Show.requiredNames(core)
         val dce = Context.timed("deadcode-elimination", source.name) {
-          Deadcode.remove(term, core)
+          Deadcode.remove(required, core)
         }
         Some(CoreTransformed(source, tree, mod, dce))
     }

--- a/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeCPS.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/chez/ChezSchemeCPS.scala
@@ -3,7 +3,7 @@ package generator
 package chez
 
 import effekt.context.Context
-import effekt.core.optimizer.{DropBindings, Optimizer}
+import effekt.core.optimizer.{Optimizer, Deadcode}
 import kiama.util.Source
 import kiama.output.PrettyPrinterTypes.Document
 
@@ -37,7 +37,7 @@ class ChezSchemeCPS extends Compiler[String] {
     Frontend andThen Middleend
   }
 
-  lazy val Optimized = allToCore(Core) andThen Aggregate andThen Optimizer andThen core.Show map {
+  lazy val Optimized = allToCore(Core) andThen Aggregate andThen Deadcode andThen core.Show andThen Optimizer map {
     case input @ CoreTransformed(source, tree, mod, core) =>
       val mainSymbol = Context.ensureMainExists(mod)
       val mainFile = path(mod)


### PR DESCRIPTION
Since the optimizer calls `Deadcode(main)` explicitly, this also means that all unused show-related functions get removed when optimising :)