### PR TITLE
Nonuniform representation

### DIFF
--- a/effekt/shared/src/main/scala/effekt/core/Mono.scala
+++ b/effekt/shared/src/main/scala/effekt/core/Mono.scala
@@ -978,7 +978,7 @@ object Mono extends Phase[CoreTransformed, CoreTransformed] {
           } else {
             targs.toList.sortBy(variantKey).foreach { variant =>
               val name =
-                if variant.isEmpty || id == core.Type.ResumeSymbol || id == core.Type.PromptSymbol then id
+                if variant.isEmpty || id == core.Type.ResumeSymbol || id == core.Type.PromptSymbol || id.isInstanceOf[symbols.ExternInterface] then id
                 else functionNames.fresh(preferredMonoName(id, variant))
               monoFunNames += ((id, variant) -> name)
             }

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -523,29 +523,32 @@ object Transformer {
   def environmentSize(environment: machine.Environment): Int =
     environment.map { case machine.Variable(_, typ) => typeSize(typ) }.sum
 
-  def typeSize(tpe: machine.Type.CTpe): Int = tpe match {
-    case machine.Type.CTpe(tpe) => tpe match {
-      case machine.CType.Ptr    => 8
-      case machine.CType.Obj    => 8
-      case machine.CType.I64    => 8
-      case machine.CType.Double => 8
-      case machine.CType.Float  => 4
-      case machine.CType.Void   => 0
-    }
-  }
-
+  /**
+   * Number of bytes reserved for a value of this type in objects and stack frames.
+   */
   def typeSize(tpe: machine.Type): Int =
     tpe match {
-      case machine.Positive()           => 16
-      case machine.Negative()           => 16
-      case machine.Type.Prompt()        => 8 // TODO Make fat?
-      case machine.Type.Stack()         => 8 // TODO Make fat?
-      case machine.Type.Int()           => 8 // TODO Make fat?
-      case machine.Type.Byte()          => 1
-      case machine.Type.Double()        => 8 // TODO Make fat?
-      case machine.Type.Reference(_)    => 16
-      case CT@machine.Type.CTpe(_)      => typeSize(CT)
+      case machine.Positive() => 16
+      case machine.Negative() => 16
+      case machine.Type.Prompt() => 8
+      case machine.Type.Stack() => 8
+      case machine.Type.Int() => 8
+      case machine.Type.Byte() => 8 // rounded up to full word
+      case machine.Type.Double() => 8
+      case machine.Type.Reference(_) => 16
+      case CT@machine.Type.CTpe(_) => typeSize(CT)
     }
+
+  def typeSize(tpe: machine.Type.CTpe): Int = tpe match {
+    case machine.Type.CTpe(tpe) => tpe match {
+      case machine.CType.Ptr => 8
+      case machine.CType.Obj => 8
+      case machine.CType.I64 => 8
+      case machine.CType.Double => 8
+      case machine.CType.Float => 8 // rounded up to full word
+      case machine.CType.Void => 0
+    }
+  }
 
   def defineFunction(name: String, parameters: List[Parameter])(prog: (FunctionContext, BlockContext) ?=> Terminator): ModuleContext ?=> Unit = {
     implicit val FC = FunctionContext();

--- a/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/llvm/Transformer.scala
@@ -132,6 +132,10 @@ object Transformer {
         eraseValues(List(variable), freeVariables(rest))
         transform(rest)
 
+      case machine.Switch(value, Nil, None) =>
+        // TODO unreachable
+        RetVoid()
+
       case machine.Switch(value, clauses, default) =>
         emit(Comment(s"switch ${value.name}, ${clauses.length} clauses"))
         val freeInClauses = clauses.flatMap(freeVariables).toSet ++ default.map(freeVariables).getOrElse(Set.empty)
@@ -219,19 +223,18 @@ object Transformer {
         emit(callLabel(LocalReference(methodType, functionName), LocalReference(objectType, objectName) +: arguments))
         RetVoid()
 
-      case machine.Var(ref @ machine.Variable(name, machine.Type.Reference(tpe)), init, rest) =>
+      case machine.Var(ref @ machine.Variable(name, machine.Type.Reference(tpe)), init, returnType, rest) =>
         val environment = List(init)
         val returnAddressName = freshName("returnAddress")
-        val returnType = transform(machine.Type.Positive())
         val returnValue = freshName("returnValue")
-        val parameters = List(Parameter(returnType, returnValue))
+        val parameters = List(Parameter(transform(returnType), returnValue))
         defineLabel(returnAddressName, parameters) {
           emit(Comment(s"var $name / return address"))
           popEnvironmentFrom(getStack(), environment)
           eraseValue(init)
           val nextReturn = LocalReference(returnAddressType, freshName("returnAddress"))
           popReturnAddressFrom(getStack(), nextReturn.name)
-          emit(callLabel(nextReturn, List(LocalReference(returnType, returnValue))))
+          emit(callLabel(nextReturn, List(LocalReference(transform(returnType), returnValue))))
           RetVoid()
         }
 
@@ -245,7 +248,7 @@ object Transformer {
 
         transform(rest)
 
-      case machine.Var(_, _, _) => ???
+      case machine.Var(_, _, _, _) => ???
 
       case machine.LoadVar(name, ref, rest) =>
         emit(Comment(s"loadvar ${name.name}, reference ${ref.name}"))

--- a/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Analysis.scala
@@ -25,7 +25,7 @@ def freeVariables(statement: Statement): Set[Variable] =
       freeVariables(clauses) ++ (freeVariables(rest) -- Set(name))
     case Invoke(value, tag, values) =>
       Set(value) ++ Set.from(values)
-    case Var(name, init, rest) =>
+    case Var(name, init, returnType, rest) =>
       Set(init) ++ (freeVariables(rest) -- Set(name))
     case LoadVar(name, ref, rest) =>
       Set(ref) ++ (freeVariables(rest) -- Set(name))

--- a/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/PrettyPrinter.scala
@@ -71,7 +71,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Invoke(receiver, tag, arguments) =>
       "invoke" <+> receiver <> "." <> tag.toString <> parens(arguments map toDoc)
 
-    case Var(name, init, rest) =>
+    case Var(name, init, returnType, rest) =>
       "var" <+> name <+> "=" <+> toDoc(init) <> ";" <> line <> toDocStmts(rest)
 
     case LoadVar(name, reference, rest) =>

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -134,7 +134,7 @@ object Transformer {
       ExternBody.StringExternBody(ff, handleExternC(template))
     case core.ExternBody.StringExternBody(ff, Template(strings, args)) =>
       ExternBody.StringExternBody(ff, Template(strings, args map {
-        case core.ValueVar(id, tpe) => Variable(transform(id), transform(tpe))
+        case core.ValueVar(id, tpe) => Variable(transform(id), transformUnboxed(tpe))
         case _ => ErrorReporter.abort("In the LLVM backend, only variables are allowed in templates")
       }))
     case core.ExternBody.Unsupported(err) =>
@@ -214,8 +214,8 @@ object Transformer {
           transform(rest)
         }
 
-      case core.ImpureApp(id, core.BlockVar(blockName, core.BlockType.Function(_, _, vparamTypes, _, resultType), capt), targs, vargs, bargs, rest) =>
-        val variable = Variable(transform(id), transform(resultType))
+      case app @ core.ImpureApp(id, core.BlockVar(blockName, core.BlockType.Function(_, _, vparamTypes, _, resultType), capt), targs, vargs, bargs, rest) =>
+        val variable = Variable(transform(id), transform(core.Type.bindingType(app)))
         transform(rest).flatMap { rest =>
           transform(vargs, bargs).run { (values, blocks) =>
             perhapsUnbox(values, vparamTypes map transformUnboxed).run { unboxeds =>
@@ -602,8 +602,10 @@ object Transformer {
         Variable(transform(name), transform(tpe))
     }
 
-  def transform(tpe: core.ValueType)(using DeclarationContext, ErrorReporter): Type =
-    Positive()
+  def transform(tpe: core.ValueType)(using DeclarationContext, ErrorReporter): Type = tpe match {
+    case core.ValueType.Var(name) => ErrorReporter.panic(s"Unexpected type variable ${name} after monomorphization")
+    case _ => Positive()
+  }
 
   def transformUnboxed(tpe: core.ValueType)(using DeclarationContext, ErrorReporter): Type =
     tpe match {

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -601,11 +601,11 @@ object Transformer {
   }
 
   /**
-   * Types in the signatures of externs, where type variables and boxed blocks are represented as positive values.
+   * Types in the signatures of externs, where type variables and boxed extern interfaces are represented as positive values.
    */
   def transformExtern(tpe: core.ValueType)(using DeclarationContext, ErrorReporter): Type = tpe match {
     case core.ValueType.Var(_) => Positive()
-    case core.ValueType.Boxed(_, _) => Positive()
+    case core.ValueType.Boxed(core.BlockType.Interface(_: symbols.ExternInterface, _), _) => Positive()
     case _ => transform(tpe)
   }
 

--- a/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Transformer.scala
@@ -63,9 +63,9 @@ object Transformer {
       if bparams.nonEmpty then ErrorReporter.abort("Foreign functions currently cannot take block arguments.")
 
       val transformedParams = vparams.map {
-        case core.ValueParam(id, tpe) => Variable(transform(id), transformUnboxed(tpe))
+        case core.ValueParam(id, tpe) => Variable(transform(id), transformExtern(tpe))
       }
-      val transformedRet = transformUnboxed(ret)
+      val transformedRet = transformExtern(ret)
       val isExternAsync = capture.contains(symbols.builtins.AsyncCapability.capture)
       noteDefinition(name, transformedParams, Nil, isExternAsync)
       Extern(transform(name), transformedParams, transformedRet, isExternAsync, transform(body))
@@ -134,7 +134,7 @@ object Transformer {
       ExternBody.StringExternBody(ff, handleExternC(template))
     case core.ExternBody.StringExternBody(ff, Template(strings, args)) =>
       ExternBody.StringExternBody(ff, Template(strings, args map {
-        case core.ValueVar(id, tpe) => Variable(transform(id), transformUnboxed(tpe))
+        case core.ValueVar(id, tpe) => Variable(transform(id), transformExtern(tpe))
         case _ => ErrorReporter.abort("In the LLVM backend, only variables are allowed in templates")
       }))
     case core.ExternBody.Unsupported(err) =>
@@ -198,16 +198,26 @@ object Transformer {
             transform(substitute(rest)(using Substitution(DB.empty, DB.empty, DB.empty, DB(id, core.BlockVar(other, tpe, capt)))))
         }
 
-      case core.Def(id, block @ core.Unbox(expr), rest) =>
+      case core.Def(id, block @ core.Unbox(pure: core.ValueVar), rest) =>
         noteParameter(id, block.tpe)
-        transform(expr).run { boxed =>
-          transform(rest).map { rest =>
-            Coerce(Variable(transform(id), Type.Negative()), boxed, rest)
-          }
-        }
+        transform(substitute(rest)(using Substitution(DB.empty, DB.empty, DB.empty, DB(id, core.Unbox(pure)))))
+
+      case core.Def(id, block @ core.Unbox(expr), rest) =>
+        ErrorReporter.panic(s"Unbox of a non-variable expression: ${expr}")
 
       case core.Let(id, core.ValueVar(otherId, otherTpe), rest) =>
         transform(substitute(rest)(using Substitution(DB.empty, DB.empty, DB(id, core.ValueVar(otherId, otherTpe)), DB.empty)))
+
+      case core.Let(id, expr @ core.Box(block, _), rest) => block match {
+        case core.BlockVar(other, tpe, capt) if !(BPC.globals contains other) && isParameter(other) =>
+          transform(substitute(rest)(using Substitution(DB.empty, DB.empty, DB(id, expr), DB.empty)))
+        case core.Unbox(pure) =>
+          transform(substitute(rest)(using Substitution(DB.empty, DB.empty, DB(id, pure), DB.empty)))
+        case _ =>
+          transformBlockArg(Variable(transform(id), transform(expr.tpe)), block).run { _ =>
+            transform(rest)
+          }
+      }
 
       case core.Let(id, expr, rest) =>
         transformNamed(Variable(transform(id), transform(expr.tpe)), expr).run { _ =>
@@ -218,14 +228,8 @@ object Transformer {
         val variable = Variable(transform(id), transform(core.Type.bindingType(app)))
         transform(rest).flatMap { rest =>
           transform(vargs, bargs).run { (values, blocks) =>
-            perhapsUnbox(values, vparamTypes map transformUnboxed).run { unboxeds =>
-              transformUnboxed(resultType) match {
-                case Type.Positive() =>
-                  Trampoline.Done(ForeignCall(variable, transform(blockName), unboxeds ++ blocks, rest))
-                case unboxedTpe =>
-                  val unboxed = Variable(freshName("unboxed"), unboxedTpe)
-                  Trampoline.Done(ForeignCall(unboxed, transform(blockName), unboxeds ++ blocks, Coerce(variable, unboxed, rest)))
-              }
+            coerce(values, vparamTypes map transformExtern).run { coerced =>
+              Trampoline.Done(foreignCall(variable, transform(blockName), coerced ++ blocks, transformExtern(resultType), rest))
             }
           }
         }
@@ -259,9 +263,16 @@ object Transformer {
                 case BlockInfo.Definition(freeParams, blockParams, true) =>
                   // TODO better way to deal with extern async functions
                   annotatedTpe match {
-                    case core.BlockType.Function(_, _, vparamTypes, _, _) =>
-                      perhapsUnbox(values, vparamTypes map transformUnboxed).run { unboxeds =>
-                        Trampoline.Done(Jump(Label(transform(id), blockParams ++ freeParams), unboxeds ++ blocks ++ freeParams))
+                    case core.BlockType.Function(_, _, vparamTypes, _, resultType) =>
+                      val returnType = transformExtern(resultType)
+                      val expectedType = transform(stmt.tpe)
+                      coerce(values, vparamTypes map transformExtern).run { coerced =>
+                        val jump = Jump(Label(transform(id), blockParams ++ freeParams), coerced ++ blocks ++ freeParams)
+                        if returnType == expectedType then Trampoline.Done(jump)
+                        else
+                          val returned = Variable(freshName("returned"), returnType)
+                          val expected = Variable(freshName("coerced"), expectedType)
+                          Trampoline.Done(PushFrame(Clause(List(returned), Coerce(expected, returned, Return(List(expected)))), jump))
                       }
                     case _ =>
                       ErrorReporter.panic("Extern definition does not have function type")
@@ -274,9 +285,8 @@ object Transformer {
               transform(substitute(Block.BlockLit(tparams, cparams, vparams, bparams, body), targs, vargs, bargs))
 
             case Block.Unbox(pure) =>
-              transform(pure).run { boxedCallee =>
-                val callee = Variable(freshName(boxedCallee.name), Type.Negative())
-                Trampoline.Done(Coerce(callee, boxedCallee, Invoke(callee, builtins.Apply, values ++ blocks)))
+              transform(pure).run { callee =>
+                Trampoline.Done(Invoke(callee, builtins.Apply, values ++ blocks))
               }
 
             case Block.New(impl) =>
@@ -297,9 +307,8 @@ object Transformer {
               Trampoline.Done(Invoke(Variable(transform(id), transform(tpe)), opTag, values ++ blocks))
 
             case Block.Unbox(pure) =>
-              transform(pure).run { boxedCallee =>
-                val callee = Variable(freshName(boxedCallee.name), Type.Negative())
-                Trampoline.Done(Coerce(callee, boxedCallee, Invoke(callee, opTag, values ++ blocks)))
+              transform(pure).run { callee =>
+                Trampoline.Done(Invoke(callee, opTag, values ++ blocks))
               }
 
             case Block.New(impl) =>
@@ -318,6 +327,9 @@ object Transformer {
             }
           }
         }
+
+      case core.Match(scrutinee, tpe, Nil, Some(default)) =>
+        transform(default)
 
       case core.Match(scrutinee, tpe, clauses, default) =>
         val transformedClauses = clauses.map { case (constr, core.BlockLit(tparams, cparams, vparams, bparams, body)) =>
@@ -358,14 +370,25 @@ object Transformer {
         }
 
       case core.Region(core.BlockLit(tparams, cparams, vparams, List(region), body)) =>
-
-        val variable = Variable(freshName("returned"), transform(body.tpe))
-        val returnClause = Clause(List(variable), Return(List(variable)))
         val prompt = transform(region)
-
         noteParameters(List(region))
-        transform(body).map { body =>
-          Reset(prompt, returnClause, body)
+
+        // Variables allocated in the region live in frames below the reset, so we box the result of the region
+        transform(body.tpe) match {
+          case Positive() =>
+            val returned = Variable(freshName("returned"), Positive())
+            transform(body).map { body =>
+              Reset(prompt, Clause(List(returned), Return(List(returned))), body)
+            }
+          case returnType =>
+            val returned = Variable(freshName("returned"), returnType)
+            val boxed = Variable(freshName("boxed"), Positive())
+            val received = Variable(freshName("boxed"), Positive())
+            val unboxed = Variable(freshName("unboxed"), returnType)
+            transform(body).map { body =>
+              PushFrame(Clause(List(received), Coerce(unboxed, received, Return(List(unboxed)))),
+                Reset(prompt, Clause(List(returned), Coerce(boxed, returned, Return(List(boxed)))), body))
+            }
         }
 
       case core.Alloc(ref, init, region, body) =>
@@ -375,12 +398,10 @@ object Transformer {
         noteParameter(ref, core.Type.TState(init.tpe))
 
         transform(body).flatMap { body =>
-          transform(init).flatMap { value =>
-            perhapsUnbox(value, transformUnboxed(init.tpe)).map { unboxed =>
-              Shift(temporary, Variable(transform(region), Type.Prompt()),
-                Var(Variable(transform(ref), Type.Reference(unboxed.tpe)), unboxed,
-                  Resume(temporary, body)))
-            }
+          transform(init).map { value =>
+            Shift(temporary, Variable(transform(region), Type.Prompt()),
+              Var(Variable(transform(ref), Type.Reference(value.tpe)), value, Positive(),
+                Resume(temporary, body)))
           }.run(x => Trampoline.Done(x))
         }
 
@@ -389,33 +410,23 @@ object Transformer {
         // TODO ref should be BlockParam
         noteParameter(ref, core.Type.TState(init.tpe))
 
+        val returnType = transform(body.tpe)
         transform(body).flatMap { body =>
-          transform(init).flatMap { value =>
-            perhapsUnbox(value, transformUnboxed(init.tpe)).map { unboxed =>
-              Var(Variable(transform(ref), Type.Reference(unboxed.tpe)), unboxed, body)
-            }
+          transform(init).map { value =>
+            Var(Variable(transform(ref), Type.Reference(value.tpe)), value, returnType, body)
           }.run(x => Trampoline.Done(x))
         }
 
       case core.Get(id, tpe, ref, capt, body) =>
-        val variable = Variable(transform(id), Positive())
-
+        val variable = Variable(transform(id), transform(tpe))
         transform(body).map { body =>
-          transformUnboxed(tpe) match {
-            case Type.Positive() =>
-              LoadVar(variable, Variable(transform(ref), Type.Reference(Type.Positive())), body)
-            case unboxedTpe =>
-              val unboxed = Variable(freshName("unboxed"), unboxedTpe)
-              LoadVar(unboxed, Variable(transform(ref), Type.Reference(unboxedTpe)), Coerce(variable, unboxed, body))
-          }
+          LoadVar(variable, Variable(transform(ref), Type.Reference(variable.tpe)), body)
         }
 
       case core.Put(ref, capt, arg, body) =>
         transform(body).flatMap { body =>
-          transform(arg).flatMap { value =>
-            perhapsUnbox(value, transformUnboxed(arg.tpe)).map { unboxed =>
-              StoreVar(Variable(transform(ref), Type.Reference(unboxed.tpe)), unboxed, body)
-            }
+          transform(arg).map { value =>
+            StoreVar(Variable(transform(ref), Type.Reference(value.tpe)), value, body)
           }.run(x => Trampoline.Done(x))
         }
 
@@ -437,10 +448,15 @@ object Transformer {
       blocks <- transformBlockArgs(bargs)
     } yield (values, blocks)
 
-  def transformBlockArg(block: core.Block)(using BPC: BlocksParamsContext, DC: DeclarationContext, E: ErrorReporter): Binding[Variable] = block match {
+  def transformBlockArg(block: core.Block)(using BPC: BlocksParamsContext, DC: DeclarationContext, E: ErrorReporter): Binding[Variable] =
+    transformBlockArg(Variable(freshName("block"), Negative()), block)
+
+  /**
+   * Binds [[variable]] to the block, except for block parameters and unboxed values, which are returned as they are.
+   */
+  def transformBlockArg(variable: Variable, block: core.Block)(using BPC: BlocksParamsContext, DC: DeclarationContext, E: ErrorReporter): Binding[Variable] = block match {
     case core.BlockVar(id, tpe, _) if BPC.globals contains id =>
       val label = BPC.globals(id)
-      val variable = Variable(transform(id), transform(tpe))
       shift { k =>
         PushFrame(Clause(List(variable), k(variable)), Jump(label, label.environment))
       }
@@ -449,7 +465,6 @@ object Transformer {
         // Passing a top-level function directly, so we need to eta-expand turning it into a closure
         // TODO cache the closure somehow to prevent it from being created on every call
         val label = transformLabel(id)
-        val variable = Variable(freshName(id.name.name ++ "$closure"), Negative())
         shift { k =>
           New(variable, List(Clause(parameters,
             Jump(label, label.environment)
@@ -462,13 +477,11 @@ object Transformer {
     case core.BlockLit(tparams, cparams, vparams, bparams, body) =>
       noteParameters(bparams)
       val parameters = vparams.map(transform) ++ bparams.map(transform);
-      val variable = Variable(freshName("blockLit"), Negative())
       shift { k =>
         New(variable, List(Clause(parameters, transform(body).run())), k(variable))
       }
 
     case core.New(impl) =>
-      val variable = Variable(freshName("new"), Negative())
       shift { k =>
         New(variable, transform(impl), k(variable))
       }
@@ -511,30 +524,16 @@ object Transformer {
       }
 
     case core.Literal(value: Long, core.Type.TInt) =>
-      shift { k =>
-        val unboxed = Variable(freshName("integer"), Type.Int())
-        LiteralInt(unboxed, value, Coerce(variable, unboxed, k(variable)))
-      }
+      shift { k => LiteralInt(variable, value, k(variable)) }
 
     case core.Literal(value: Int, core.Type.TChar) =>
-      shift { k =>
-        val unboxed = Variable(freshName("character"), Type.Int())
-        LiteralInt(unboxed, value, Coerce(variable, unboxed, k(variable)))
-      }
+      shift { k => LiteralInt(variable, value, k(variable)) }
 
     case core.Literal(value: Byte, core.Type.TByte) =>
-      shift { k =>
-        val unboxed = Variable(freshName("byte"), Type.Byte())
-        val b = UByte.unsafeFromByte(value)
-        // TODO: Literal bytes could now also be just byte-sized in Machine (= use 'UByte'; they are byte-sized in LLVM anyway).
-        LiteralByte(unboxed, b.toInt, Coerce(variable, unboxed, k(variable)))
-      }
+      shift { k => LiteralByte(variable, UByte.unsafeFromByte(value).toInt, k(variable)) }
 
     case core.Literal(v: Double, core.Type.TDouble) =>
-      shift { k =>
-        val unboxed = Variable(freshName("double"), Type.Double())
-        LiteralDouble(unboxed, v, Coerce(variable, unboxed, k(variable)))
-      }
+      shift { k => LiteralDouble(variable, v, k(variable)) }
 
     case core.Literal(javastring: String, core.Type.TString) =>
       shift { k =>
@@ -543,16 +542,8 @@ object Transformer {
 
     case core.PureApp(core.BlockVar(blockName, core.BlockType.Function(_, _, vparamTypes, _, resultType), _), _, vargs) =>
       transform(vargs).flatMap { values =>
-        perhapsUnbox(values, vparamTypes map transformUnboxed).flatMap { unboxeds =>
-          shift { k =>
-            transformUnboxed(resultType) match {
-              case Type.Positive() =>
-                ForeignCall(variable, transform(blockName), unboxeds, k(variable))
-              case unboxedTpe =>
-                val unboxed = Variable(freshName("unboxed"), unboxedTpe)
-                ForeignCall(unboxed, transform(blockName), unboxeds, Coerce(variable, unboxed, k(variable)))
-            }
-          }
+        coerce(values, vparamTypes map transformExtern).flatMap { coerced =>
+          shift { k => foreignCall(variable, transform(blockName), coerced, transformExtern(resultType), k(variable)) }
         }
       }
 
@@ -566,11 +557,7 @@ object Transformer {
       }
 
     case core.Box(block, annot) =>
-      transformBlockArg(block).flatMap { unboxed =>
-        shift { k =>
-          Coerce(variable, unboxed, k(variable))
-        }
-      }
+      transformBlockArg(variable, block)
 
     case _ =>
       ErrorReporter.abort(s"Unsupported expression: $expr")
@@ -603,22 +590,27 @@ object Transformer {
     }
 
   def transform(tpe: core.ValueType)(using DeclarationContext, ErrorReporter): Type = tpe match {
+    case core.Type.TInt => Type.Int()
+    case core.Type.TChar => Type.Int()
+    case core.Type.TByte => Type.Byte()
+    case core.Type.TDouble => Type.Double()
+    case core.ValueType.Data(name, _) if isValidExternC(name) => getExternCTpe(name)
+    case core.ValueType.Data(_, _) => Positive()
+    case core.ValueType.Boxed(_, _) => Negative()
     case core.ValueType.Var(name) => ErrorReporter.panic(s"Unexpected type variable ${name} after monomorphization")
-    case _ => Positive()
   }
 
-  def transformUnboxed(tpe: core.ValueType)(using DeclarationContext, ErrorReporter): Type =
-    tpe match {
-        case core.Type.TInt => Type.Int()
-        case core.Type.TChar => Type.Int()
-        case core.Type.TByte => Type.Byte()
-        case core.Type.TDouble => Type.Double()
-        case core.ValueType.Data(name, _) if isValidExternC(name) => getExternCTpe(name)
-        case _ => Positive()
-      }
+  /**
+   * Types in the signatures of externs, where type variables and boxed blocks are represented as positive values.
+   */
+  def transformExtern(tpe: core.ValueType)(using DeclarationContext, ErrorReporter): Type = tpe match {
+    case core.ValueType.Var(_) => Positive()
+    case core.ValueType.Boxed(_, _) => Positive()
+    case _ => transform(tpe)
+  }
 
   def transform(tpe: core.BlockType)(using DeclarationContext, ErrorReporter): Type = tpe match {
-    case core.Type.TState(stateType) => Type.Reference(transformUnboxed(stateType))
+    case core.Type.TState(stateType) => Type.Reference(transform(stateType))
     case core.Type.TPrompt(answer) => Type.Prompt()
     case core.Type.TResume(result, answer) => Type.Stack()
     case core.Type.TRegion => Type.Prompt()
@@ -634,17 +626,25 @@ object Transformer {
   def transform(id: Id): String =
     s"${id.name}_${id.id}"
 
-  def perhapsUnbox(value: Variable, tpe: machine.Type): Binding[Variable] =
-    tpe match {
-      case Type.CTpe(CType.Void) => pure(value)
-      case Type.Int() | Type.Byte() | Type.Double() | Type.CTpe(_) =>
-        val unboxed = Variable(freshName("unboxed"), tpe)
-        shift { k => Coerce(unboxed, value, k(unboxed)) }
-      case _ => pure(value)
+  def coerce(value: Variable, tpe: Type): Binding[Variable] =
+    if value.tpe == tpe then pure(value)
+    else
+      val coerced = Variable(freshName("coerced"), tpe)
+      shift { k => Coerce(coerced, value, k(coerced)) }
+
+  def coerce(values: List[Variable], tpes: List[Type]): Binding[List[Variable]] =
+    traverse(values.zip(tpes)) { case (value, tpe) => coerce(value, tpe) }
+
+  def foreignCall(variable: Variable, name: String, arguments: Environment, returnType: Type, rest: Statement): Statement =
+    if (returnType == variable.tpe) {
+      ForeignCall(variable, name, arguments, rest)
+    } else {
+      val returned = Variable(freshName("returned"), returnType)
+      ForeignCall(returned, name, arguments, Coerce(variable, returned, rest))
     }
 
-  def perhapsUnbox(values: List[Variable], tpes: List[machine.Type]): Binding[List[Variable]] =
-    traverse(values.zip(tpes)) { case (value, tpe) => perhapsUnbox(value, tpe) }
+  def isParameter(id: Id)(using BPC: BlocksParamsContext): Boolean =
+    BPC.info.get(id).exists { case BlockInfo.Parameter(_) => true; case _ => false }
 
   def freshName(baseName: String): String = baseName + "_" + symbols.Symbol.fresh.next()
 

--- a/effekt/shared/src/main/scala/effekt/machine/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/machine/Tree.scala
@@ -134,7 +134,7 @@ enum Statement {
   /**
    * e.g. var x = 42; s
    */
-  case Var(name: Variable, init: Variable, rest: Statement)
+  case Var(name: Variable, init: Variable, returnType: Type, rest: Statement)
 
   /**
    * e.g. let y = loadVar(x); s

--- a/libraries/common/io.effekt
+++ b/libraries/common/io.effekt
@@ -12,7 +12,7 @@ extern def spawn[T](task: () => T at {io, async, global}) at async: Unit =
   js "$effekt.capture(k => { setTimeout(() => k($effekt.unit), 0); return $effekt.run(${task}) })"
   llvm """
     notail call void @c_yield(%Stack %stack)
-    notail call void @run(%Pos ${task})
+    notail call void @run(%Neg ${task})
     ret void
   """
 

--- a/libraries/common/io/network.effekt
+++ b/libraries/common/io/network.effekt
@@ -182,7 +182,7 @@ namespace internal {
   extern def listen(listener: Int, handler: Connection => Unit at {io, async, global}) at async: Int =
     jsNode "$effekt.capture(k => tcp$listen(${listener}, ${handler}, k))"
     llvm """
-      notail call void @c_tcp_listen(%Int ${listener}, %Pos ${handler}, %Stack %stack)
+      notail call void @c_tcp_listen(%Int ${listener}, %Neg ${handler}, %Stack %stack)
       ret void
     """
 

--- a/libraries/common/process.effekt
+++ b/libraries/common/process.effekt
@@ -48,7 +48,7 @@ extern def onStdout(opts: SpawnOptions, callback: String => Unit at {io, global}
     };
     return old; })()"""
   llvm """
-    %opts = call %Pos @c_spawn_options_on_stdout(%Pos ${opts}, %Pos ${callback})
+    %opts = call %Pos @c_spawn_options_on_stdout(%Pos ${opts}, %Neg ${callback})
     ret %Pos %opts
   """
 extern def onStderr(opts: SpawnOptions, callback: String => Unit at {io, global}) at {}: SpawnOptions =
@@ -64,7 +64,7 @@ extern def onStderr(opts: SpawnOptions, callback: String => Unit at {io, global}
     };
     return old; })()"""
   llvm """
-    %opts = call %Pos @c_spawn_options_on_stderr(%Pos ${opts}, %Pos ${callback})
+    %opts = call %Pos @c_spawn_options_on_stderr(%Pos ${opts}, %Neg ${callback})
     ret %Pos %opts
   """
 extern type WritableStream =
@@ -84,7 +84,7 @@ extern def withStdin(opts: SpawnOptions, callback: WritableStream => Unit at {io
     return old;
   })()"""
   llvm """
-    %opts = call %Pos @c_spawn_options_pipe_stdin(%Pos ${opts}, %Pos ${callback})
+    %opts = call %Pos @c_spawn_options_pipe_stdin(%Pos ${opts}, %Neg ${callback})
     ret %Pos %opts
   """
 extern def write(to: WritableStream, s: String) at io: Unit =

--- a/libraries/llvm/io.c
+++ b/libraries/llvm/io.c
@@ -383,18 +383,18 @@ Int c_tcp_bind(String host, Int port) {
 
 typedef struct {
     Stack stack;
-    struct Pos handler;
+    struct Neg handler;
 } tcp_listen_closure_t;
 
 void c_tcp_listen_cb(uv_stream_t* server, int status) {
     tcp_listen_closure_t* listen_closure = (tcp_listen_closure_t*)server->data;
     Stack closure_stack = listen_closure->stack;
-    struct Pos closure_handler = listen_closure->handler;
+    struct Neg closure_handler = listen_closure->handler;
 
     if (status < 0) {
         server->data = NULL;
         free(listen_closure);
-        erasePositive(closure_handler);
+        eraseNegative(closure_handler);
         resume_Int(closure_stack, status);
         return;
     }
@@ -406,7 +406,7 @@ void c_tcp_listen_cb(uv_stream_t* server, int status) {
         free(client);
         server->data = NULL;
         free(listen_closure);
-        erasePositive(closure_handler);
+        eraseNegative(closure_handler);
         resume_Int(closure_stack, result);
         return;
     }
@@ -416,16 +416,16 @@ void c_tcp_listen_cb(uv_stream_t* server, int status) {
         uv_close((uv_handle_t*)client, (uv_close_cb)free);
         server->data = NULL;
         free(listen_closure);
-        erasePositive(closure_handler);
+        eraseNegative(closure_handler);
         resume_Int(closure_stack, result);
         return;
     }
 
-    sharePositive(closure_handler);
+    shareNegative(closure_handler);
     run_Int(closure_handler, (int64_t)client);
 }
 
-void c_tcp_listen(Int listener, struct Pos handler, Stack stack) {
+void c_tcp_listen(Int listener, struct Neg handler, Stack stack) {
     uv_stream_t* server = (uv_stream_t*)listener;
 
     tcp_listen_closure_t* listen_closure = malloc(sizeof(tcp_listen_closure_t));
@@ -436,7 +436,7 @@ void c_tcp_listen(Int listener, struct Pos handler, Stack stack) {
     int result = uv_listen(server, SOMAXCONN, c_tcp_listen_cb);
     if (result < 0) {
         free(listen_closure);
-        erasePositive(handler);
+        eraseNegative(handler);
         resume_Int(stack, result);
         return;
     }
@@ -451,9 +451,9 @@ void c_tcp_shutdown(Int handle, Stack stack) {
 
     if (listen_closure) {
         Stack closure_stack = listen_closure->stack;
-        struct Pos closure_handler = listen_closure->handler;
+        struct Neg closure_handler = listen_closure->handler;
         free(listen_closure);
-        erasePositive(closure_handler);
+        eraseNegative(closure_handler);
         resume_Int(closure_stack, 0);
     }
 }
@@ -601,7 +601,7 @@ static void subproc_alloc_cb(uv_handle_t* handle, size_t suggested_size, uv_buf_
 }
 
 typedef struct {
-  struct Pos handler;
+  struct Neg handler;
 } subproc_stream_cb_closure_t;
 void subproc_stream_cb(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
   subproc_stream_cb_closure_t* clos = (subproc_stream_cb_closure_t*)(stream->data);
@@ -611,12 +611,12 @@ void subproc_stream_cb(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) 
     run_Pos(clos->handler, chunk);
   } else {
     uv_read_stop(stream);
-    erasePositive(clos->handler);
+    eraseNegative(clos->handler);
     free(clos);
     if (buf->base) free(buf->base);
   }
 }
-struct Pos subproc_options_on_stream(struct Pos opts, size_t id, uv_stdio_flags flags, struct Pos callback) {
+struct Pos subproc_options_on_stream(struct Pos opts, size_t id, uv_stdio_flags flags, struct Neg callback) {
     uv_process_options_t* options = (uv_process_options_t*)opts.obj;
 
     options->stdio[id].flags = UV_CREATE_PIPE | flags;
@@ -631,13 +631,13 @@ struct Pos subproc_options_on_stream(struct Pos opts, size_t id, uv_stdio_flags 
 
     return opts;
 }
-struct Pos c_spawn_options_on_stdout(struct Pos opts, struct Pos callback) {
+struct Pos c_spawn_options_on_stdout(struct Pos opts, struct Neg callback) {
   return subproc_options_on_stream(opts, 1, UV_WRITABLE_PIPE, callback);
 }
-struct Pos c_spawn_options_on_stderr(struct Pos opts, struct Pos callback) {
+struct Pos c_spawn_options_on_stderr(struct Pos opts, struct Neg callback) {
   return subproc_options_on_stream(opts, 2, UV_WRITABLE_PIPE, callback);
 }
-struct Pos c_spawn_options_pipe_stdin(struct Pos opts, struct Pos callback) {
+struct Pos c_spawn_options_pipe_stdin(struct Pos opts, struct Neg callback) {
   return subproc_options_on_stream(opts, 0, UV_READABLE_PIPE, callback);
 }
 
@@ -754,7 +754,7 @@ void c_spawn(struct Pos cmd, struct Pos args, struct Pos options, Stack stack) {
         subproc_stream_cb_closure_t* clos = (subproc_stream_cb_closure_t*)(stream->data);
         struct Pos str = (struct Pos) { .tag = 0, .obj = stream, };
         run_Pos(clos->handler, str);
-        erasePositive(clos->handler);
+        eraseNegative(clos->handler);
         free(clos);
     }
     if(opts->stdio[1].flags & UV_CREATE_PIPE)

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -739,9 +739,7 @@ define ccc void @resume_Pos(%Stack %stack, %Pos %argument) {
     ret void
 }
 
-define ccc void @run(%Pos %boxed) {
-
-    %function = call %Neg @coercePosNeg(%Pos %boxed)
+define ccc void @run(%Neg %function) {
     %stack = call %Stack @withEmptyStack()
 
     %arrayPointer = extractvalue %Neg %function, 0
@@ -753,9 +751,7 @@ define ccc void @run(%Pos %boxed) {
     ret void
 }
 
-define ccc void @run_Int(%Pos %boxed, %Int %argument) {
-
-    %function = call ccc %Neg @coercePosNeg(%Pos %boxed)
+define ccc void @run_Int(%Neg %function, %Int %argument) {
     %stack = call %Stack @withEmptyStack()
 
     %arrayPointer = extractvalue %Neg %function, 0
@@ -767,9 +763,7 @@ define ccc void @run_Int(%Pos %boxed, %Int %argument) {
     ret void
 }
 
-define ccc void @run_Pos(%Pos %boxed, %Pos %argument) {
-
-    %function = call ccc %Neg @coercePosNeg(%Pos %boxed)
+define ccc void @run_Pos(%Neg %function, %Pos %argument) {
     %stack = call %Stack @withEmptyStack()
 
     %arrayPointer = extractvalue %Neg %function, 0

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -91,9 +91,6 @@
 %Double = type double
 %Byte = type i8
 %Char = type i64
-%Bool = type %Pos
-%Unit = type %Pos
-%String = type %Pos
 
 ; Foreign imports
 
@@ -726,9 +723,11 @@ define private %Stack @withEmptyStack() {
     ret %Stack %stack
 }
 
-define ccc void @resume_Int(%Stack %stack, %Int %integer) {
-    %argument = call ccc %Pos @coerceIntPos(%Int %integer)
-    call ccc void @resume_Pos(%Stack %stack, %Pos %argument)
+define ccc void @resume_Int(%Stack %stack, %Int %argument) {
+    %stackPointer = call ccc %StackPointer @stackDeallocate(%Stack %stack, i64 24)
+    %returnAddressPointer = getelementptr %FrameHeader, %StackPointer %stackPointer, i64 0, i32 0
+    %returnAddress = load %ReturnAddress, ptr %returnAddressPointer, !alias.scope !12, !noalias !22
+    tail call tailcc void %returnAddress(%Int %argument, %Stack %stack)
     ret void
 }
 
@@ -754,9 +753,17 @@ define ccc void @run(%Pos %boxed) {
     ret void
 }
 
-define ccc void @run_Int(%Pos %boxed, %Int %integer) {
-    %argument = call ccc %Pos @coerceIntPos(%Int %integer)
-    call ccc %Pos @run_Pos(%Pos %boxed, %Pos %argument)
+define ccc void @run_Int(%Pos %boxed, %Int %argument) {
+
+    %function = call ccc %Neg @coercePosNeg(%Pos %boxed)
+    %stack = call %Stack @withEmptyStack()
+
+    %arrayPointer = extractvalue %Neg %function, 0
+    %object = extractvalue %Neg %function, 1
+    %functionPointerPointer = getelementptr ptr, ptr %arrayPointer, i64 0
+    %functionPointer = load ptr, ptr %functionPointerPointer, !alias.scope !15, !noalias !25
+
+    tail call tailcc %Pos %functionPointer(%Object %object, %Int %argument, %Stack %stack)
     ret void
 }
 

--- a/libraries/llvm/types.c
+++ b/libraries/llvm/types.c
@@ -38,9 +38,9 @@ typedef struct StackValue* Stack;
 extern void resume_Int(Stack, Int);
 extern void resume_Pos(Stack, struct Pos);
 
-extern void run(struct Pos);
-extern void run_Int(struct Pos, Int);
-extern void run_Pos(struct Pos, struct Pos);
+extern void run(struct Neg);
+extern void run_Int(struct Neg, Int);
+extern void run_Pos(struct Neg, struct Pos);
 
 // Reference counting primitives defined in LLVM
 extern void eraseNegative(struct Neg);


### PR DESCRIPTION
Finally we reap the benefits of monomorphization and use different representations for different types. Positions where we still need boxing, to be addressed in the future:

- Type variables in extern types `Array[T]`, `Ref[T]`, `Signal[A, B]`, `spawn[T]`.
- Answer types of regions
