### PR TITLE
CI: Temporarily disable macOS LLVM smoke tests

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -78,24 +78,25 @@ jobs:
       - name: Run Windows smoke test
         run: sbt "effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*casestudies.*; effektJVM/testOnly effekt.JavaScriptTests -- --tests=.*examples[\\/]*neg[\[...]"
 
-  macos-llvm-tests:
-    name: "macOS LLVM Smoke Tests"
-    needs: build-and-compile
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: 'true'
+  # # temporarily disabled, see PR #1419
+  # macos-llvm-tests:
+  #   name: "macOS LLVM Smoke Tests"
+  #   needs: build-and-compile
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #       with:
+  #         submodules: 'true'
 
-      - uses: ./.github/actions/setup-effekt
-        with:
-          install-dependencies: 'true'
+  #     - uses: ./.github/actions/setup-effekt
+  #       with:
+  #         install-dependencies: 'true'
 
-      - name: Compile project
-        run: sbt Test/compile
+  #     - name: Compile project
+  #       run: sbt Test/compile
 
-      - name: Run macOS LLVM smoke tests (with debug)
-        run: EFFEKT_DEBUG=1 sbt "effektJVM/testOnly effekt.LLVMTests -- --tests=.*benchmarks[\\/]*input_output[\\/].*"
+  #     - name: Run macOS LLVM smoke tests (with debug)
+  #       run: EFFEKT_DEBUG=1 sbt "effektJVM/testOnly effekt.LLVMTests -- --tests=.*benchmarks[\\/]*input_output[\\/].*"
 
   js-tests:
     name: "JS Backend"


### PR DESCRIPTION
Apparently they don't work and I have to cancel them manually...