### PR TITLE
docs: fix typo preceeding -> preceding

### DIFF
--- a/examples/casestudies/frontend.effekt.md
+++ b/examples/casestudies/frontend.effekt.md
@@ -742,7 +742,7 @@ def printer(width: Int, defaultIndent: Int) { prog: => Unit / { Emit, Layout } }
 
 Maybe most interestingly, we update the current position and invoke the effect operation `fail`, if
 the document exceeds the width.
-This will potentially cause backtracking and revision of a preceeding layout decision.
+This will potentially cause backtracking and revision of a preceding layout decision.
 If the current text still fits the line, we simply re-emit it.
 
 Finally, we can compose the different handlers to a single pretty printing handler:

--- a/examples/casestudies/prettyprinter.effekt.md
+++ b/examples/casestudies/prettyprinter.effekt.md
@@ -306,7 +306,7 @@ def printer(width: Int, defaultIndent: Int) { prog: => Unit / { Emit, Layout } }
 
 Maybe most interestingly, we update the current position and invoke the effect operation `fail`, if
 the document exceeds the width.
-This will potentially cause backtracking and revision of a preceeding layout decision.
+This will potentially cause backtracking and revision of a preceding layout decision.
 If the current text still fits the line, we simply re-emit it.
 
 Finally, we can compose the different handlers to a single pretty printing handler:


### PR DESCRIPTION
Typo fix in two case-study documents:

- `examples/casestudies/frontend.effekt.md:745` — `preceeding` → `preceding`
- `examples/casestudies/prettyprinter.effekt.md:309` — `preceeding` → `preceding`

Prose only — no Effekt code changed.
