### PR TITLE
Add 'benchmarks/other/unify_dictionary.effekt' to VMTests

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/VMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/VMTests.scala
@@ -1249,7 +1249,7 @@ class VMTests extends munit.FunSuite {
       staticDispatches = 4662067,
       dynamicDispatches = 184329,
       patternMatches = 2556198,
-      branches = 2695696,
+      branches = 2703889,
       pushedFrames = 1732897,
       poppedFrames = 1732897,
       allocations = 1749276,

--- a/effekt/jvm/src/test/scala/effekt/core/VMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/VMTests.scala
@@ -1245,6 +1245,23 @@ class VMTests extends munit.FunSuite {
       resumes = 0
     )),
 
+    examplesDir / "benchmarks" / "other" / "unify_dictionary.effekt" -> Some(Summary(
+      staticDispatches = 4662067,
+      dynamicDispatches = 184329,
+      patternMatches = 2556198,
+      branches = 2695696,
+      pushedFrames = 1732897,
+      poppedFrames = 1732897,
+      allocations = 1749276,
+      closures = 90123,
+      variableReads = 569362,
+      variableWrites = 380936,
+      resets = 2,
+      shifts = 0,
+      resumes = 0
+    )),
+
+
     examplesDir / "stdlib" / "stream" / "fix.effekt" -> Some(Summary(
       staticDispatches = 38,
       dynamicDispatches = 52,

--- a/effekt/shared/src/main/scala/effekt/core/vm/Builtin.scala
+++ b/effekt/shared/src/main/scala/effekt/core/vm/Builtin.scala
@@ -211,9 +211,16 @@ lazy val bytes: Builtins = Map(
 
   // Conversion
   // ----------
+  builtin("effekt::toInt(Byte)") {
+    case As.Byte(b) :: Nil => Value.Int(b.toInt.toLong)
+  },
+  builtin("effekt::toByte(Int)") {
+    case As.Int(n) :: Nil => Value.Byte(UByte.unsafeFromInt(n.toInt & 0xFF))
+  },
+
   builtin("effekt::showBuiltin(Byte)") {
     case As.Byte(b) :: Nil => Value.String(b.toHexString)
-  }
+  },
 )
 
 lazy val strings: Builtins = Map(
@@ -298,7 +305,7 @@ lazy val arrays: Builtins = Map(
 )
 
 lazy val bytearrays: Builtins = Map(
-  builtin("bytearray::unsafeAllocate(Int)") {
+  builtin("bytearray::allocate(Int)") {
     case As.Int(x) :: Nil => Value.ByteArray(scala.Array.ofDim(x.toInt))
   },
   builtin("bytearray::size(ByteArray)") {


### PR DESCRIPTION
The actual values might be off, this is copy-pasted from a different endeavour where I'd like to have `unify_dictionary.effekt` in the VMTests for comparison (`bytearray`-heavy)