### PR TITLE
Replace partial functions by dynamic dispatch

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/TestRenamerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/TestRenamerTests.scala
@@ -119,7 +119,7 @@ class TestRenamerTests extends CoreTests {
         |
         |def foo_renamed_2() = {
         |  12 match[Int] {
-        |    X : { (aa_renamed_3: Int, bb_renamed_4: Int) =>
+        |    X_renamed_0 : { (aa_renamed_3: Int, bb_renamed_4: Int) =>
         |      return aa_renamed_3: Int
         |    }
         |  }

--- a/effekt/shared/src/main/scala/effekt/core/Renamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Renamer.scala
@@ -42,11 +42,9 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
   def withBinding[R](id: Id)(f: => R): R = withBindings(List(id))(f)
 
   // free variables are left untouched
-  override def id: PartialFunction[core.Id, core.Id] = {
-    id => scope.getOrElse(id, id)
-  }
+  override def rewrite(id: Id): Id = scope.getOrElse(id, id)
 
-  override def stmt: PartialFunction[Stmt, Stmt] = {
+  override def rewrite(s: Stmt): Stmt = s match {
     case core.Def(id, block, body) =>
       // can be recursive
       withBinding(id) { core.Def(rewrite(id), rewrite(block), rewrite(body)) }
@@ -84,9 +82,11 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
     case core.Shift(p, k, body) =>
       val resolvedPrompt = rewrite(p)
       withBinding(k.id) { core.Shift(resolvedPrompt, rewrite(k), rewrite(body)) }
+
+    case other => super.rewrite(other)
   }
 
-  override def block: PartialFunction[Block, Block] = {
+  override def rewrite(b: BlockLit): BlockLit = b match {
     case Block.BlockLit(tparams, cparams, vparams, bparams, body) =>
       withBindings(tparams ++ cparams ++ vparams.map(_.id) ++ bparams.map(_.id)) {
         Block.BlockLit(tparams map rewrite, cparams map rewrite, vparams map rewrite, bparams map rewrite,
@@ -112,9 +112,7 @@ class Renamer(names: Names = Names(Map.empty), prefix: String = "") extends core
         core.ModuleDecl(path, includes, declarations, externs, definitions map rewrite, exports)
     }
 
-  def apply(s: Stmt): Stmt = {
-    rewrite(s)
-  }
+  def apply(s: Stmt): Stmt = rewrite(s)
 }
 
 object Renamer {

--- a/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
+++ b/effekt/shared/src/main/scala/effekt/core/TestRenamer.scala
@@ -68,28 +68,26 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
 
   // Top-level items may be mutually recursive. This means that a bound occurrence may precede its binding.
   // We use a separate pass to collect all top-level ids, so that we can distinguish them from free variables.
-  override def id: PartialFunction[core.Id, core.Id] = {
-    case id =>
-      if (builtins.isCoreBuiltin(id)) {
-        // builtin, do not rename
-        id
-      } else {
-        scopes.collectFirst {
-          // locally bound variable
-          case bnds if bnds.contains(id) => bnds(id)
-        }.getOrElse {
-          if (toplevelScope.contains(id)) {
-            // id references a top-level item
-            toplevelScope(id)
-          } else {
-            // free variable, do not rename
-            id
-          }
+  override def rewrite(id: Id) =
+    if (builtins.isCoreBuiltin(id)) {
+      // builtin, do not rename
+      id
+    } else {
+      scopes.collectFirst {
+        // locally bound variable
+        case bnds if bnds.contains(id) => bnds(id)
+      }.getOrElse {
+        if (toplevelScope.contains(id)) {
+          // id references a top-level item
+          toplevelScope(id)
+        } else {
+          // free variable, do not rename
+          id
         }
       }
-  }
+    }
 
-  override def stmt: PartialFunction[Stmt, Stmt] = {
+  override def rewrite(stmt: Stmt): Stmt = stmt match {
     case core.Def(id, block, body) =>
       // can be recursive
       withBinding(id) { core.Def(rewrite(id), rewrite(block), rewrite(body)) }
@@ -127,9 +125,11 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
     case core.Shift(p, k, body) =>
       val resolvedPrompt = rewrite(p)
       withBinding(k.id) { core.Shift(resolvedPrompt, rewrite(k), rewrite(body)) }
+
+    case other => super.rewrite(other)
   }
 
-  override def block: PartialFunction[Block, Block] = {
+  override def rewrite(b: BlockLit): BlockLit = b match {
     case Block.BlockLit(tparams, cparams, vparams, bparams, body) =>
       withBindings(tparams ++ cparams ++ vparams.map(_.id) ++ bparams.map(_.id)) {
         Block.BlockLit(tparams map rewrite, cparams map rewrite, vparams map rewrite, bparams map rewrite,
@@ -182,7 +182,7 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
     case Template(strings, args) => Template(strings, args map rewrite)
   }
 
-  override def rewrite(e: Extern) = e match {
+  override def rewrite(e: Extern): Extern = e match {
     case Extern.Def(id, tparams, cparams, vparams, bparams, ret, annotatedCapture, body) => {
       // We don't use withBinding(id) here, because top-level ids are pre-collected.
       withBindings(tparams ++ cparams ++ vparams.map(_.id) ++ bparams.map(_.id)) {
@@ -213,7 +213,7 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
     }
   }
 
-  override def rewrite(c: Constructor) = c match {
+  override def rewrite(c: Constructor): Constructor = c match {
     case Constructor(id, tparams, fields) =>
       // We don't use withBinding(id) here, because top-level ids are pre-collected.
       withBindings(tparams) {
@@ -221,12 +221,12 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
       }
   }
 
-  override def rewrite(p: Property) = p match {
+  override def rewrite(p: Property): Property = p match {
     // We don't use withBinding here, because top-level ids are pre-collected.
     case Property(id: Id, tpe: BlockType) => Property(rewrite(id), rewrite(tpe))
   }
 
-  override def rewrite(f: Field) = f match {
+  override def rewrite(f: Field): Field = f match {
     // We don't use withBinding here, because top-level ids are pre-collected.
     case Field(id, tpe) => Field(rewrite(id), rewrite(tpe))
   }
@@ -240,7 +240,7 @@ class TestRenamer(names: Names = Names(Map.empty), prefix: String = "$", preserv
       BlockType.Interface(rewrite(name), targs map rewrite)
   }
 
-  override def rewrite(b: BlockType.Interface) = b match {
+  override def rewrite(b: BlockType.Interface): BlockType.Interface = b match {
     case BlockType.Interface(name, targs) =>
       BlockType.Interface(rewrite(name), targs map rewrite)
   }

--- a/effekt/shared/src/main/scala/effekt/core/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Tree.scala
@@ -410,7 +410,6 @@ object Bind {
     }
 }
 
-
 object Tree {
 
   // Generic traversal of trees, applying the partial function `f` to every contained
@@ -468,65 +467,151 @@ object Tree {
     def query(m: ModuleDecl)(using Ctx) = structuralQuery(m, PartialFunction.empty)
   }
 
-  class Rewrite extends Structural {
-    def id: PartialFunction[Id, Id] = PartialFunction.empty
-    def pure: PartialFunction[Expr, Expr] = PartialFunction.empty
-    def stmt: PartialFunction[Stmt, Stmt] = PartialFunction.empty
-    def toplevel: PartialFunction[Toplevel, Toplevel] = PartialFunction.empty
-    def block: PartialFunction[Block, Block] = PartialFunction.empty
-    def implementation: PartialFunction[Implementation, Implementation] = PartialFunction.empty
+  trait Rewrite {
+    def rewrite(x: Id): Id = x
 
-    def rewrite(x: Id): Id = if id.isDefinedAt(x) then id(x) else x
-    def rewrite(p: Expr): Expr = rewriteStructurally(p, pure)
-    def rewrite(s: Stmt): Stmt = rewriteStructurally(s, stmt)
-    def rewrite(b: Block): Block = rewriteStructurally(b, block)
-    def rewrite(d: Toplevel): Toplevel = rewriteStructurally(d, toplevel)
-    def rewrite(e: Implementation): Implementation = rewriteStructurally(e, implementation)
-    def rewrite(o: Operation): Operation = rewriteStructurally(o)
-    def rewrite(p: ValueParam): ValueParam = rewriteStructurally(p)
-    def rewrite(p: BlockParam): BlockParam = rewriteStructurally(p)
+    def rewrite(p: Expr): Expr = p match {
+      case Expr.ValueVar(id, annotatedType) =>
+        Expr.ValueVar(rewrite(id), rewrite(annotatedType))
+      case Expr.Literal(value, annotatedType) =>
+        Expr.Literal(value, rewrite(annotatedType))
+      case Expr.PureApp(b, targs, vargs) =>
+        Expr.PureApp(rewrite(b), targs map rewrite, vargs map rewrite)
+      case Expr.Make(data, tag, targs, vargs) =>
+        Expr.Make(rewrite(data), rewrite(tag), targs map rewrite, vargs map rewrite)
+      case Expr.Box(b, annotatedCapture) =>
+        Expr.Box(rewrite(b), rewrite(annotatedCapture))
+    }
+    def rewrite(s: Stmt): Stmt = s match {
+      case Stmt.Def(id, block, body) =>
+        Stmt.Def(rewrite(id), rewrite(block), rewrite(body))
+      case Stmt.Let(id, binding, body) =>
+        Stmt.Let(rewrite(id), rewrite(binding), rewrite(body))
+      case Stmt.ImpureApp(id, callee, targs, vargs, bargs, body) =>
+        Stmt.ImpureApp(rewrite(id), rewrite(callee), targs map rewrite, vargs map rewrite, bargs map rewrite, rewrite(body))
+      case Stmt.Return(expr) =>
+        Stmt.Return(rewrite(expr))
+      case Stmt.Val(id, binding, body) =>
+        Stmt.Val(rewrite(id), rewrite(binding), rewrite(body))
+      case Stmt.App(callee, targs, vargs, bargs) =>
+        Stmt.App(rewrite(callee), targs map rewrite, vargs map rewrite, bargs map rewrite)
+      case Stmt.Invoke(callee, method, methodTpe, targs, vargs, bargs) =>
+        Stmt.Invoke(rewrite(callee), rewrite(method), rewrite(methodTpe), targs map rewrite, vargs map rewrite, bargs map rewrite)
+      case Stmt.If(cond, thn, els) =>
+        Stmt.If(rewrite(cond), rewrite(thn), rewrite(els))
+      case Stmt.Match(scrutinee, annotatedTpe, clauses, default) =>
+        Stmt.Match(rewrite(scrutinee), rewrite(annotatedTpe), clauses map rewrite, default map rewrite)
+      case Stmt.Region(body) =>
+        Stmt.Region(rewrite(body))
+      case Stmt.Alloc(id, init, region, body) =>
+        Stmt.Alloc(rewrite(id), rewrite(init), rewrite(region), rewrite(body))
+      case Stmt.Var(ref, init, capture, body) =>
+        Stmt.Var(rewrite(ref), rewrite(init), rewrite(capture), rewrite(body))
+      case Stmt.Get(id, annotatedTpe, ref, annotatedCapt, body) =>
+        Stmt.Get(rewrite(id), rewrite(annotatedTpe), rewrite(ref), rewrite(annotatedCapt), rewrite(body))
+      case Stmt.Put(ref, annotatedCapt, value, body) =>
+        Stmt.Put(rewrite(ref), rewrite(annotatedCapt), rewrite(value), rewrite(body))
+      case Stmt.Reset(body) =>
+        Stmt.Reset(rewrite(body))
+      case Stmt.Shift(prompt, k, body) =>
+        Stmt.Shift(rewrite(prompt), rewrite(k), rewrite(body))
+      case Stmt.Resume(k, body) =>
+        Stmt.Resume(rewrite(k), rewrite(body))
+      case Stmt.Hole(annotatedTpe, span) =>
+        Stmt.Hole(rewrite(annotatedTpe), span)
+    }
+    def rewrite(b: Block): Block = b match {
+      case b @ Block.BlockVar(_, _, _) => rewrite(b)
+      case b @ Block.BlockLit(_, _, _, _, _) => rewrite(b)
+      case Block.Unbox(pure) => Block.Unbox(rewrite(pure))
+      case Block.New(impl) => Block.New(rewrite(impl))
+    }
+    def rewrite(d: Toplevel): Toplevel = d match {
+      case Toplevel.Def(id, block) => Toplevel.Def(rewrite(id), rewrite(block))
+      case Toplevel.Val(id, binding) => Toplevel.Val(rewrite(id), rewrite(binding))
+    }
+    def rewrite(e: Implementation): Implementation = e match {
+      case Implementation(interface, operations) =>
+        Implementation(rewrite(interface), operations map rewrite)
+    }
+    def rewrite(o: Operation): Operation = o match {
+      case Operation(name, tparams, cparams, vparams, bparams, body) =>
+        Operation(rewrite(name), tparams map rewrite, cparams map rewrite, vparams map rewrite, bparams map rewrite, rewrite(body))
+    }
+    def rewrite(p: ValueParam): ValueParam = p match {
+      case ValueParam(id, tpe) => ValueParam(rewrite(id), rewrite(tpe))
+    }
+    def rewrite(p: BlockParam): BlockParam = p match {
+      case BlockParam(id, tpe, capt) => BlockParam(rewrite(id), rewrite(tpe), rewrite(capt))
+    }
     def rewrite(b: ExternBody[Expr]): ExternBody[Expr] = b match {
       case ExternBody.StringExternBody(ff, Template(strings, args)) =>
         ExternBody.StringExternBody(ff, Template(strings, args.map(rewrite)))
       case e: ExternBody.Unsupported => e
     }
-    def rewrite(e: Extern): Extern= e match {
+    def rewrite(e: Extern): Extern = e match {
       case e @ (Extern.Data(_,_,_) | Extern.Include(_,_) | Extern.Interface(_,_,_)) => e
       case Extern.Def(id, tps, cps, vps, bps, ret, capts, body) =>
-        Extern.Def(id, tps, cps, vps, bps, ret, capts, rewrite(body))
+        Extern.Def(rewrite(id), tps map rewrite, cps map rewrite, vps map rewrite, bps map rewrite, rewrite(ret), rewrite(capts), rewrite(body))
     }
-    def rewrite(d: Declaration): Declaration = rewriteStructurally(d)
-    def rewrite(c: Constructor): Constructor = rewriteStructurally(c)
-    def rewrite(f: Field): Field = rewriteStructurally(f)
+    def rewrite(d: Declaration): Declaration = d match {
+      case Declaration.Data(id, tparams, constructors) =>
+        Declaration.Data(rewrite(id), tparams map rewrite, constructors map rewrite)
+      case Declaration.Interface(id, tparams, properties) =>
+        Declaration.Interface(rewrite(id), tparams map rewrite, properties map rewrite)
+    }
+    def rewrite(c: Constructor): Constructor = c match {
+      case Constructor(id, tparams, fields) =>
+        Constructor(rewrite(id), tparams map rewrite, fields map rewrite)
+    }
+    def rewrite(f: Field): Field = f match {
+      case Field(id, tpe) => Field(rewrite(id), rewrite(tpe))
+    }
 
-    def rewrite(b: BlockLit): BlockLit = if block.isDefinedAt(b) then block(b).asInstanceOf else b match {
+    def rewrite(b: BlockLit): BlockLit = b match {
       case BlockLit(tparams, cparams, vparams, bparams, body) =>
         BlockLit(tparams map rewrite, cparams map rewrite, vparams map rewrite, bparams map rewrite, rewrite(body))
     }
-    def rewrite(b: BlockVar): BlockVar = if block.isDefinedAt(b) then block(b).asInstanceOf else b match {
-      case BlockVar(id, annotatedTpe, annotatedCapt) => BlockVar(rewrite(id), rewrite(annotatedTpe), rewrite(annotatedCapt))
+    def rewrite(b: BlockVar): BlockVar = b match {
+      case BlockVar(id, annotatedTpe, annotatedCapt) =>
+        BlockVar(rewrite(id), rewrite(annotatedTpe), rewrite(annotatedCapt))
     }
 
-    def rewrite(t: ValueType): ValueType = rewriteStructurally(t)
-    def rewrite(t: ValueType.Data): ValueType.Data = rewriteStructurally(t)
+    def rewrite(t: ValueType): ValueType = t match {
+      case ValueType.Var(name) => ValueType.Var(rewrite(name))
+      case ValueType.Data(name, targs) => ValueType.Data(rewrite(name), targs map rewrite)
+      case ValueType.Boxed(tpe, capt) => ValueType.Boxed(rewrite(tpe), rewrite(capt))
+    }
+    def rewrite(t: ValueType.Data): ValueType.Data = t match {
+      case ValueType.Data(name, targs) => ValueType.Data(rewrite(name), targs map rewrite)
+    }
 
-    def rewrite(t: BlockType): BlockType = rewriteStructurally(t)
-    def rewrite(t: BlockType.Interface): BlockType.Interface = rewriteStructurally(t)
+    def rewrite(t: BlockType): BlockType = t match {
+      case BlockType.Function(tparams, cparams, vparams, bparams, result) =>
+        BlockType.Function(tparams map rewrite, cparams map rewrite, vparams map rewrite, bparams map rewrite, rewrite(result))
+      case BlockType.Interface(name, targs) =>
+        BlockType.Interface(rewrite(name), targs map rewrite)
+    }
+    def rewrite(t: BlockType.Interface): BlockType.Interface = t match {
+      case BlockType.Interface(name, targs) => BlockType.Interface(rewrite(name), targs map rewrite)
+    }
     def rewrite(capt: Captures): Captures = capt.map(rewrite)
-    def rewrite(p: Property): Property = rewriteStructurally(p)
+    def rewrite(p: Property): Property = p match {
+      case Property(id, tpe) => Property(rewrite(id), rewrite(tpe))
+    }
 
     def rewrite(m: ModuleDecl): ModuleDecl =
       m match {
         case ModuleDecl(path, includes, declarations, externs, definitions, exports) =>
-          ModuleDecl(path, includes, declarations, externs, definitions.map(rewrite), exports)
+          ModuleDecl(path, includes, declarations map rewrite, externs map rewrite, definitions map rewrite, exports map rewrite)
       }
 
     def rewrite(matchClause: (Id, BlockLit)): (Id, BlockLit) = matchClause match {
-      case (p, b) => (p, rewrite(b))
+      case (p, b) => (rewrite(p), rewrite(b))
     }
   }
 
-  class TrampolinedRewrite {
+  trait TrampolinedRewrite {
 
     import Trampoline.done
 
@@ -784,48 +869,147 @@ object Tree {
     }
   }
 
-  class RewriteWithContext[Ctx] extends Structural {
-    def id(using Ctx): PartialFunction[Id, Id] = PartialFunction.empty
-    def expr(using Ctx): PartialFunction[Expr, Expr] = PartialFunction.empty
-    def stmt(using Ctx): PartialFunction[Stmt, Stmt] = PartialFunction.empty
-    def toplevel(using Ctx): PartialFunction[Toplevel, Toplevel] = PartialFunction.empty
-    def block(using Ctx): PartialFunction[Block, Block] = PartialFunction.empty
-    def implementation(using Ctx): PartialFunction[Implementation, Implementation] = PartialFunction.empty
+  class RewriteWithContext[Ctx] {
 
-    def rewrite(x: Id)(using Ctx): Id = if id.isDefinedAt(x) then id(x) else x
-    def rewrite(p: Expr)(using Ctx): Expr = rewriteStructurally(p, expr)
-    def rewrite(s: Stmt)(using Ctx): Stmt = rewriteStructurally(s, stmt)
-    def rewrite(b: Block)(using Ctx): Block = rewriteStructurally(b, block)
-    def rewrite(d: Toplevel)(using Ctx): Toplevel = rewriteStructurally(d, toplevel)
-    def rewrite(e: Implementation)(using Ctx): Implementation = rewriteStructurally(e, implementation)
-    def rewrite(o: Operation)(using Ctx): Operation = rewriteStructurally(o)
-    def rewrite(p: ValueParam)(using Ctx): ValueParam = rewriteStructurally(p)
-    def rewrite(p: BlockParam)(using Ctx): BlockParam = rewriteStructurally(p)
-    def rewrite(b: ExternBody[Expr])(using Ctx): ExternBody[Expr] = rewrite(b)
+    def rewrite(x: Id)(using Ctx): Id = x
+    def rewrite(p: Expr)(using Ctx): Expr = p match {
+      case Expr.ValueVar(id, annotatedType) =>
+        Expr.ValueVar(rewrite(id), rewrite(annotatedType))
+      case Expr.Literal(value, annotatedType) =>
+        Expr.Literal(value, rewrite(annotatedType))
+      case Expr.PureApp(b, targs, vargs) =>
+        Expr.PureApp(rewrite(b), targs map rewrite, vargs map rewrite)
+      case Expr.Make(data, tag, targs, vargs) =>
+        Expr.Make(rewrite(data), rewrite(tag), targs map rewrite, vargs map rewrite)
+      case Expr.Box(b, annotatedCapture) =>
+        Expr.Box(rewrite(b), rewrite(annotatedCapture))
+    }
+    def rewrite(s: Stmt)(using Ctx): Stmt = s match {
+      case Stmt.Def(id, block, body) =>
+        Stmt.Def(rewrite(id), rewrite(block), rewrite(body))
+      case Stmt.Let(id, binding, body) =>
+        Stmt.Let(rewrite(id), rewrite(binding), rewrite(body))
+      case Stmt.ImpureApp(id, callee, targs, vargs, bargs, body) =>
+        Stmt.ImpureApp(rewrite(id), rewrite(callee), targs map rewrite, vargs map rewrite, bargs map rewrite, rewrite(body))
+      case Stmt.Return(expr) =>
+        Stmt.Return(rewrite(expr))
+      case Stmt.Val(id, binding, body) =>
+        Stmt.Val(rewrite(id), rewrite(binding), rewrite(body))
+      case Stmt.App(callee, targs, vargs, bargs) =>
+        Stmt.App(rewrite(callee), targs map rewrite, vargs map rewrite, bargs map rewrite)
+      case Stmt.Invoke(callee, method, methodTpe, targs, vargs, bargs) =>
+        Stmt.Invoke(rewrite(callee), rewrite(method), rewrite(methodTpe), targs map rewrite, vargs map rewrite, bargs map rewrite)
+      case Stmt.If(cond, thn, els) =>
+        Stmt.If(rewrite(cond), rewrite(thn), rewrite(els))
+      case Stmt.Match(scrutinee, annotatedTpe, clauses, default) =>
+        Stmt.Match(rewrite(scrutinee), rewrite(annotatedTpe), clauses map rewrite, default map rewrite)
+      case Stmt.Region(body) =>
+        Stmt.Region(rewrite(body))
+      case Stmt.Alloc(id, init, region, body) =>
+        Stmt.Alloc(rewrite(id), rewrite(init), rewrite(region), rewrite(body))
+      case Stmt.Var(ref, init, capture, body) =>
+        Stmt.Var(rewrite(ref), rewrite(init), rewrite(capture), rewrite(body))
+      case Stmt.Get(id, annotatedTpe, ref, annotatedCapt, body) =>
+        Stmt.Get(rewrite(id), rewrite(annotatedTpe), rewrite(ref), rewrite(annotatedCapt), rewrite(body))
+      case Stmt.Put(ref, annotatedCapt, value, body) =>
+        Stmt.Put(rewrite(ref), rewrite(annotatedCapt), rewrite(value), rewrite(body))
+      case Stmt.Reset(body) =>
+        Stmt.Reset(rewrite(body))
+      case Stmt.Shift(prompt, k, body) =>
+        Stmt.Shift(rewrite(prompt), rewrite(k), rewrite(body))
+      case Stmt.Resume(k, body) =>
+        Stmt.Resume(rewrite(k), rewrite(body))
+      case Stmt.Hole(annotatedTpe, span) =>
+        Stmt.Hole(rewrite(annotatedTpe), span)
+    }
+    def rewrite(b: Block)(using Ctx): Block = b match {
+      case b @ Block.BlockVar(_, _, _) => rewrite(b)
+      case b @ Block.BlockLit(_, _, _, _, _) => rewrite(b)
+      case Block.Unbox(pure) => Block.Unbox(rewrite(pure))
+      case Block.New(impl) => Block.New(rewrite(impl))
+    }
+    def rewrite(d: Toplevel)(using Ctx): Toplevel = d match {
+      case Toplevel.Def(id, block) => Toplevel.Def(rewrite(id), rewrite(block))
+      case Toplevel.Val(id, binding) => Toplevel.Val(rewrite(id), rewrite(binding))
+    }
+    def rewrite(e: Implementation)(using Ctx): Implementation = e match {
+      case Implementation(interface, operations) =>
+        Implementation(rewrite(interface), operations map rewrite)
+    }
+    def rewrite(o: Operation)(using Ctx): Operation = o match {
+      case Operation(name, tparams, cparams, vparams, bparams, body) =>
+        Operation(rewrite(name), tparams map rewrite, cparams map rewrite, vparams map rewrite, bparams map rewrite, rewrite(body))
+    }
+    def rewrite(p: ValueParam)(using Ctx): ValueParam = p match {
+      case ValueParam(id, tpe) => ValueParam(rewrite(id), rewrite(tpe))
+    }
+    def rewrite(p: BlockParam)(using Ctx): BlockParam = p match {
+      case BlockParam(id, tpe, capt) => BlockParam(rewrite(id), rewrite(tpe), rewrite(capt))
+    }
+    def rewrite(b: ExternBody[Expr])(using Ctx): ExternBody[Expr] = b match {
+      case ExternBody.StringExternBody(ff, Template(strings, args)) =>
+        ExternBody.StringExternBody(ff, Template(strings, args.map(rewrite)))
+      case e: ExternBody.Unsupported => e
+    }
+    def rewrite(e: Extern)(using Ctx): Extern = e match {
+      case e @ (Extern.Data(_,_,_) | Extern.Include(_,_) | Extern.Interface(_,_,_)) => e
+      case Extern.Def(id, tps, cps, vps, bps, ret, capts, body) =>
+        Extern.Def(rewrite(id), tps map rewrite, cps map rewrite, vps map rewrite, bps map rewrite, rewrite(ret), rewrite(capts), rewrite(body))
+    }
+    def rewrite(d: Declaration)(using Ctx): Declaration = d match {
+      case Declaration.Data(id, tparams, constructors) =>
+        Declaration.Data(rewrite(id), tparams map rewrite, constructors map rewrite)
+      case Declaration.Interface(id, tparams, properties) =>
+        Declaration.Interface(rewrite(id), tparams map rewrite, properties map rewrite)
+    }
+    def rewrite(c: Constructor)(using Ctx): Constructor = c match {
+      case Constructor(id, tparams, fields) =>
+        Constructor(rewrite(id), tparams map rewrite, fields map rewrite)
+    }
+    def rewrite(f: Field)(using Ctx): Field = f match {
+      case Field(id, tpe) => Field(rewrite(id), rewrite(tpe))
+    }
 
-    def rewrite(b: BlockLit)(using Ctx): BlockLit = if block.isDefinedAt(b) then block(b).asInstanceOf else b match {
+    def rewrite(b: BlockLit)(using Ctx): BlockLit = b match {
       case BlockLit(tparams, cparams, vparams, bparams, body) =>
         BlockLit(tparams map rewrite, cparams map rewrite, vparams map rewrite, bparams map rewrite, rewrite(body))
     }
-    def rewrite(b: BlockVar)(using Ctx): BlockVar = if block.isDefinedAt(b) then block(b).asInstanceOf else b match {
-      case BlockVar(id, annotatedTpe, annotatedCapt) => BlockVar(rewrite(id), rewrite(annotatedTpe), rewrite(annotatedCapt))
+    def rewrite(b: BlockVar)(using Ctx): BlockVar = b match {
+      case BlockVar(id, annotatedTpe, annotatedCapt) =>
+        BlockVar(rewrite(id), rewrite(annotatedTpe), rewrite(annotatedCapt))
     }
 
-    def rewrite(t: ValueType)(using Ctx): ValueType = rewriteStructurally(t)
-    def rewrite(t: ValueType.Data)(using Ctx): ValueType.Data = rewriteStructurally(t)
+    def rewrite(t: ValueType)(using Ctx): ValueType = t match {
+      case ValueType.Var(name) => ValueType.Var(rewrite(name))
+      case ValueType.Data(name, targs) => ValueType.Data(rewrite(name), targs map rewrite)
+      case ValueType.Boxed(tpe, capt) => ValueType.Boxed(rewrite(tpe), rewrite(capt))
+    }
+    def rewrite(t: ValueType.Data)(using Ctx): ValueType.Data = t match {
+      case ValueType.Data(name, targs) => ValueType.Data(rewrite(name), targs map rewrite)
+    }
 
-    def rewrite(t: BlockType)(using Ctx): BlockType = rewriteStructurally(t)
-    def rewrite(t: BlockType.Interface)(using Ctx): BlockType.Interface = rewriteStructurally(t)
+    def rewrite(t: BlockType)(using Ctx): BlockType = t match {
+      case BlockType.Function(tparams, cparams, vparams, bparams, result) =>
+        BlockType.Function(tparams map rewrite, cparams map rewrite, vparams map rewrite, bparams map rewrite, rewrite(result))
+      case BlockType.Interface(name, targs) =>
+        BlockType.Interface(rewrite(name), targs map rewrite)
+    }
+    def rewrite(t: BlockType.Interface)(using Ctx): BlockType.Interface = t match {
+      case BlockType.Interface(name, targs) => BlockType.Interface(rewrite(name), targs map rewrite)
+    }
     def rewrite(capt: Captures)(using Ctx): Captures = capt.map(rewrite)
+    def rewrite(p: Property)(using Ctx): Property = p match {
+      case Property(id, tpe) => Property(rewrite(id), rewrite(tpe))
+    }
 
     def rewrite(m: ModuleDecl)(using Ctx): ModuleDecl =
       m match {
         case ModuleDecl(path, includes, declarations, externs, definitions, exports) =>
-          ModuleDecl(path, includes, declarations, externs, definitions.map(rewrite), exports)
+          ModuleDecl(path, includes, declarations map rewrite, externs map rewrite, definitions map rewrite, exports map rewrite)
       }
 
     def rewrite(matchClause: (Id, BlockLit))(using Ctx): (Id, BlockLit) = matchClause match {
-      case (p, b) => (p, rewrite(b))
+      case (p, b) => (rewrite(p), rewrite(b))
     }
   }
 }

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/DirectStyle.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/DirectStyle.scala
@@ -4,7 +4,7 @@ package optimizer
 
 object DirectStyle extends Tree.Rewrite {
 
-  override def stmt = {
+  override def rewrite(s: Stmt): Stmt = s match {
 
     // val x = { ... return 42 }; stmt2
     //
@@ -24,6 +24,7 @@ object DirectStyle extends Tree.Rewrite {
       else
         Val(id, rewrittenBinding, rewrittenBody)
 
+    case other => super.rewrite(other)
   }
 
   private def canBeDirect(s: Stmt): Boolean = s match {

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/DropBindings.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/DropBindings.scala
@@ -46,14 +46,16 @@ object DropBindings extends Phase[CoreTransformed, CoreTransformed] {
 
   private object dropping extends Tree.RewriteWithContext[DropContext] {
 
-    override def expr(using DropContext) = {
+    override def rewrite(expr: Expr)(using DropContext): Expr = expr match {
       case Expr.ValueVar(id, tpe) if usedOnce(id) && hasDefinition(id) => definitionOf(id)
+      case other => super.rewrite(other)
     }
 
-    override def stmt(using C: DropContext) = {
+    override def rewrite(stmt: Stmt)(using C: DropContext): Stmt = stmt match {
       case Stmt.Let(id, p: Expr, body) if usedOnce(id) =>
         val transformed = rewrite(p)
         rewrite(body)(using C.updated(id, transformed))
+      case other => super.rewrite(other)
     }
   }
 }

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/RemoveTailResumptions.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/RemoveTailResumptions.scala
@@ -7,10 +7,11 @@ object RemoveTailResumptions {
   def apply(m: ModuleDecl): ModuleDecl = removal.rewrite(m)
 
   object removal extends Tree.Rewrite {
-    override def stmt: PartialFunction[Stmt, Stmt] = {
+    override def rewrite(stmt: Stmt): Stmt = stmt match {
       case Stmt.Shift(prompt, BlockParam(k, Type.TResume(from, to), capt), body) if tailResumptive(k, body) =>
         removeTailResumption(k, from, body)
-      case Stmt.Shift(prompt, k, body) => Shift(prompt, k, rewrite(body))
+
+      case other => super.rewrite(other)
     }
   }
 

--- a/effekt/shared/src/main/scala/effekt/core/optimizer/StaticArguments.scala
+++ b/effekt/shared/src/main/scala/effekt/core/optimizer/StaticArguments.scala
@@ -14,6 +14,11 @@ import effekt.core.Type.returnType
  */
 object StaticArguments {
 
+  enum ArgumentType {
+    case Static(name: String)
+    case NonStatic
+  }
+
   case class IsStatic(
     types: List[Boolean],
     values: List[Boolean],
@@ -105,7 +110,7 @@ object StaticArguments {
         dropStatic(staticB, blockLit.cparams),
         dropStatic(staticV, blockLit.vparams),
         dropStatic(staticB, blockLit.bparams),
-        rewrite(blockLit.body)(using enterFunction(id))
+        rewriter.rewrite(blockLit.body)(using enterFunction(id))
       ), App(
         workerVar,
         dropStatic(staticT, blockLit.tparams.map(t => ValueType.Var(t))),
@@ -115,89 +120,31 @@ object StaticArguments {
     )
   }
 
-  def rewrite(d: Toplevel)(using StaticArgumentsContext): Toplevel = d match {
-    case Toplevel.Def(id, block: BlockLit) if hasStatics(id) => Toplevel.Def(id, wrapDefinition(id, block))
-    case Toplevel.Def(id, block) => Toplevel.Def(id, rewrite(block))
-    case Toplevel.Val(id, binding) => Toplevel.Val(id, rewrite(binding))
-  }
+  object rewriter extends Tree.RewriteWithContext[StaticArgumentsContext] {
+    override def rewrite(d: Toplevel)(using StaticArgumentsContext): Toplevel = d match {
+     case Toplevel.Def(id, block: BlockLit) if hasStatics(id) =>
+       Toplevel.Def(id, wrapDefinition(id, block))
 
-  def rewrite(s: Stmt)(using C: StaticArgumentsContext): Stmt = s match {
-
-    case Stmt.Def(id, block: BlockLit, body) if hasStatics(id) => Stmt.Def(id, wrapDefinition(id, block), rewrite(body))
-    case Stmt.Def(id, block, body) => Stmt.Def(id, rewrite(block), rewrite(body))
-
-    case Stmt.Let(id, binding, body) => Stmt.Let(id, rewrite(binding), rewrite(body))
-
-    case Stmt.ImpureApp(id, callee, targs, vargs, bargs, body) =>
-      Stmt.ImpureApp(id, callee, targs, vargs.map(rewrite), bargs.map(rewrite), rewrite(body))
-
-    case Stmt.App(b, targs, vargs, bargs) =>
-      b match {
-        // if arguments are static && recursive call: call worker with reduced arguments
-        case BlockVar(id, annotatedTpe, annotatedCapt) if hasStatics(id) && within(id) =>
-          val IsStatic(staticT, staticV, staticB) = C.statics(id)
-          Stmt.App(C.workers(id),
-            dropStatic(staticT, targs),
-            dropStatic(staticV, vargs).map(rewrite),
-            dropStatic(staticB, bargs).map(rewrite))
-        case _ => Stmt.App(rewrite(b), targs, vargs.map(rewrite), bargs.map(rewrite))
-      }
-
-    case Stmt.Invoke(b, method, methodTpe, targs, vargs, bargs) =>
-      Stmt.Invoke(rewrite(b), method, methodTpe, targs, vargs.map(rewrite), bargs.map(rewrite))
-
-    case Stmt.Reset(body) =>
-      rewrite(body) match {
-        case b => Stmt.Reset(b)
-      }
-
-    // congruences
-    case Stmt.Return(expr) => Return(rewrite(expr))
-    case Stmt.Val(id, binding, body) => Stmt.Val(id, rewrite(binding), rewrite(body))
-    case Stmt.If(cond, thn, els) => If(rewrite(cond), rewrite(thn), rewrite(els))
-    case Stmt.Match(scrutinee, tpe, clauses, default) => Stmt.Match(rewrite(scrutinee), tpe, clauses.map { case (id, value) => id -> rewrite(value) }, default.map(rewrite))
-    case Stmt.Alloc(id, init, region, body) => Alloc(id, rewrite(init), region, rewrite(body))
-    case Stmt.Shift(prompt, k, body) => Shift(prompt, k, rewrite(body))
-    case Stmt.Resume(k, body) => Resume(k, rewrite(body))
-    case Stmt.Region(body) => Region(rewrite(body))
-    case Stmt.Var(ref, init, capture, body) => Stmt.Var(ref, rewrite(init), capture, rewrite(body))
-    case Stmt.Get(id, tpe, ref, capt, body) => Stmt.Get(id, tpe, ref, capt, rewrite(body))
-    case Stmt.Put(ref, capt, value, body) => Stmt.Put(ref, capt, rewrite(value), rewrite(body))
-    case Stmt.Hole(tpe, span) => Stmt.Hole(tpe, span)
-  }
-  def rewrite(b: BlockLit)(using StaticArgumentsContext): BlockLit =
-    b match {
-      case BlockLit(tparams, cparams, vparams, bparams, body) =>
-        BlockLit(tparams, cparams, vparams, bparams, rewrite(body))
+     case other => super.rewrite(other)
     }
 
-  def rewrite(b: Block)(using C: StaticArgumentsContext): Block = b match {
-    case b @ Block.BlockVar(id, _, _) => b
+    override def rewrite(s: Stmt)(using C: StaticArgumentsContext): Stmt = s match {
+      case Stmt.Def(id, block: BlockLit, body) if hasStatics(id) =>
+        Stmt.Def(id, wrapDefinition(id, block), rewrite(body))
 
-    // congruences
-    case b @ Block.BlockLit(tparams, cparams, vparams, bparams, body) => rewrite(b)
-    case Block.Unbox(expr) => Block.Unbox(rewrite(expr))
-    case Block.New(impl) => Block.New(rewrite(impl))
-  }
+      // if arguments are static && recursive call: call worker with reduced arguments
+      case Stmt.App(BlockVar(id, annotatedTpe, annotatedCapt), targs, vargs, bargs) if hasStatics(id) && within(id) =>
+        val IsStatic(staticT, staticV, staticB) = C.statics(id)
+        Stmt.App(C.workers(id),
+          dropStatic(staticT, targs),
+          dropStatic(staticV, vargs).map(rewrite),
+          dropStatic(staticB, bargs).map(rewrite))
 
-  def rewrite(s: Implementation)(using StaticArgumentsContext): Implementation =
-    s match {
-      case Implementation(interface, operations) => Implementation(interface, operations.map { op =>
-        op.copy(body = rewrite(op.body))
-      })
+      case other => super.rewrite(other)
     }
-
-  def rewrite(p: Expr)(using StaticArgumentsContext): Expr = p match {
-    case Expr.PureApp(f, targs, vargs) => Expr.PureApp(f, targs, vargs.map(rewrite))
-    case Expr.Make(data, tag, targs, vargs) => Expr.Make(data, tag, targs, vargs.map(rewrite))
-    case x @ Expr.ValueVar(id, annotatedType) => x
-
-    // congruences
-    case Expr.Literal(value, annotatedType) => p
-    case Expr.Box(b, annotatedCapture) => Expr.Box(rewrite(b), annotatedCapture)
   }
 
-  def transform(entrypoint: Id, m: ModuleDecl): ModuleDecl =
+  def transform(entrypoint: Id, m: ModuleDecl): ModuleDecl = {
     val recursiveFunctions = Recursive(m)
 
     val statics: Map[Id, IsStatic] = recursiveFunctions.map {
@@ -229,11 +176,7 @@ object StaticArguments {
       List()
     )
 
-    val updatedDefs = m.definitions.map(rewrite)
+    val updatedDefs = m.definitions.map(rewriter.rewrite)
     m.copy(definitions = updatedDefs)
-}
-
-enum ArgumentType {
-  case Static(name: String)
-  case NonStatic
+  }
 }


### PR DESCRIPTION
In this PR I am trying to get rid of more usages of the macro by explicating the traversal in `Tree.Rewrite` manually. Instead of specifying the special cases in partial functions, now users have to override the specific `rewrite` method for the nonterminal of interest and call `super.rewrite(...)` for the homomorphic cases.