### PR TITLE
Improve LLVM RTS: fix declarations, add assumption annotations

### DIFF
--- a/libraries/common/array.effekt
+++ b/libraries/common/array.effekt
@@ -108,7 +108,7 @@ define void @assertInbounds(i64 %index, %Pos %arr) alwaysinline {
   %in_bounds = icmp ult i64 %index, %size
   br i1 %in_bounds, label %ok, label %out
 out:
-  call void @exit(i64 1)
+  call void @exit(i32 1)
   unreachable
 ok:
   ret void

--- a/libraries/common/bytearray.effekt
+++ b/libraries/common/bytearray.effekt
@@ -61,7 +61,7 @@ define void @assertInboundsByteArray(i64 %index, %Pos %arr) alwaysinline {
   %in_bounds = icmp ult i64 %index, %size
   br i1 %in_bounds, label %ok, label %out
 out:
-  call void @exit(i64 1)
+  call void @exit(i32 1)
   unreachable
 ok:
   ret void

--- a/libraries/common/io/signal.effekt
+++ b/libraries/common/io/signal.effekt
@@ -85,7 +85,7 @@ extern def fire[A, B](signal: Signal[A, B], value: A) at async: B =
     notail call void @resume_Pos(%Stack %stack, %Pos %otherValue)
     ret void
   panic:
-    notail call void @exit(i64 1)
+    notail call void @exit(i32 1)
     ret void
   """
 
@@ -113,7 +113,7 @@ extern def wait[A, B](signal: Signal[A, B], value: B) at async: A =
     notail call void @resume_Pos(%Stack %stack, %Pos %otherValue)
     ret void
   panic:
-    notail call void @exit(i64 1)
+    notail call void @exit(i32 1)
     ret void
   """
 

--- a/libraries/common/process.effekt
+++ b/libraries/common/process.effekt
@@ -4,7 +4,8 @@ import array
 extern def exit(errorCode: Int) at io: Nothing =
   js   "(function() { process.exit(${errorCode}) })()"
   llvm """
-    call void @exit(i64 ${errorCode})
+    %exitCode = trunc i64 ${errorCode} to i32
+    call void @exit(i32 %exitCode)
     ret %Pos zeroinitializer
   """
   chez "(exit ${errorCode})"

--- a/libraries/llvm/bytearray.c
+++ b/libraries/llvm/bytearray.c
@@ -77,7 +77,7 @@ struct Pos c_bytearray_construct(const uint64_t n, const uint8_t *data) {
 
 struct Pos c_bytearray_from_nullterminated_string(const char *data) {
     uint64_t n = 0;
-    while (data[++n]);
+    while (data[n]) n++;
 
     return c_bytearray_construct(n, (uint8_t*)data);
 }

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -162,7 +162,7 @@ define private void @shareObject(%Object %object) alwaysinline {
 
     next:
     %objectReferenceCount = getelementptr %Header, ptr %object, i64 0, i32 0
-    %referenceCount = load %ReferenceCount, ptr %objectReferenceCount, !alias.scope !14, !noalias !24
+    %referenceCount = load %ReferenceCount, ptr %objectReferenceCount, !alias.scope !14, !noalias !24, !range !41
     %referenceCount.1 = add %ReferenceCount %referenceCount, 1
     store %ReferenceCount %referenceCount.1, ptr %objectReferenceCount, !alias.scope !14, !noalias !24
     br label %done
@@ -189,7 +189,7 @@ define private void @eraseObject(%Object %object) alwaysinline {
 
     next:
     %objectReferenceCount = getelementptr %Header, ptr %object, i64 0, i32 0
-    %referenceCount = load %ReferenceCount, ptr %objectReferenceCount, !alias.scope !14, !noalias !24
+    %referenceCount = load %ReferenceCount, ptr %objectReferenceCount, !alias.scope !14, !noalias !24, !range !41
     switch %ReferenceCount %referenceCount, label %decr [%ReferenceCount 0, label %free]
 
     decr:
@@ -486,7 +486,7 @@ define private {%Resumption, %Stack} @shift(%Stack %stack, %Prompt %prompt) {
 
 define private void @erasePrompt(%Prompt %prompt) alwaysinline {
     %referenceCount_pointer = getelementptr %PromptValue, %Prompt %prompt, i64 0, i32 0
-    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !13, !noalias !23
+    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !13, !noalias !23, !range !41
     switch %ReferenceCount %referenceCount, label %decrement [%ReferenceCount 0, label %free]
 
 decrement:
@@ -501,7 +501,7 @@ free:
 
 define private void @sharePrompt(%Prompt %prompt) alwaysinline {
     %referenceCount_pointer = getelementptr %PromptValue, %Prompt %prompt, i64 0, i32 0
-    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !13, !noalias !23
+    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !13, !noalias !23, !range !41
     %newReferenceCount = add %ReferenceCount %referenceCount, 1
     store %ReferenceCount %newReferenceCount, ptr %referenceCount_pointer, !alias.scope !13, !noalias !23
     ret void
@@ -569,7 +569,7 @@ define private %Resumption @uniqueStack(%Resumption %resumption) alwaysinline {
 
 entry:
     %referenceCount_pointer = getelementptr %StackValue, %Resumption %resumption, i64 0, i32 0
-    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !11, !noalias !21
+    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !11, !noalias !21, !range !41
     switch %ReferenceCount %referenceCount, label %copy [%ReferenceCount 0, label %done]
 
 done:
@@ -613,7 +613,7 @@ stop:
 
 define void @shareResumption(%Resumption %resumption) alwaysinline {
     %referenceCount_pointer = getelementptr %StackValue, %Resumption %resumption, i64 0, i32 0
-    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !11, !noalias !21
+    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !11, !noalias !21, !range !41
     %referenceCount.1 = add %ReferenceCount %referenceCount, 1
     store %ReferenceCount %referenceCount.1, ptr %referenceCount_pointer, !alias.scope !11, !noalias !21
     ret void
@@ -621,7 +621,7 @@ define void @shareResumption(%Resumption %resumption) alwaysinline {
 
 define void @eraseResumption(%Resumption %resumption) alwaysinline {
     %referenceCount_pointer = getelementptr %StackValue, %Resumption %resumption, i64 0, i32 0
-    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !11, !noalias !21
+    %referenceCount = load %ReferenceCount, ptr %referenceCount_pointer, !alias.scope !11, !noalias !21, !range !41
     switch %ReferenceCount %referenceCount, label %decr [%ReferenceCount 0, label %free]
 
     decr:
@@ -915,3 +915,6 @@ define ccc %CObject @coercePosObj(%Pos %input) {
 !23 = !{!1, !2,     !4, !5} ; not prompt
 !24 = !{!1, !2, !3,     !5} ; not object
 !25 = !{!1, !2, !3, !4    } ; not vtable
+
+; Ranges
+!41 = !{i64 0, i64 9223372036854775807} ; positive i64

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -334,10 +334,8 @@ realloc:
 
 define private %StackPointer @stackAllocate(%Stack %stack, i64 %n) alwaysinline {
     %stackPointer_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 1
-    %limit_pointer = getelementptr %StackValue, %Stack %stack, i64 0, i32 2
 
     %currentStackPointer = load %StackPointer, ptr %stackPointer_pointer, !alias.scope !11, !noalias !21
-    %limit = load %Limit, ptr %limit_pointer, !alias.scope !11, !noalias !21
     %nextStackPointer = getelementptr i8, %StackPointer %currentStackPointer, i64 %n
 
     store %StackPointer %nextStackPointer, ptr %stackPointer_pointer, !alias.scope !11, !noalias !21

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -101,7 +101,7 @@ declare ptr @malloc(i64)
 declare void @free(ptr)
 declare ptr @realloc(ptr, i64)
 declare noalias ptr @calloc(i64, i64)
-declare void @memcpy(ptr, ptr, i64)
+declare ptr @memcpy(ptr, ptr, i64)
 declare i64 @llvm.ctlz.i64 (i64 , i1)
 declare i64 @llvm.fshr.i64(i64, i64, i64)
 declare double @llvm.sqrt.f64(double)
@@ -544,7 +544,7 @@ define private %Stack @copyStack(%Stack %stack) alwaysinline {
     %newStackPointer = getelementptr i8, %Stack %newStack, i64 %used
     %newLimit = getelementptr i8, %Stack %newStack, i64 %size
 
-    call void @memcpy(ptr %newStack, ptr %stack, i64 %used)
+    %copied = call ptr @memcpy(ptr %newStack, ptr %stack, i64 %used)
 
     %newStackPointer_pointer = getelementptr %StackValue, %Stack %newStack, i64 0, i32 1
     %newLimit_pointer = getelementptr %StackValue, %Stack %newStack, i64 0, i32 2

--- a/libraries/llvm/rts.ll
+++ b/libraries/llvm/rts.ll
@@ -117,8 +117,7 @@ declare double @log1p(double)
 ; Intrinsic versions of the following two only added in LLVM 19
 declare double @atan(double)
 declare double @tan(double)
-declare void @print(i64)
-declare void @exit(i64)
+declare void @exit(i32)
 declare void @llvm.assume(i1)
 
 


### PR DESCRIPTION
Subsumes #1384

1. assume RC >= 0 (this seems to help a lot in some benchmarks like `bounce`: LLVM then can reason that `rc+1>0`)
2. const char* -> bytearray conversion was off-by-one on empty strings (see the commit description by clicking on `[...]` below)
3. fix memcpy declaration (clang couldn't pair it with the libc version and thus infer what the function does)
4. remove unused `%limit`-related computations from the RTS
5. fix exit declaration (same reason as memcpy, though this one actually lead to miscompilations)