### PR TITLE
Improve CRLF support in lexer

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -76,7 +76,7 @@ jobs:
         run: sbt Test/compile
 
       - name: Run Windows smoke test
-        run: sbt "effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\[...]; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*casestudies[\[...]"
+        run: sbt "effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*casestudies.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\[...]"
 
   macos-llvm-tests:
     name: "macOS LLVM Smoke Tests"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -76,7 +76,7 @@ jobs:
         run: sbt Test/compile
 
       - name: Run Windows smoke test
-        run: sbt "effektJVM/testOnly effekt.JavaScriptTests"
+        run: sbt "effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\[...]; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*casestudies[\[...]"
 
   macos-llvm-tests:
     name: "macOS LLVM Smoke Tests"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -76,7 +76,7 @@ jobs:
         run: sbt Test/compile
 
       - name: Run Windows smoke test
-        run: sbt "effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*pos[\\/]*sideeffects.*"
+        run: sbt "effektJVM/testOnly effekt.JavaScriptTests"
 
   macos-llvm-tests:
     name: "macOS LLVM Smoke Tests"

--- a/effekt/jvm/src/test/scala/effekt/LexerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LexerTests.scala
@@ -476,6 +476,22 @@ class LexerTests extends munit.FunSuite {
     )
   }
 
+  test("single-line string unexpectedly ends with CRLF") {
+    val prog = "val s = \"hello\r\n"
+    assertTokensEq(
+      prog,
+      `val`, Ident("s"), `=`, Error(UnterminatedStringLike(Str("hello", multiline = false))), Newline, EOF
+    )
+  }
+
+  test("single-line string unexpectedly ends with LF") {
+    val prog = "val s = \"hello\n"
+    assertTokensEq(
+      prog,
+      `val`, Ident("s"), `=`, Error(UnterminatedStringLike(Str("hello", multiline = false))), Newline, EOF
+    )
+  }
+
   def assertSuccessFile(filename: String): Unit = {
     // val start = System.nanoTime()
     val file = scala.io.Source.fromFile(filename).mkString

--- a/effekt/jvm/src/test/scala/effekt/LexerTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/LexerTests.scala
@@ -352,6 +352,26 @@ class LexerTests extends munit.FunSuite {
     )
   }
 
+  test("singleline comment ends with CRLF") {
+    val prog = "// foo\r\nval x = 2"
+    assertTokensEq(
+      prog,
+      Comment(" foo"), Newline,
+      `val`, Ident("x"), `=`, Integer(2),
+      EOF
+    )
+  }
+
+  test("singleline comment ends with LF") {
+    val prog = "// foo\nval x = 2"
+    assertTokensEq(
+      prog,
+      Comment(" foo"), Newline,
+      `val`, Ident("x"), `=`, Integer(2),
+      EOF
+    )
+  }
+
   test("multiline comment") {
     val prog =
       """val x = 42

--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -32,7 +32,8 @@ object SpanSyntax {
     }
 
     def sourceAndPositions: (Source, Seq[Int]) = {
-      val lines = content.stripMargin.split("\n").toBuffer
+      val normalized = content.stripMargin.replace("\r\n", "\n")
+      val lines = normalized.split("\n", -1).toBuffer
       val positions = scala.collection.mutable.ArrayBuffer[Int]()
       var lineIdx = 0
       var lineBytePos = 0
@@ -230,7 +231,8 @@ class ParserTests extends munit.FunSuite {
 
     val textWithoutSpan =
       raw"""There is some content here.
-           |And here.""".stripMargin
+           |And here.
+           |""".stripMargin.replace("\r\n", "\n")
 
     assertEquals(span.from, 4)
     assertEquals(span.to, 33)

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -569,7 +569,7 @@ class Lexer(source: Source) extends Iterator[Token] {
 
     if hexString.length > 2 then
       return TokenKind.Error(LexerError.InvalidByteFormat)
-    
+
     try {
       val byte = java.lang.Integer.parseInt(hexString, 16)
       assert(byte >= 0 && byte <= 255)
@@ -650,6 +650,8 @@ class Lexer(source: Source) extends Iterator[Token] {
         // newlines
         case ('\n', _) if !delimiter.isMultiline =>
           return close(unterminated = true)
+        case ('\r', '\n') if !delimiter.isMultiline =>
+          return close(unterminated = true)
 
         // "normal" characters of a string
         case (_, _) => contents.addOne(advance())
@@ -687,7 +689,7 @@ class Lexer(source: Source) extends Iterator[Token] {
 
   private def singlelineComment(): TokenKind =
     val isDocComment = currentChar == '/'
-    advanceWhile { (curr, _) => curr != '\n' }
+    advanceWhile { (curr, _) => curr != '\n' && curr != '\r' }
 
     if isDocComment then
       TokenKind.DocComment(getCurrentSlice(skipAfterStart = 3)) // Remove '///'

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -713,7 +713,7 @@ class Lexer(source: Source) extends Iterator[Token] {
       TokenKind.Comment(comment)
 
   private def shebang(): TokenKind =
-    advanceWhile { (curr, _) => curr != '\n' }
+    advanceWhile { (curr, _) => curr != '\n' && curr != '\r' }
     val command = getCurrentSlice(skipAfterStart = 2) // Remove `#!`
     TokenKind.Shebang(command)
 }


### PR DESCRIPTION
This change should help with resolving #1183, though I can't confirm it's solved completely while being on a Mac.

I also changed the Windows smoke tests to run the case studies -- hopefully this means a slightly bigger subset of the language being checked on Windows CI :)