### PR TITLE
Add support for trailing commas

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/ParserTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/ParserTests.scala
@@ -147,6 +147,13 @@ class ParserTests extends munit.FunSuite {
   def parseInfo(input: String)(using munit.Location): Info =
     parse(input, _.info())
 
+  def parseRecovering[R](input: String, f: Parser => R)(using munit.Location): List[RecoverableDiagnostic] = {
+    val p = parser(input)
+    f(p)
+    assert(p.peek(TokenKind.EOF), s"Did not consume everything: ${p.peek}")
+    p.recoverableDiagnostics.toList
+  }
+
   // Custom asserts
   //
   //
@@ -326,7 +333,9 @@ class ParserTests extends munit.FunSuite {
     parseExpr("[1,2,3]")
     parseExpr("[3,2,1,]")
     parseExpr("[]")
-    parseExpr("[,]")
+
+    // a comma with nothing before it is not an empty list
+    intercept[Throwable] { parseExpr("[,]") }
     intercept[Throwable] { parseExpr("[,1]") }
   }
 
@@ -1686,5 +1695,82 @@ class ParserTests extends munit.FunSuite {
       "llvm \"\"\"call void @c_io_println_String(%Pos %value); ret %Pos zeroinitializer ; Unit\"\"\"" + "\n" +
       "extern js \"\"\" function \"\"\""
     )
+  }
+
+  test("Trailing commas") {
+    // valueArgs
+    parseExpr("f(1, 2,)")
+    parseExpr("f(x,)")
+
+    // valueParams
+    parseDefinition("def f(x: Int, y: Int,) = 1")
+    parseParams("(x: Int,)")
+    parseDefinition("record R(x: Int, y: Int,)")
+
+    // valueParamsOpt
+    parseLambdaParams("(x, y,)")
+
+    // valueTypes
+    parseValueType("(Int, String,) => Int")
+
+    // typeArgs
+    parseValueType("List[Int,]")
+    parseExpr("f[Int, String,](1)")
+
+    // typeParams
+    parseDefinition("def f[A, B,](x: A) = x")
+
+    // captureSet
+    parseValueType("() => Int at {a, b,}")
+
+    // effects
+    parseReturnAnnotation(": Int / {Exc, State,}")
+
+    // matchPattern: constructor pattern
+    parseMatchPattern("Some(x,)")
+
+    // matchPattern: tuple pattern
+    parseMatchPattern("(x, y,)")
+
+    // tupleOrGroup
+    parseExpr("(1, 2,)")
+
+    // atomicType tuple
+    parseValueType("(Int, String,)")
+
+    // listLiteral
+    parseExpr("[1, 2,]")
+
+    // trailing comma leaves no trace in the tree
+    assertEqualModuloSpans(parseExpr("f(1, 2,)"), parseExpr("f(1, 2)"))
+    assertEqualModuloSpans(parseValueType("List[Int,]"), parseValueType("List[Int]"))
+    assertEqualModuloSpans(parseDefinition("def f(x: Int,) = x"), parseDefinition("def f(x: Int) = x"))
+    assertEqualModuloSpans(parseExpr("(1, 2,)"), parseExpr("(1, 2)"))
+
+    // with trailing commas, `(x,)` would parse as a grouping, although it looks like a tuple
+    assert(parseRecovering("(x,)", _.expr()).nonEmpty, "`(x,)` should soft fail")
+    assert(parseRecovering("(1,)", _.expr()).nonEmpty, "`(1,)` should soft fail")
+    assert(parseRecovering("(Int,)", _.valueType()).nonEmpty, "`(Int,)` should soft fail")
+
+    // ... but it still parses as the grouping it looks like
+    assertEqualModuloSpans(parseExpr("(x,)"), parseExpr("(x)"))
+
+    // no recovery needed for `f(x,)` and similar
+    assert(parseRecovering("f(x,)", _.expr()).isEmpty, "`f(x,)` is a one-element argument list")
+    assert(parseRecovering("[x,]", _.expr()).isEmpty, "`[x,]` is a one-element list literal")
+    assert(parseRecovering("(x: Int,)", _.params()).isEmpty, "`(x: Int,)` is a one-element parameter list")
+    assert(parseRecovering("List[Int,]", _.valueType()).isEmpty, "`List[Int,]` is a one-element type-argument list")
+
+    // ... so `(1, 2,)` is an ordinary tuple
+    assert(parseRecovering("(1, 2,)", _.expr()).isEmpty, "`(1, 2,)` is an ordinary tuple")
+
+    // only trailing -> error
+    intercept[Throwable] { parseExpr("f(,)") }
+    intercept[Throwable] { parseValueType("List[,]") }
+    intercept[Throwable] { parseParams("(,)") }
+    // two commas -> error
+    intercept[Throwable] { parseExpr("f(1,,2)") }
+    intercept[Throwable] { parseExpr("[1,,2]") }
+    intercept[Throwable] { parseExpr("f(1, 2,,)") }
   }
 }

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -1100,7 +1100,7 @@ class Parser(tokens: Seq[Token], source: Source) {
     given PrecedenceTable = table
     // since by default, the associativity is left-associative, we only need to specify it for the cases where it is different
     table.declare(Associativity.None, `===`, `!==`, `<=`, `>=`, `<`, `>`)
-    // We want `+` and `-` (as well as `*` and `/`) to bind equally strong and use associativity instead to disambiguate 
+    // We want `+` and `-` (as well as `*` and `/`) to bind equally strong and use associativity instead to disambiguate
     `+` =?= `-`
     `*` =?= `/`
     Set(`||`) ?< Set(`&&`)
@@ -1191,7 +1191,7 @@ class Parser(tokens: Seq[Token], source: Source) {
     case `>=` => "infixGte"
     case `:=` => "infixColonEq"
     case `+`  => "infixPlus"
-    // `+=` (`-=`, `*=`, `/=`) has the same name as `+` (`-`, `*`, `/`) due to the way it is manually desugared in [[ primExpr ]] 
+    // `+=` (`-=`, `*=`, `/=`) has the same name as `+` (`-`, `*`, `/`) due to the way it is manually desugared in [[ primExpr ]]
     case `+=` => "infixPlus"
     case `-`  => "infixMinus"
     case `-=` => "infixMinus"

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -1835,7 +1835,7 @@ class Parser(tokens: Seq[Token], source: Source) {
 
   /**
    * Parses `p (sep p)* sep? after` in order to deduplicate work in [[some]] and [[many]].
-   * Soft fails when `failOnSingleton` is set and the "list" has one element and a trailing separator.
+   * Soft fails when [[failOnSingleton]] is set and the "list" has one element and a trailing separator.
    */
   private inline def delimitedUntil[T](
     p: () => T, sep: TokenKind, after: TokenKind,

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -297,7 +297,7 @@ class Parser(tokens: Seq[Token], source: Source) {
   def withStmt(inBraces: Boolean): Stmt = `with` ~> peek.kind match {
     case `val` =>
       consume(`val`)
-      val patterns = some(matchPattern, `,`)
+      val patterns = someSep(matchPattern, `,`)
       val guards = manyWhile(`and` ~> matchGuard(), `and`)
       val call = `=` ~> expr()
       val fallback = when(`else`) { Some(stmt()) } { None }
@@ -489,7 +489,7 @@ class Parser(tokens: Seq[Token], source: Source) {
       Include(`import` ~> moduleName(), span())
 
   def moduleName(): String =
-    some(ident, `/`).mkString("/") labelled "module name"
+    someSep(ident, `/`).mkString("/") labelled "module name"
 
   def isToplevel: Boolean = peek.kind match {
     case `val` | `def` | `type` | `effect` | `namespace` | `interface` | `type` | `record` | `var` | `include` | `extern` => true
@@ -993,7 +993,7 @@ class Parser(tokens: Seq[Token], source: Source) {
 
   def matchClause(): MatchClause =
     nonterminal:
-      val patterns = `case` ~> some(matchPattern, `,`)
+      val patterns = `case` ~> someSep(matchPattern, `,`)
       val pattern: MatchPattern = patterns match {
         case Many(List(pat), _) => pat
         case pats => MultiPattern(pats.unspan, pats.span)
@@ -1007,7 +1007,7 @@ class Parser(tokens: Seq[Token], source: Source) {
 
   def matchGuards() =
     nonterminal:
-      some(matchGuard, `and`)
+      someSep(matchGuard, `and`)
 
   def matchGuard(): MatchGuard =
     nonterminal:
@@ -1502,13 +1502,13 @@ class Parser(tokens: Seq[Token], source: Source) {
 
   def idRef(): IdRef =
     nonterminal:
-      some(ident, PathSep) match {
+      someSep(ident, PathSep) match {
         case ids => IdRef(ids.init, ids.last, span())
       }
 
   def idDef(): IdDef =
     nonterminal:
-      some(ident, PathSep) match {
+      someSep(ident, PathSep) match {
         case ids => IdDef(ids.init, ids.last, span())
       }
 
@@ -1843,7 +1843,10 @@ class Parser(tokens: Seq[Token], source: Source) {
       consume(after)
       Many(res.unspan, span())
 
-  inline def some[T](p: () => T, sep: TokenKind): Many[T] =
+  /**
+   * Repeats [[p]] at least once, separated by [[sep]]. No trailing commas supported (no delimiters).
+   */
+  inline def someSep[T](p: () => T, sep: TokenKind): Many[T] =
     nonterminal:
       val components: ListBuffer[T] = ListBuffer.empty
       components += p()

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -1364,7 +1364,7 @@ class Parser(tokens: Seq[Token], source: Source) {
   }
   def listLiteral(): Term =
     nonterminal:
-      manyTrailing(() => spanned(expr()), `[`, `,`, `]`).foldRight(NilTree) { ConsTree }
+      many(() => spanned(expr()), `[`, `,`, `]`).unspan.foldRight(NilTree) { ConsTree }
 
   private def NilTree: Term =
     Call(IdTarget(IdRef(List(), "Nil", span())), Nil, Nil, Nil, span())
@@ -1381,7 +1381,7 @@ class Parser(tokens: Seq[Token], source: Source) {
   def isTupleOrGroup: Boolean = peek(`(`)
   def tupleOrGroup(): Term =
     nonterminal:
-      some(expr, `(`, `,`, `)`) match {
+      some(expr, `(`, `,`, `)`, failOnSingleton = true) match {
         case Many(e :: Nil, _) => e
         case Many(xs, _) => Call(IdTarget(IdRef(List("effekt"), s"Tuple${xs.size}", span().synthesized)), Nil, xs.map(ValueArg.Unnamed), Nil, span().synthesized)
       }
@@ -1566,7 +1566,7 @@ class Parser(tokens: Seq[Token], source: Source) {
     nonterminal:
       peek.kind match {
         case `(` =>
-          some(boxedType, `(`, `,`, `)`) match {
+          some(boxedType, `(`, `,`, `)`, failOnSingleton = true) match {
             case Many(tpe :: Nil, _) => tpe
             case tpes => TypeTuple(tpes)
           }
@@ -1834,14 +1834,39 @@ class Parser(tokens: Seq[Token], source: Source) {
   }
 
   /**
-   * Repeats [[p]], separated by [[sep]] enclosed by [[before]] and [[after]]
+   * Parses `p (sep p)* sep? after` in order to deduplicate work in [[some]] and [[many]].
+   * Soft fails when `failOnSingleton` is set and the "list" has one element and a trailing separator.
    */
-  inline def some[T](p: () => T, before: TokenKind, sep: TokenKind, after: TokenKind): Many[T] =
+  private inline def delimitedUntil[T](
+    p: () => T, sep: TokenKind, after: TokenKind,
+    inline failOnSingleton: Boolean
+  ): List[T] =
+    val components: ListBuffer[T] = ListBuffer.empty
+    components += p()
+    while (peek(sep)) {
+      consume(sep)
+      if (!peek(after)) { // if `after` follows `sep`, then it was trailing
+        components += p()
+      } else if (failOnSingleton && components.size == 1) {
+        // NOTE(jiribenes, 2026-07-31): As of the time of writing, this is exclusively fired for the tuple/grouping overload, so the message is phrased for tuples.
+        softFail(s"There are no one-element tuples. Remove the trailing `${explain(sep)}` to group, or add another element.",
+          position - 1, position - 1) // `position - 1` is the `sep` we just consumed
+      }
+    }
+    consume(after)
+    components.toList
+
+  /**
+   * Repeats [[p]], separated by [[sep]] enclosed by [[before]] and [[after]].
+   *
+   * Set [[failOnSingleton]] where the delimiters are overloaded and a one-element list is not a
+   * list at all but just a grouping, i.e., when `(x,)` denotes `(x)`, like with tuples vs groupings.
+   */
+  inline def some[T](p: () => T, before: TokenKind, sep: TokenKind, after: TokenKind,
+                     inline failOnSingleton: Boolean = false): Many[T] =
     nonterminal:
       consume(before)
-      val res = some(p, sep)
-      consume(after)
-      Many(res.unspan, span())
+      Many(delimitedUntil(p, sep, after, failOnSingleton), span())
 
   /**
    * Repeats [[p]] at least once, separated by [[sep]]. No trailing commas supported (no delimiters).
@@ -1903,39 +1928,8 @@ class Parser(tokens: Seq[Token], source: Source) {
         consume(after)
         Many.empty(span())
       } else {
-        val components: ListBuffer[T] = ListBuffer.empty
-        components += p()
-        while (peek(sep)) {
-          consume(sep)
-          components += p()
-        }
-        consume(after)
-        Many(components.toList,span())
+        Many(delimitedUntil(p, sep, after, failOnSingleton = false), span())
       }
-
-
-  inline def manyTrailing[T](p: () => T, before: TokenKind, sep: TokenKind, after: TokenKind): List[T] =
-    consume(before)
-    if (peek(after)) {
-      consume(after)
-      Nil
-    } else if (peek(sep)) {
-      consume(sep)
-      consume(after)
-      Nil
-    } else {
-      val components: ListBuffer[T] = ListBuffer.empty
-      components += p()
-      while (peek(sep)) {
-        consume(sep)
-
-        if (!peek(after)) {
-          components += p()
-        }
-      }
-      consume(after)
-      components.toList
-    }
 
 
   // Positions

--- a/examples/neg/parsing/trailing-comma-singleton.check
+++ b/examples/neg/parsing/trailing-comma-singleton.check
@@ -1,0 +1,6 @@
+[error] examples/neg/parsing/trailing_comma_singleton.effekt:2:13: There are no one-element tuples. Remove the trailing `,` to group, or add another element.
+  val a = (1,) // would mean `1` if not for the soft fail
+            ^
+[error] examples/neg/parsing/trailing-comma-singleton.effekt:4:14: There are no one-element tuples. Remove the trailing `,` to group, or add another element.
+  val c: (Int,) = 4  // would mean `Int` if not for the soft fail
+             ^

--- a/examples/neg/parsing/trailing-comma-singleton.check
+++ b/examples/neg/parsing/trailing-comma-singleton.check
@@ -1,4 +1,4 @@
-[error] examples/neg/parsing/trailing_comma_singleton.effekt:2:13: There are no one-element tuples. Remove the trailing `,` to group, or add another element.
+[error] examples/neg/parsing/trailing-comma-singleton.effekt:2:13: There are no one-element tuples. Remove the trailing `,` to group, or add another element.
   val a = (1,) // would mean `1` if not for the soft fail
             ^
 [error] examples/neg/parsing/trailing-comma-singleton.effekt:4:14: There are no one-element tuples. Remove the trailing `,` to group, or add another element.

--- a/examples/neg/parsing/trailing-comma-singleton.effekt
+++ b/examples/neg/parsing/trailing-comma-singleton.effekt
@@ -1,0 +1,11 @@
+def main() = {
+  val a = (1,) // would mean `1` if not for the soft fail
+  val b = (2, 3,)
+  val c: (Int,) = 4  // would mean `Int` if not for the soft fail
+  val d: (Int, Int,) = (5, 6,)
+
+  println(a)
+  println(b.second)
+  println(c)
+  println(d.first)
+}


### PR DESCRIPTION
Continues the work of #873 and #900 by allowing trailing commas everywhere*.

\*The single exception being `(x,)` and `(Int,)` which would look like singleton tuples, but are actually groupings (that is, equivalent to `(x)` and `(Int)`) -- we have a special recovered error for those.