### PR TITLE
Resolve flaky ReparseTests by making coreBuiltins lazy

### DIFF
--- a/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
+++ b/effekt/shared/src/main/scala/effekt/symbols/builtins.scala
@@ -102,7 +102,7 @@ object builtins {
     Bindings(Map.empty, rootTypes, rootCaptures, Map("effekt" -> Bindings(Map.empty, rootTypes, rootCaptures, Map.empty)))
 
   // All built-in symbols that can occur in core programs
-  val coreBuiltins: Map[String, symbols.Symbol] = {
+  lazy val coreBuiltins: Map[String, symbols.Symbol] = {
     symbols.builtins.rootTypes
       ++ symbols.builtins.rootCaptures
       + ("Resume" -> ResumeSymbol)


### PR DESCRIPTION
ReparseTests have been flaky for a while. There was a problem in initialization order of Files / Classes

PromptSymbol & ResumeSymbol are initialized in core.Type. 
In symbols.builtins we use these values to build the `coreBuiltin` lookup table. Sometimes PromptSymbol & ResumeSymbol were not initialized when building this Map and therefore `null`. 

When we later look up these names we get crashes in the tests.