### PR TITLE
Speed-up array and bytearray

### DIFF
--- a/effekt/jvm/src/test/scala/effekt/core/VMTests.scala
+++ b/effekt/jvm/src/test/scala/effekt/core/VMTests.scala
@@ -1230,10 +1230,10 @@ class VMTests extends munit.FunSuite {
     )),
 
     examplesDir / "benchmarks" / "other" / "unify.effekt" -> Some(Summary(
-      staticDispatches = 2506958,
+      staticDispatches = 6662383,
       dynamicDispatches = 1460350,
       patternMatches = 3850477,
-      branches = 2791752,
+      branches = 13982006,
       pushedFrames = 1970337,
       poppedFrames = 1970337,
       allocations = 2039967,

--- a/effekt/shared/src/main/scala/effekt/core/vm/Builtin.scala
+++ b/effekt/shared/src/main/scala/effekt/core/vm/Builtin.scala
@@ -251,7 +251,7 @@ lazy val strings: Builtins = Map(
   },
 
   builtin("string::unsafeCharAt(String, Int)") {
-    case As.String(x) :: As.Int(at) :: Nil => Value.Int(x.charAt(at.toInt).toLong)
+    case As.String(x) :: As.Int(at) :: Nil => Value.Int(x.codePointAt(at.toInt).toLong)
   },
 
   builtin("char::toInt(Char)") {
@@ -260,6 +260,10 @@ lazy val strings: Builtins = Map(
 
   builtin("char::toChar(Int)") {
     case As.Int(n) :: Nil => Value.Int(n)
+  },
+
+  builtin("char::charWidth(Char)") {
+    case As.Int(c) :: Nil => Value.Int(if (c > 0xFFFF) 2 else 1)
   },
 
   builtin("char::infixLte(Char, Char)") {
@@ -316,6 +320,11 @@ lazy val bytearrays: Builtins = Map(
   },
   builtin("bytearray::set(ByteArray, Int, Byte)") {
     case As.ByteArray(arr) :: As.Int(index) :: As.Byte(value) :: Nil => arr.update(index.toInt, value); Value.Unit()
+  },
+  builtin("bytearray::unsafeCopy(ByteArray, Int, ByteArray, Int, Int)") {
+    case As.ByteArray(from) :: As.Int(start) :: As.ByteArray(to) :: As.Int(offset) :: As.Int(length) :: Nil =>
+      System.arraycopy(from, start.toInt, to, offset.toInt, length.toInt)
+      Value.Unit()
   },
   builtin("bytearray::compareByteArrayImpl(ByteArray, ByteArray)") {
     case As.ByteArray(arr1) :: As.ByteArray(arr2) :: Nil => Value.Int(java.util.Arrays.compare(arr1.map(_.toByte), arr2.map(_.toByte)))

--- a/examples/benchmarks/other/unify.effekt
+++ b/examples/benchmarks/other/unify.effekt
@@ -82,7 +82,7 @@ def unifyMany(args1: List[Type], args2: List[Type], subst: Substitution): Substi
   }
 
 def unify(ty1: Type, ty2: Type): Substitution / Exception[UnificationError] =
-  unify(ty1, ty2, map::empty(box bytearray::compareStringBytes))
+  unify(ty1, ty2, map::empty(box string::compareStringBytes))
 
 def showType(ty: Type): String = ty match {
   case Var(name) => name

--- a/libraries/common/array.effekt
+++ b/libraries/common/array.effekt
@@ -63,9 +63,10 @@ extern def unsafeAllocate[T](size: Int) at global: Array[T] =
 
 /// Fills a given array in-place.
 def fill[T](arr: Array[T], filler: T): Unit = {
-  arr.foreachIndex { (idx, _) =>
-    arr.set(idx, filler)
-  }
+  val n = arr.size
+  def go(i: Int): Unit =
+    if (i < n) { arr.set(i, filler); go(i + 1) }
+  go(0)
 }
 
 /// Creates a new Array of size `size` filled with the value `init`

--- a/libraries/common/bytearray.effekt
+++ b/libraries/common/bytearray.effekt
@@ -253,12 +253,6 @@ def compareByteArray(b1: ByteArray, b2: ByteArray): Ordering = {
   }
 }
 
-def compareStringBytes(left: String, right: String): Ordering = {
-  val l = left.fromString
-  val r = right.fromString
-  compareByteArray(l, r)
-}
-
 
 // Streaming
 // ---------

--- a/libraries/common/bytearray.effekt
+++ b/libraries/common/bytearray.effekt
@@ -113,17 +113,35 @@ def build(size: Int) { index: Int => Byte }: ByteArray = {
   arr
 }
 
+/// Copies `length`-many bytes from `from` to `to`
+/// starting at `start` (in `from`) and `offset` (in `to`).
+/// The ranges may overlap, even within the same bytearray: the source bytes are
+/// read before any are written. Panics if out of bounds.
+///
+/// O(N)
+def copy(from: ByteArray, start: Int, to: ByteArray, offset: Int, length: Int): Unit =
+  if (length < 0 || start < 0 || offset < 0
+      || start + length > from.size || offset + length > to.size) {
+    <{ "bytearray::copy: range out of bounds" }>
+  } else {
+    unsafeCopy(from, start, to, offset, length)
+  }
+
+/// `copy` without its bounds check.
+/// Corrupts memory if misused; prefer `copy`.
+extern def unsafeCopy(from: ByteArray, start: Int, to: ByteArray, offset: Int, length: Int) at global: Unit =
+  js "bytearray$copy(${from}, ${start}, ${to}, ${offset}, ${length})"
+  chez "(bytevector-copy! ${from} ${start} ${to} ${offset} ${length})"
+  llvm """
+    %z = call %Pos @c_bytearray_copy(%Pos ${from}, %Int ${start}, %Pos ${to}, %Int ${offset}, %Int ${length})
+    ret %Pos %z
+  """
+
 def resize(source: ByteArray, size: Int): ByteArray = {
   val target = allocate(size)
-  val n = min(source.size, target.size)
-  def go(i: Int): ByteArray =
-    if (i < n) {
-      target.set(i, source.get(i))
-      go(i + 1)
-    } else {
-      target
-    }
-  go(0)
+  // safe: `min` establishes the bound for both ranges ~> no check is needed
+  unsafeCopy(source, 0, target, 0, min(source.size, size))
+  target
 }
 
 /// Sorts a given bytearray `arr` in-place using a counting sort,
@@ -190,6 +208,21 @@ extern def toString(arr: ByteArray) at {}: String =
   chez "(utf8->string ${arr})"
 
 extern js """
+  function bytearray$copy(src, srcOff, dst, dstOff, n) {
+    // for small `n`, it's faster to copy manually to avoid allocating `subarray`
+    if (n < 40) {
+      if (srcOff < dstOff) {
+        for (let i = n - 1; i >= 0; --i) dst[dstOff + i] = src[srcOff + i];
+      } else {
+        for (let i = 0; i < n; ++i) dst[dstOff + i] = src[srcOff + i];
+      }
+    } else {
+      // safe: `set` clones the source region first when both share a buffer
+      dst.set(src.subarray(srcOff, srcOff + n), dstOff);
+    }
+    return $effekt.unit;
+  }
+
   function bytearray$set(bytes, index, value) {
     bytes[index] = value;
     return $effekt.unit;

--- a/libraries/common/bytearray.effekt
+++ b/libraries/common/bytearray.effekt
@@ -275,16 +275,8 @@ extern def compareByteArrayImpl(b1: ByteArray, b2: ByteArray) at {}: Int =
   """
   chez "(bytearray$compare ${b1} ${b2})"
 
-def compareByteArray(b1: ByteArray, b2: ByteArray): Ordering = {
-  val ret = compareByteArrayImpl(b1, b2)
-  if (ret == 0) {
-    Equal()
-  } else if (ret < 0) {
-    Less()
-  } else { // ret > 0
-    Greater()
-  }
-}
+def compareByteArray(b1: ByteArray, b2: ByteArray): Ordering =
+  compareByteArrayImpl(b1, b2).fromInt
 
 
 // Streaming

--- a/libraries/common/char.effekt
+++ b/libraries/common/char.effekt
@@ -144,6 +144,10 @@ extern def infixGte(x: Char, y: Char) at {}: Bool =
     ret %Pos %adt_boolean
   """
 
+def compareChar(x: Char, y: Char): Ordering =
+  if (x == y) Equal()
+  else if (x < y) Less()
+  else Greater()
 
 /**
  * Determines the number of bytes needed by a codepoint

--- a/libraries/common/char.effekt
+++ b/libraries/common/char.effekt
@@ -155,18 +155,21 @@ def utf8ByteCount(codepoint: Char): Int = codepoint match {
   case c and c >= '\u0080'  and c <= '\u07FF'   => 2
   case c and c >= '\u0800'  and c <= '\uFFFF'   => 3
   case c and c >= '\u10000' and c <= '\u10FFFF' => 4
-  case c => panic("Not a valid code point")
+  case c => <{ "Not a valid code point" }>
 }
 
 def utf16UnitCount(codepoint: Char): Int = codepoint match {
   case c and c >= '\u0000'  and c <= '\uFFFF'   => 1
-  case c and c >= '\u10000' and c <= '\u10FFFF' => 4
-  case c => panic("Not a valid code point")
+  case c and c >= '\u10000' and c <= '\u10FFFF' => 2
+  case c => <{ "Not a valid code point" }>
 }
 
+/// How many index units `c` occupies in the unit that `length` and `unsafeCharAt`
+/// use on this backend. Adding it to a code-point boundary gives the next character.
 extern def charWidth(c: Char) at {}: Int =
-  // JavaScript strings are UTF-16 where every unicode character after 0xffff takes two units
-  js "(${c} > 0xffff) ? 2 : 1"
+  js { utf16UnitCount(c) }
+  chez { 1 }
+  llvm { utf8ByteCount(c) }
 
 
 def decodeChar(): Char / {next[Byte], stop} = {

--- a/libraries/common/effekt.effekt
+++ b/libraries/common/effekt.effekt
@@ -191,19 +191,24 @@ extern def random() at io: Double =
 // extern io def freshGlobal[T](t: T): Ref[T] at global = js "$effekt.fresh(${t})"
 
 
-// Equality
+// Comparison
 // ========
 
 /// Result of comparison between two objects according to some order:
 ///
 /// - `Less()` means that the first object is *before* the first in the order,
-/// - `Equal()` means that the two objects are the same in the order,
-/// - and `Greater()` means that the second object is *before* the first in the order.
+/// - `Equal()` means that the two objects are the same in the order, and
+/// - `Greater()` means that the second object is *before* the first in the order.
 type Ordering {
   Less();
   Equal();
   Greater()
 }
+
+def ordering::fromInt(n: Int): Ordering =
+  if (n == 0) Equal()
+  else if (n < 0) Less()
+  else Greater()
 
 def compareInt(n: Int, m: Int) =
   if (n == m) Equal()
@@ -215,16 +220,8 @@ extern def genericCompareImpl[R](x: R, y: R) at {}: Int =
 
 /// Compares two values of the same type, returning an `Ordering`.
 /// Only available on the JavaScript backend.
-def genericCompare[R](x: R, y: R): Ordering = {
-  val ret = genericCompareImpl(x, y)
-  if (ret == 0) {
-    Equal()
-  } else if (ret < 0) {
-    Less()
-  } else { // ret > 0
-    Greater()
-  }
-}
+def genericCompare[R](x: R, y: R): Ordering =
+  genericCompareImpl(x, y).fromInt
 
 def println(o: Ordering): Unit = println(o.show)
 

--- a/libraries/common/string.effekt
+++ b/libraries/common/string.effekt
@@ -210,6 +210,23 @@ namespace internal {
       do emit(c.utf8ByteCount)
     }
   }
+
+  /// Negative, zero or positive, like `compareByteArrayImpl`.
+  def compareCodePoints(left: String, right: String): Int = {
+    val ln = left.length
+    val rn = right.length
+    def go(i: Int, j: Int): Int =
+      if (i >= ln) { if (j >= rn) 0 else -1 }
+      else if (j >= rn) 1
+      else {
+        val a = unsafeCharAt(left, i).toInt
+        val b = unsafeCharAt(right, j).toInt
+        if (a != b) a - b
+        // equal code points have equal widths, so take the step only once
+        else { val w = a.toChar.charWidth; go(i + w, j + w) }
+      }
+    go(0, 0)
+  }
 }
 
 /// Returns the number of bytes that the given `str` would take up in a UTF-8 encoding.
@@ -234,6 +251,17 @@ extern def utf8ByteLength(str: String) at {io, global}: Int =
 
 // extern def unsafeIndexOf(str: String, sub: String) at {}: Int =
 //   js "${str}.indexOf(${sub})"
+
+/// Compares two strings lexicographically by code point.
+/// Identical on every backend.
+def compareStringBytes(left: String, right: String): Ordering = {
+  val ret = compareStringBytesImpl(left, right)
+  if (ret == 0) { Equal() } else if (ret < 0) { Less() } else { Greater() }
+}
+
+extern def compareStringBytesImpl(left: String, right: String) at {}: Int =
+  llvm { compareByteArrayImpl(fromString(left), fromString(right)) }
+  default { internal::compareCodePoints(left, right) }
 
 def charAt(str: String, index: Int): Char / Exception[OutOfBounds] =
   if (index < 0 || index >= length(str))

--- a/libraries/common/string.effekt
+++ b/libraries/common/string.effekt
@@ -211,20 +211,25 @@ namespace internal {
     }
   }
 
-  /// Negative, zero or positive, like `compareByteArrayImpl`.
-  def compareCodePoints(left: String, right: String): Int = {
+  def compareCodePoints(left: String, right: String): Ordering = {
     val ln = left.length
     val rn = right.length
-    def go(i: Int, j: Int): Int =
-      if (i >= ln) { if (j >= rn) 0 else -1 }
-      else if (j >= rn) 1
+    def go(i: Int, j: Int): Ordering =
+      if (i >= ln) { if (j >= rn) Equal() else Less() }
+      else if (j >= rn) Greater()
       else {
-        val a = unsafeCharAt(left, i).toInt
-        val b = unsafeCharAt(right, j).toInt
-        if (a != b) a - b
-        // equal code points have equal widths, so take the step only once
-        else { val w = a.toChar.charWidth; go(i + w, j + w) }
+        val a = unsafeCharAt(left, i)
+        val b = unsafeCharAt(right, j)
+        compareChar(a, b) match {
+          case Equal() =>
+            // equal code points have equal widths, so take the step only once
+            val w = a.charWidth
+            go(i + w, j + w)
+          case Less() => Less()
+          case Greater() => Greater()
+        }
       }
+
     go(0, 0)
   }
 }
@@ -254,13 +259,8 @@ extern def utf8ByteLength(str: String) at {io, global}: Int =
 
 /// Compares two strings lexicographically by code point.
 /// Identical on every backend.
-def compareStringBytes(left: String, right: String): Ordering = {
-  val ret = compareStringBytesImpl(left, right)
-  if (ret == 0) { Equal() } else if (ret < 0) { Less() } else { Greater() }
-}
-
-extern def compareStringBytesImpl(left: String, right: String) at {}: Int =
-  llvm { compareByteArrayImpl(fromString(left), fromString(right)) }
+extern def compareStringBytes(left: String, right: String) at {}: Ordering =
+  llvm { compareByteArray(fromString(left), fromString(right)) }
   default { internal::compareCodePoints(left, right) }
 
 def charAt(str: String, index: Int): Char / Exception[OutOfBounds] =

--- a/libraries/common/stringbuffer.effekt
+++ b/libraries/common/stringbuffer.effekt
@@ -28,11 +28,11 @@ def flushableStringBuffer[A] { program: () => A / { write, flush } }: A = {
     program()
   } with write { string =>
     val bytes = fromString(string)
-    ensureCapacity(bytes.size)
-    bytes.foreach { b =>
-      buffer.set(position, b)
-      position = position + 1
-    }
+    val n = bytes.size
+    ensureCapacity(n)
+    // safe: `ensureCapacity` just established the target range
+    bytearray::unsafeCopy(bytes, 0, buffer, position, n)
+    position = position + n
     resume(())
   } with flush {
     val string = buffer.resize(position).toString()

--- a/libraries/llvm/bytearray.c
+++ b/libraries/llvm/bytearray.c
@@ -56,6 +56,17 @@ uint8_t* c_bytearray_data(const struct Pos arr) {
     return data;
 }
 
+struct Pos c_bytearray_copy(const struct Pos source, const Int sourceOffset,
+                            const struct Pos target, const Int targetOffset,
+                            const Int length) {
+  // memmove, not memcpy: the ranges may overlap, and may even be the same bytearray
+  memmove(c_bytearray_data(target) + targetOffset,
+          c_bytearray_data(source) + sourceOffset, length);
+  erasePositive(source);
+  erasePositive(target);
+  return Unit;
+}
+
 struct Pos c_bytearray_construct(const uint64_t n, const uint8_t *data) {
     struct Pos arr = c_bytearray_new(n);
     memcpy(c_bytearray_data(arr), data, n);

--- a/libraries/llvm/bytearray.c
+++ b/libraries/llvm/bytearray.c
@@ -145,11 +145,9 @@ struct Pos c_bytearray_concatenate(const struct Pos left, const struct Pos right
     uint64_t left_size = left.tag;
     uint64_t right_size = right.tag;
     const struct Pos concatenated = c_bytearray_new(left_size + right_size);
-    for (uint64_t j = 0; j < concatenated.tag; ++j)
-        c_bytearray_data(concatenated)[j]
-            = j < left_size
-            ? c_bytearray_data(left)[j]
-            : c_bytearray_data(right)[j - left_size];
+    // two memcpys rather than a byte loop with a branch per byte
+    memcpy(c_bytearray_data(concatenated), c_bytearray_data(left), left_size);
+    memcpy(c_bytearray_data(concatenated) + left_size, c_bytearray_data(right), right_size);
 
     erasePositive(left);
     erasePositive(right);

--- a/libraries/llvm/forward-declare-c.ll
+++ b/libraries/llvm/forward-declare-c.ll
@@ -25,6 +25,7 @@ declare %Int @c_bytearray_size(%Pos)
 declare %Byte @c_bytearray_get(%Pos, %Int)
 declare %Pos @c_bytearray_set(%Pos, %Int, %Byte)
 
+declare %Pos @c_bytearray_copy(%Pos, %Int, %Pos, %Int, %Int)
 declare ptr @c_bytearray_data(%Pos)
 declare %Pos @c_bytearray_construct(i64, ptr)
 


### PR DESCRIPTION
- most array and bytearray operations on LLVM become much faster
- string comparison gets much faster on JS, speeding up all programs using `Map` with string keys greatly