### PR TITLE
Improve error message for 'match { _ => ... }'

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -1037,9 +1037,15 @@ class Parser(tokens: Seq[Token], source: Source) {
       }
 
   def matchExpr(scrutinee: Term): Term =
-      val clauses = `match` ~> braces { manyWhile(matchClause(), `case`) }
-      val default = when(`else`) { Some(stmt()) } { None }
-      Match(List(scrutinee), clauses, default, span())
+   val clauses = `match` ~> braces {
+     peek.kind match {
+       case `case` | `}` => ()
+       case k => fail("case", k)
+     }
+     manyWhile(matchClause(), `case`)
+   }
+   val default = when(`else`) { Some(stmt()) } { None }
+   Match(List(scrutinee), clauses, default, span())
 
 
   def assignExpr(assignee: Term.Var): Term =

--- a/examples/neg/match_block_underscore.check
+++ b/examples/neg/match_block_underscore.check
@@ -1,0 +1,3 @@
+[error] examples/neg/match_block_underscore.effekt:2:31: Expected case but got identifier _
+  val res = [1, 2, 3] match { _ => 42 }
+                              ^

--- a/examples/neg/match_block_underscore.effekt
+++ b/examples/neg/match_block_underscore.effekt
@@ -1,0 +1,4 @@
+def main() = { // user wanted to write `... match { case _ => ... }` but forgot the `case` keyword
+  val res = [1, 2, 3] match { _ => 42 }
+  println(res)
+}


### PR DESCRIPTION
Before:
```scala
... match { _ => 42 }
//          ^ error: Expected } but got identifier _
```

After:
```scala
... match { _ => 42 }
//          ^ error: Expected case but got identifier _
```

cc @serkm 