### PR TITLE
Tidy up stdlib 'map' and 'set'

### DIFF
--- a/examples/stdlib/map/collect.check
+++ b/examples/stdlib/map/collect.check
@@ -1,0 +1,17 @@
+m1 := map::collect { stream() }
+m1.toList.foreach === m1.foreach
+1 -> uno
+2 -> two
+3 -> three
+1 -> uno
+2 -> two
+3 -> three
+----
+m2 := list::collect { stream() }.map:fromList
+m2.toList.foreach === m2.foreach
+1 -> uno
+2 -> two
+3 -> three
+1 -> uno
+2 -> two
+3 -> three

--- a/examples/stdlib/map/collect.effekt
+++ b/examples/stdlib/map/collect.effekt
@@ -1,0 +1,40 @@
+import map
+
+def main() = {
+  def stream() = {
+    do emit((1, "one"))
+    do emit((2, "two"))
+    do emit((3, "three"))
+    do emit((1, "uno")) // checks that we override the existing key
+  }
+
+  println("m1 := map::collect { stream() }")
+
+  val m1: Map[Int, String] = map::collect(box compareInt) { stream() }
+
+  println("m1.toList.foreach === m1.foreach")
+
+  m1.toList.foreach { case (k, v) =>
+    println(s"${k.show} -> ${v}")
+  }
+
+  m1.foreach { (k, v) =>
+    println(s"${k.show} -> ${v}")
+  }
+
+  println("----")
+
+  println("m2 := list::collect { stream() }.map:fromList")
+
+  val m2: Map[Int, String] = list::collect { stream() }.fromList(box compareInt)
+
+  println("m2.toList.foreach === m2.foreach")
+
+  m2.toList.foreach { case (k, v) =>
+    println(s"${k.show} -> ${v}")
+  }
+
+  m2.foreach { (k, v) =>
+    println(s"${k.show} -> ${v}")
+  }
+}

--- a/libraries/common/map.effekt
+++ b/libraries/common/map.effekt
@@ -641,7 +641,7 @@ namespace internal {
                 cr match {
                   case (r, xs, Nil()) => go(level.bitwiseShl(1), link(k, v, l, r), xs)
                   case (r, Nil(), ys) => insertMany(link(k, v, l, r), ys)
-                  case _ => panic("create: go: cannot happen, invariant broken!")
+                  case _ => <{ "create: go: cannot happen, invariant broken!" }>
                 }
               }
           }
@@ -810,10 +810,8 @@ namespace internal {
           t2    t3            t1    t2
     */
     def singleL[A, B](k1: A, v1: B, t1: Tree[A, B], m: Tree[A, B]): Tree[A, B] = {
-      m match {
-        case Bin(_, k2, v2, t2, t3) => bin(k2, v2, bin(k1, v1, t1, t2), t3)
-        case _ => panic("impossible: singleL: Tip")
-      }
+      val Bin(_, k2, v2, t2, t3) = m else <{ "impossible: singleL: Tip" }>
+      bin(k2, v2, bin(k1, v1, t1, t2), t3)
     }
 
     /*
@@ -826,10 +824,8 @@ namespace internal {
       t1    t2            t1      t2    t3
     */
     def singleR[A, B](k1: A, v1: B, m: Tree[A, B], t3: Tree[A, B]): Tree[A, B] = {
-      m match {
-        case Bin(_, k2, v2, t1, t2) => bin(k2, v2, t1, bin(k1, v1, t2, t3))
-        case _ => panic("impossible: singleR: Tip")
-      }
+      val Bin(_, k2, v2, t1, t2) = m else <{ "impossible: singleR: Tip" }>
+      bin(k2, v2, t1, bin(k1, v1, t2, t3))
     }
 
     /*
@@ -844,11 +840,8 @@ namespace internal {
           t2    t3
     */
     def doubleL[A, B](k1: A, v1: B, t1: Tree[A, B], m: Tree[A, B]): Tree[A, B] = {
-      m match {
-        case Bin(_, k2, v2, Bin(_, k3, v3, t2, t3), t4) =>
-          bin(k3, v3, bin(k1, v1, t1, t2), bin(k2, v2, t3, t4))
-        case _ => panic("impossible: doubleL: Tip")
-      }
+      val Bin(_, k2, v2, Bin(_, k3, v3, t2, t3), t4) = m else <{ "impossible: doubleL: Tip" }>
+      bin(k3, v3, bin(k1, v1, t1, t2), bin(k2, v2, t3, t4))
     }
 
     /*
@@ -863,12 +856,8 @@ namespace internal {
                 t2    t3
     */
     def doubleR[A, B](k1: A, v1: B, m: Tree[A, B], t4: Tree[A, B]): Tree[A, B] = {
-      m match {
-        case Bin(_, k2, v2, t1, Bin(_, k3, v3, t2, t3)) =>
-          bin(k3, v3, bin(k2, v2, t1, t2), bin(k1, v1, t3, t4))
-        case _ =>
-          panic("impossible: doubleR: Tip")
-      }
+      val Bin(_, k2, v2, t1, Bin(_, k3, v3, t2, t3)) = m else <{ "impossible: doubleR: Tip" }>
+      bin(k3, v3, bin(k2, v2, t1, t2), bin(k1, v1, t3, t4))
     }
 
     def rotateL[A, B](k: A, v: B, l: Tree[A, B], r: Tree[A, B]): Tree[A, B] = {

--- a/libraries/common/map.effekt
+++ b/libraries/common/map.effekt
@@ -172,7 +172,7 @@ def foreachReversed[K, V](m: Map[K, V]) { action: (K, V) => Unit }: Unit =
 /// O(N)
 def toList[K, V](m: Map[K, V]): List[(K, V)] = {
   var acc = Nil()
-  m.foreachReversed{ (k, v) =>
+  m.foreachReversed { (k, v) =>
     acc = Cons((k, v), acc)
   }
   acc

--- a/libraries/common/map.effekt
+++ b/libraries/common/map.effekt
@@ -8,7 +8,7 @@ record Map[K, V](tree: internal::Tree[K, V], compare: (K, K) => Ordering at {})
 /// Create a new empty map using a pure, first-class comparison function.
 ///
 /// O(1)
-def empty[K, V](compare: (K, K) => Ordering at {}): Map[K, V] =
+def empty[K, V](?compare: (K, K) => Ordering at {}): Map[K, V] =
   Map(internal::empty(), compare)
 
 /// Create a new empty map using a generic comparison function.
@@ -34,7 +34,7 @@ def nonEmpty[K, V](m: Map[K, V]): Bool = internal::nonEmpty(m.tree)
 /// Create a new map containing the mapping from `k` to `v` and a pure, first-class comparison function.
 ///
 /// O(1)
-def singleton[K, V](k: K, v: V, compare: (K, K) => Ordering at {}): Map[K, V] =
+def singleton[K, V](k: K, v: V, ?compare: (K, K) => Ordering at {}): Map[K, V] =
   Map(internal::singleton(k, v), compare)
 
 /// Create a new map containing the mapping from `k` to `v` using a generic comparison function.
@@ -206,7 +206,7 @@ def values[K, V](m: Map[K, V]): List[V] = {
 ///
 /// O(N) if the list is sorted by key,
 /// O(N log N) otherwise
-def fromList[K, V](pairs: List[(K, V)], compare: (K, K) => Ordering at {}): Map[K, V] =
+def fromList[K, V](pairs: List[(K, V)], ?compare: (K, K) => Ordering at {}): Map[K, V] =
   Map(internal::fromList(pairs, compare), compare)
 
 /// Create a map from a list of (key, value) pairs and a generic comparison function.
@@ -264,7 +264,7 @@ def getIndex[K, V](m: Map[K, V], n: Int): Option[(K, V)] =
 /// Uses an explicit pure, first-class comparison function.
 ///
 /// O(???)
-def difference[K, V](m1: Map[K, V], m2: Map[K, V], compare: (K, K) => Ordering at {}) = {
+def difference[K, V](m1: Map[K, V], m2: Map[K, V], ?compare: (K, K) => Ordering at {}) = {
   val newTree = internal::difference(m1.tree, m2.tree, compare)
   Map(newTree, compare)
 }
@@ -284,7 +284,7 @@ def difference[K, V](m1: Map[K, V], m2: Map[K, V]) = {
 /// Uses an explicit pure, first-class comparison function.
 ///
 /// O(???)
-def union[K, V](m1: Map[K, V], m2: Map[K, V], compare: (K, K) => Ordering at {}) { combine: (K, V, V) => V }: Map[K, V] = {
+def union[K, V](m1: Map[K, V], m2: Map[K, V], ?compare: (K, K) => Ordering at {}) { combine: (K, V, V) => V }: Map[K, V] = {
   val newTree = internal::union(m1.tree, m2.tree, compare) {combine}
   Map(newTree, compare)
 }
@@ -294,7 +294,7 @@ def union[K, V](m1: Map[K, V], m2: Map[K, V], compare: (K, K) => Ordering at {})
 /// Uses an explicit pure, first-class comparison function.
 ///
 /// O(???)
-def union[K, V](m1: Map[K, V], m2: Map[K, V], compare: (K, K) => Ordering at {}) { combine: (V, V) => V }: Map[K, V] =
+def union[K, V](m1: Map[K, V], m2: Map[K, V], ?compare: (K, K) => Ordering at {}) { combine: (V, V) => V }: Map[K, V] =
   union(m1, m2, compare) { (k, v1, v2) => combine(v1, v2) }
 
 /// Construct a new map which contains the elements of both `m1` and `m2`.
@@ -308,7 +308,7 @@ def union[K, V](m1: Map[K, V], m2: Map[K, V]): Map[K, V] =
 /// Construct a new map which combines all elements that are in both `m1` and `m2` using the `combine` function.
 ///
 /// O(???)
-def intersection[K, A, B, C](m1: Map[K, A], m2: Map[K, B], compare: (K, K) => Ordering at {}) { combine: (K, A, B) => C }: Map[K, C] = {
+def intersection[K, A, B, C](m1: Map[K, A], m2: Map[K, B], ?compare: (K, K) => Ordering at {}) { combine: (K, A, B) => C }: Map[K, C] = {
   val newTree = internal::intersection(m1.tree, m2.tree, compare) {combine}
   Map(newTree, compare)
 }
@@ -316,7 +316,7 @@ def intersection[K, A, B, C](m1: Map[K, A], m2: Map[K, B], compare: (K, K) => Or
 /// Construct a new map which combines all elements that are in both `m1` and `m2` using the `combine` function.
 ///
 /// O(???)
-def intersection[K, A, B, C](m1: Map[K, A], m2: Map[K, B], compare: (K, K) => Ordering at {}) { combine: (A, B) => C }: Map[K, C] =
+def intersection[K, A, B, C](m1: Map[K, A], m2: Map[K, B], ?compare: (K, K) => Ordering at {}) { combine: (A, B) => C }: Map[K, C] =
   m1.intersection[K, A, B, C](m2, compare) { (k, v1, v2) => combine(v1, v2) }
 
 /// Construct a new map which combines all elements that are in both `m1` and `m2`.
@@ -325,6 +325,47 @@ def intersection[K, A, B, C](m1: Map[K, A], m2: Map[K, B], compare: (K, K) => Or
 /// O(???)
 def intersection[K, A, B](m1: Map[K, A], m2: Map[K, B]): Map[K, A] =
   m1.intersection[K, A, B, A](m2, m1.compare) { (k, v1, v2) => v1 }
+
+
+
+// Streaming
+// ---------
+
+/// Turns a `map` into a producer of a push stream
+/// of `(key, value)` pairs by emitting each contained *in order*.
+def each[K, V](map: Map[K, V]): Unit / emit[(K, V)] =
+  map.foreach { (k, v) => do emit((k, v)) }
+
+/// Turns a `map` into a producer of a push stream
+/// of its keys by emitting each contained *in order*.
+def eachKey[K, V](map: Map[K, V]): Unit / emit[K] =
+  map.foreach { (k, _v) => do emit(k) }
+
+/// Turns a `map` into a producer of a push stream
+/// of its values by emitting each contained.
+def eachValue[K, V](map: Map[K, V]): Unit / emit[V] =
+  map.foreach { (_k, v) => do emit(v) }
+
+/// Collects `(key, value)` pairs from a push stream producer `stream` into a new `map`
+/// using the provided `compare` function, discarding the result of the producer.
+def collect[K, V](?compare: (K, K) => Ordering at {}) { stream: () => Unit / emit[(K, V)] }: Map[K, V] =
+  returning::collect[K, V, Unit](compare){stream}.second
+
+namespace returning {
+  /// Collects `(key, value)` pairs from a push stream producer `stream` into a new `map`,
+  /// using the provided `compare` function, returning the result of the producer as well as the collected map.
+  def collect[K, V, R](?compare: (K, K) => Ordering at {}) { stream: () => R / emit[(K, V)] }: (R, Map[K, V]) =
+    var map = map::empty[K, V](compare)
+    val r = try {
+      stream()
+    } with emit[(K, V)] { case (k, v) =>
+      map = map.put(k, v)
+      resume(())
+    }
+    (r, map)
+}
+
+// Internal tree representation
 
 /// Please don't directly use:
 /// - the `Tree` type
@@ -984,13 +1025,13 @@ namespace internal {
   // Section: prettyprinting for trees:
 
   /// Works only on the backends that support `genericShow` (JavaScript)!
-  def prettyTree[K, V](m: Tree[K, V]): String = {
+  def prettyTree[K, V](m: Tree[K, V]) { ?key::show: K => String } { ?value::show: V => String }: String = {
     // Helper function to recursively build the string representation of the tree
     def go(t: Tree[K, V], prefix: String, isTail: Bool): String = {
       t match {
         case Tip() => ""
         case Bin(_, k, v, l, r) =>
-          val pair = k.show ++ " → " ++ v.show
+          val pair = key::show(k) ++ " → " ++ value::show(v)
           val currentLine = prefix ++ (if (isTail) "└── " else "├── ") ++ pair ++ "\n"
 
           val newPrefix = prefix ++ (if (isTail) "    " else "│   ")
@@ -1005,49 +1046,11 @@ namespace internal {
     go(m, "", true)
   }
 
-  def prettyPairs[K, V](list: List[(K, V)]) { showLeft: K => String } { showRight: V => String }: String = {
+  def prettyPairs[K, V](list: List[(K, V)]) { ?key::show: K => String } { ?value::show: V => String }: String = {
     val res: String =
-      list.map { case (k, v) => showLeft(k) ++ " → " ++ showRight(v) }
+      list.map { case (k, v) => key::show(k) ++ " → " ++ value::show(v) }
           .join(", ")
 
     "[" ++ res ++ "]"
   }
-}
-
-
-// Streaming
-// ---------
-
-/// Turns a `map` into a producer of a push stream
-/// of `(key, value)` pairs by emitting each contained *in order*.
-def each[K, V](map: Map[K, V]): Unit / emit[(K, V)] =
-  map.foreach { (k, v) => do emit((k, v)) }
-
-/// Turns a `map` into a producer of a push stream
-/// of its keys by emitting each contained *in order*.
-def eachKey[K, V](map: Map[K, V]): Unit / emit[K] =
-  map.foreach { (k, _v) => do emit(k) }
-
-/// Turns a `map` into a producer of a push stream
-/// of its values by emitting each contained.
-def eachValue[K, V](map: Map[K, V]): Unit / emit[V] =
-  map.foreach { (_k, v) => do emit(v) }
-
-/// Collects `(key, value)` pairs from a push stream producer `stream` into a new `map`
-/// using the provided `compare` function, discarding the result of the producer.
-def collect[K, V](compare: (K, K) => Ordering at {}) { stream: () => Unit / emit[(K, V)] }: Map[K, V] =
-  returning::collect[K, V, Unit](compare){stream}.second
-
-namespace returning {
-  /// Collects `(key, value)` pairs from a push stream producer `stream` into a new `map`,
-  /// using the provided `compare` function, returning the result of the producer as well as the collected map.
-  def collect[K, V, R](compare: (K, K) => Ordering at {}) { stream: () => R / emit[(K, V)] }: (R, Map[K, V]) =
-    var map = map::empty[K, V](compare)
-    val r = try {
-      stream()
-    } with emit[(K, V)] { case (k, v) =>
-      map = map.put(k, v)
-      resume(())
-    }
-    (r, map)
 }

--- a/libraries/common/map.effekt
+++ b/libraries/common/map.effekt
@@ -615,7 +615,10 @@ namespace internal {
                 res match {
                   case (_, Nil(), _) => res
                   case (l, Cons((k2, v2), Nil()), zs) => (l.putMax(k2, v2), [], zs)
-                  case (l, xs, _) and xs is Cons((k2, v2), rest2) =>
+                  case (l, Cons((k2, v2), rest2), _) =>
+                    // @-pattern
+                    val xs = Cons((k2, v2), rest2)
+
                     if (notOrdered(k2, rest2)) { (l, [], xs) }
                     else {
                       val (r, zs, ws) = create(level.bitwiseShr(1), rest2);

--- a/libraries/common/map.effekt
+++ b/libraries/common/map.effekt
@@ -91,7 +91,7 @@ def getOrElse[K, V](m: Map[K, V], k: K) { default: => V }: V =
 def contains[K, V](m: Map[K, V], k: K): Bool =
   internal::get(m.tree, m.compare, k) match {
     case None() => false
-    case Some(v) => true
+    case Some(_) => true
   }
 
 /// Get minimum in the map `m`.
@@ -156,15 +156,26 @@ def filter[K, V](m: Map[K, V]) { shouldKeep: V => Bool }: Map[K, V] =
 def foreach[K, V](m: Map[K, V]) { action: (K, V) => Unit }: Unit =
   internal::foreach(m.tree) {action}
 
+/// Traverse all keys and their associated values in map `m` in *reverse*order,
+/// running the function `action` on a key and its associated value.
+///
+/// Law: `m.foreachReversed { action } === m.toList.reverse.foreach { action }`
+///
+/// O(N)
+///
+/// TODO: Support {Control} for early exits.
+def foreachReversed[K, V](m: Map[K, V]) { action: (K, V) => Unit }: Unit =
+  internal::foreachReversed(m.tree) {action}
+
 /// Convert a map `m` into a list of (key, value) pairs.
 ///
 /// O(N)
 def toList[K, V](m: Map[K, V]): List[(K, V)] = {
   var acc = Nil()
-  m.foreach { (k, v) =>
+  m.foreachReversed{ (k, v) =>
     acc = Cons((k, v), acc)
   }
-  acc.reverse
+  acc
 }
 
 /// Get a list of keys of the map `m`.
@@ -172,10 +183,10 @@ def toList[K, V](m: Map[K, V]): List[(K, V)] = {
 /// O(N)
 def keys[K, V](m: Map[K, V]): List[K] = {
   var acc = Nil()
-  m.foreach { (k, _v) =>
+  m.foreachReversed { (k, _v) =>
     acc = Cons(k, acc)
   }
-  acc.reverse
+  acc
 }
 
 /// Get a list of values of the map `m`.
@@ -183,10 +194,10 @@ def keys[K, V](m: Map[K, V]): List[K] = {
 /// O(N)
 def values[K, V](m: Map[K, V]): List[V] = {
   var acc = Nil()
-  m.foreach { (_k, v) =>
+  m.foreachReversed { (_k, v) =>
     acc = Cons(v, acc)
   }
-  acc.reverse
+  acc
 }
 
 /// Create a map from a list of (key, value) pairs and a pure, first-class comparison function.
@@ -527,6 +538,27 @@ namespace internal {
     go(m)
   }
 
+  /// Traverse all keys and their associated values in tree `m` in *reverse* order,
+  /// running the function `action` on a key and its associated value.
+  ///
+  /// Law: `m.foreachReversed { action } === m.toList.reverse.foreach { action }`
+  ///
+  /// O(N)
+  ///
+  /// TODO: Support {Control} for early exits.
+  def foreachReversed[K, V](m: Tree[K, V]) { action: (K, V) => Unit }: Unit = {
+    def go(m: Tree[K, V]): Unit = {
+      m match {
+        case Tip() => ()
+        case Bin(_, k, v, l, r) =>
+          go(r)
+          action(k, v)
+          go(l)
+      }
+    }
+    go(m)
+  }
+
   /// Create a tree from a list of (key, value) pairs.
   /// If the list contains more than one value for the same key,
   /// only the last value is used in the tree.
@@ -572,20 +604,18 @@ namespace internal {
             case Nil() => (Tip(), [], [])
             case Cons((k, v), rest) =>
               if (level == 1) {
-                val singleton = Bin(1, k, v, Tip(), Tip())
+                val one = singleton(k, v)
                 if (notOrdered(k, rest)) {
-                  (singleton, [], rest)
+                  (one, [], rest)
                 } else {
-                  (singleton, rest, [])
+                  (one, rest, [])
                 }
               } else {
                 val res = create(level.bitwiseShr(1), pairs)
                 res match {
                   case (_, Nil(), _) => res
                   case (l, Cons((k2, v2), Nil()), zs) => (l.putMax(k2, v2), [], zs)
-                  case (l, Cons((k2, v2), rest2), _) =>
-                    val xs = Cons((k2, v2), rest2) // @-pattern
-
+                  case (l, xs, _) and xs is Cons((k2, v2), rest2) =>
                     if (notOrdered(k2, rest2)) { (l, [], xs) }
                     else {
                       val (r, zs, ws) = create(level.bitwiseShr(1), rest2);
@@ -763,9 +793,8 @@ namespace internal {
   val ratio = 2
   val delta = 3
 
-  def bin[K, V](k: K, v: V, l: Tree[K, V], r: Tree[K, V]): Tree[K, V] = {
+  def bin[K, V](k: K, v: V, l: Tree[K, V], r: Tree[K, V]): Tree[K, V] =
     Bin(l.size() + r.size() + 1, k, v, l, r)
-  }
 
   def balance[K, V](k: K, v: V, l: Tree[K, V], r: Tree[K, V]): Tree[K, V] = {
     /*
@@ -859,7 +888,7 @@ namespace internal {
     if ((sizeL + sizeR) <= 1) { Bin(sizeCombined, k, v, l, r) }
     else if (sizeR > (delta * sizeL)) { rotateL(k, v, l, r) }
     else if (sizeL > (delta * sizeR)) { rotateR(k, v, l, r) }
-    else { Bin(sizeCombined, k, v, l, r)}
+    else { Bin(sizeCombined, k, v, l, r) }
   }
 
   record MaxView[K, V](k: K, v: V, m: Tree[K, V])
@@ -1021,10 +1050,12 @@ namespace returning {
   /// Collects `(key, value)` pairs from a push stream producer `stream` into a new `map`,
   /// using the provided `compare` function, returning the result of the producer as well as the collected map.
   def collect[K, V, R](compare: (K, K) => Ordering at {}) { stream: () => R / emit[(K, V)] }: (R, Map[K, V]) =
-    try {
-      (stream(), empty(compare))
+    var map = map::empty[K, V](compare)
+    val r = try {
+      stream()
     } with emit[(K, V)] { case (k, v) =>
-      val (r, map) = resume(());
-      (r, map.put(k, v))
+      map = map.put(k, v)
+      resume(())
     }
+    (r, map)
 }

--- a/libraries/common/set.effekt
+++ b/libraries/common/set.effekt
@@ -9,7 +9,7 @@ record Set[A](tree: internal::Tree[A, Unit], compare: (A, A) => Ordering at {})
 /// Create a new empty set using a pure, first-class comparison function.
 ///
 /// O(1)
-def empty[A](compare: (A, A) => Ordering at {}): Set[A] =
+def empty[A](?compare: (A, A) => Ordering at {}): Set[A] =
   Set(internal::empty(), compare)
 
 /// Create a new empty set using a generic comparison function.
@@ -36,7 +36,7 @@ def nonEmpty[A](s: Set[A]): Bool = internal::nonEmpty(s.tree)
 /// Requires a pure, first-class comparison function.
 ///
 /// O(1)
-def singleton[A](element: A, compare: (A, A) => Ordering at {}): Set[A] =
+def singleton[A](element: A, ?compare: (A, A) => Ordering at {}): Set[A] =
   Set(internal::singleton(element, ()), compare)
 
 /// Create a new set containing a single `element` and a generic comparison function.
@@ -81,7 +81,7 @@ def toMap[K, V](keys: Set[K]) { valueOf: K => V }: Map[K, V] = {
 ///
 /// O(N log N)
 /// O(N) if the list is sorted
-def fromList[A](list: List[A], compare: (A, A) => Ordering at {}): Set[A] = {
+def fromList[A](list: List[A], ?compare: (A, A) => Ordering at {}): Set[A] = {
   val tree: internal::Tree[A, Unit] = internal::fromList(list.map { k => (k, ()) }, compare)
   Set(tree, compare)
 }
@@ -197,7 +197,7 @@ def deleteMany[A](s: Set[A], list: List[A]): Set[A] = {
 /// Uses an explicit comparison function.
 ///
 /// O(???)
-def difference[A](s1: Set[A], s2: Set[A], compare: (A, A) => Ordering at {}): Set[A] = {
+def difference[A](s1: Set[A], s2: Set[A], ?compare: (A, A) => Ordering at {}): Set[A] = {
   val newTree = internal::difference(s1.tree, s2.tree, compare)
   Set(newTree, compare)
 }
@@ -214,7 +214,7 @@ def difference[A](s1: Set[A], s2: Set[A]): Set[A] =
 /// Uses an explicit comparison function.
 ///
 /// O(???)
-def union[A](s1: Set[A], s2: Set[A], compare: (A, A) => Ordering at {}): Set[A] = {
+def union[A](s1: Set[A], s2: Set[A], ?compare: (A, A) => Ordering at {}): Set[A] = {
   val newTree = internal::union(s1.tree, s2.tree, compare) { (_k, _v1, _v2) => () }
   Set(newTree, compare)
 }
@@ -230,7 +230,7 @@ def union[A](s1: Set[A], s2: Set[A]): Set[A] =
 /// Uses an explicit comparison function.
 ///
 /// O(???)
-def intersection[A](s1: Set[A], s2: Set[A], compare: (A, A) => Ordering at {}): Set[A] = {
+def intersection[A](s1: Set[A], s2: Set[A], ?compare: (A, A) => Ordering at {}): Set[A] = {
   val newTree = internal::intersection(s1.tree, s2.tree, compare) { (_k, _v1, _v2) => () }
   Set(newTree, compare)
 }
@@ -253,13 +253,13 @@ def each[A](set: Set[A]): Unit / emit[A] =
 
 /// Collects elements emitted by a push stream producer `stream` into a new set
 /// using provided `compare` function, discarding the result of the producer.
-def collect[A](compare: (A, A) => Ordering at {}) { stream: () => Unit / emit[A] }: Set[A] =
+def collect[A](?compare: (A, A) => Ordering at {}) { stream: () => Unit / emit[A] }: Set[A] =
   returning::collect[A, Unit](compare){stream}.second
 
 namespace returning {
   /// Collects elements emitted by a push stream producer `stream` into a new set
   /// using provided `compare` function, returning the result of the producer as well as the collected set.
-  def collect[A, R](compare: (A, A) => Ordering at {}) { stream: () => R / emit[A] }: (R, Set[A]) = {
+  def collect[A, R](?compare: (A, A) => Ordering at {}) { stream: () => R / emit[A] }: (R, Set[A]) = {
     var set = set::empty(compare)
     val r = try {
       stream()

--- a/libraries/common/set.effekt
+++ b/libraries/common/set.effekt
@@ -105,15 +105,23 @@ def fromListGeneric[A](list: List[A]): Set[A] = {
 def foreach[A](s: Set[A]) { action: A => Unit }: Unit =
   internal::foreach(s.tree) { (k, _v) => action(k) }
 
+/// Traverse all elements in *reverse* order, running the function `action` on each element.
+///
+/// Law: `s.foreachReversed { action } === s.toList.reverse.foreach { action }`
+///
+/// O(N)
+def foreachReversed[A](s: Set[A]) { action: A => Unit }: Unit =
+  internal::foreachReversed(s.tree) { (k, _v) => action(k) }
+
 /// Create a list from a given set.
 ///
 /// O(N)
 def toList[A](s: Set[A]): List[A] = {
   var acc = Nil()
-  s.foreach { a =>
+  s.foreachReversed { a =>
     acc = Cons(a, acc)
   }
-  acc.reverse
+  acc
 }
 
 /// Check if a predicate holds for all elements in a given set.
@@ -251,11 +259,14 @@ def collect[A](compare: (A, A) => Ordering at {}) { stream: () => Unit / emit[A]
 namespace returning {
   /// Collects elements emitted by a push stream producer `stream` into a new set
   /// using provided `compare` function, returning the result of the producer as well as the collected set.
-  def collect[A, R](compare: (A, A) => Ordering at {}) { stream: () => R / emit[A] }: (R, Set[A]) =
-    try {
-      (stream(), empty(compare))
+  def collect[A, R](compare: (A, A) => Ordering at {}) { stream: () => R / emit[A] }: (R, Set[A]) = {
+    var set = set::empty(compare)
+    val r = try {
+      stream()
     } with emit[A] { (v) =>
-      val (r, set) = resume(());
-      (r, set.insert(v))
+      set = set.insert(v)
+      resume(())
     }
+    (r, set)
+  }
 }


### PR DESCRIPTION
- Remove useless `.reverse` in `.toList` methods
- Fix `collect` not respecting the ordering of key-value pairs
- Use typed holes instead of panics to avoid `io` capture
- Use name-based implicits for `?compare` and `?show`