### PR TITLE
Feature/Experiment: Line-based raw strings

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -64,6 +64,7 @@ enum TokenKind {
   case Integer(n: Long)
   case Float(d: Double)
   case Str(s: String, multiline: Boolean)
+  case RawStr(s: String)
   case HoleStr(s: String)
   case Chr(c: Int)
   case Byt(b: UByte)
@@ -90,6 +91,7 @@ enum TokenKind {
   case `{`
   case `}`
   case `}$`
+  case `$|`
   case `(`
   case `)`
   case `[`
@@ -276,12 +278,15 @@ class Lexer(source: Source) extends Iterator[Token] {
   enum Delimiter {
     //          "...",   """...""",      '...',    <"...">
     case SingleString, MultiString, CharString, HoleString
+    // #|...
+    case RawString
 
     def allowsInterpolation: Boolean = this match {
       case SingleString => true
       case MultiString => true
       case CharString => false
       case HoleString => true
+      case RawString => true
     }
 
     def isMultiline: Boolean = this match {
@@ -289,6 +294,7 @@ class Lexer(source: Source) extends Iterator[Token] {
       case MultiString => true
       case CharString => false
       case HoleString => true
+      case RawString => true
     }
 
     def allowsEscapes: Boolean = !this.isMultiline
@@ -300,6 +306,7 @@ class Lexer(source: Source) extends Iterator[Token] {
       case CharString if cs.isEmpty => TokenKind.Error(LexerError.EmptyCharLiteral)
       case CharString if cs.codePointCount(0, cs.length) > 1 => TokenKind.Error(LexerError.MultipleCodePointsInChar)
       case CharString /* otherwise */ => TokenKind.Chr(cs.codePointAt(0))
+      case RawString => TokenKind.RawStr(cs)
     }
   }
   export Delimiter.*
@@ -381,6 +388,11 @@ class Lexer(source: Source) extends Iterator[Token] {
   private def isAtInterpolationBoundary: Boolean =
     interpolationDepths.nonEmpty && interpolationDepths.top == depthTracker.braces
 
+  private def newline(): TokenKind = {
+    delimiters.popWhile(_ == RawString)
+    TokenKind.Newline
+  }
+
   /**
    * "Main" function for getting the next token kind.
    * Wrapped on the outside by [[Lexer.next]] which handles whitespace.
@@ -397,8 +409,8 @@ class Lexer(source: Source) extends Iterator[Token] {
 
     (currentChar, nextChar) match {
       // Whitespace: first try matching newlines, then whitespace-like
-      case ('\n',    _) => advanceWith(TokenKind.Newline)
-      case ('\r', '\n') => advance2With(TokenKind.Newline)
+      case ('\n',    _) => advanceWith(newline())
+      case ('\r', '\n') => advance2With(newline())
       case (c, _) if c.isWhitespace => advanceSpaces()
 
       // Numbers
@@ -413,6 +425,8 @@ class Lexer(source: Source) extends Iterator[Token] {
       case ('"',   _)                        => advanceWith(stringLike(SingleString)) // " ... """
       case ('\'',  _)                        => advanceWith(stringLike(CharString))   // ' ... '
       case ('<', '"')                        => advance2With(stringLike(HoleString))  // <" ... ">
+      case ('#', '|')                        => advance2With(stringLike(RawString))   // #|...
+      case ('$', '|')                        => delimiters.push(RawString); advance2With(`$|`)
 
       // Comments
       case ('/', '*') => advance2With(multilineComment())
@@ -621,6 +635,9 @@ class Lexer(source: Source) extends Iterator[Token] {
           return advance2With(close())
         case ('\'', _) if delimiter == CharString =>
           return advanceWith(close())
+        case ('\n', _) | ('\r', '\n') if delimiter == RawString =>
+          delimiters.popWhile(_ == RawString)
+          return advanceWith(close(shouldPop = false))
 
         // escapes
         case ('\\', _) if delimiter.allowsEscapes =>

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -64,7 +64,7 @@ enum TokenKind {
   case Integer(n: Long)
   case Float(d: Double)
   case Str(s: String, multiline: Boolean)
-  case RawStr(s: String)
+  case RawStr(s: String, terminator: String)
   case HoleStr(s: String)
   case Chr(c: Int)
   case Byt(b: UByte)
@@ -299,14 +299,14 @@ class Lexer(source: Source) extends Iterator[Token] {
 
     def allowsEscapes: Boolean = !this.isMultiline
 
-    def toTokenKind(cs: String): TokenKind = this match {
+    def toTokenKind(cs: String, terminator: String = ""): TokenKind = this match {
       case SingleString => TokenKind.Str(cs, multiline = false)
       case MultiString => TokenKind.Str(cs, multiline = true)
       case HoleString => TokenKind.HoleStr(cs)
       case CharString if cs.isEmpty => TokenKind.Error(LexerError.EmptyCharLiteral)
       case CharString if cs.codePointCount(0, cs.length) > 1 => TokenKind.Error(LexerError.MultipleCodePointsInChar)
       case CharString /* otherwise */ => TokenKind.Chr(cs.codePointAt(0))
-      case RawString => TokenKind.RawStr(cs)
+      case RawString => TokenKind.RawStr(cs, terminator)
     }
   }
   export Delimiter.*
@@ -608,6 +608,7 @@ class Lexer(source: Source) extends Iterator[Token] {
     if !continued then delimiters.push(delimiter)
 
     val contents = StringBuilder()
+    var terminator = ""
 
     /**
      * Creates the correct token to be returned, takes care of the [[delimiters]] stack.
@@ -615,7 +616,7 @@ class Lexer(source: Source) extends Iterator[Token] {
     def close(shouldPop: Boolean = true, unterminated: Boolean = false) = {
       if shouldPop then delimiters.pop()
 
-      val kind = delimiter.toTokenKind(contents.toString)
+      val kind = delimiter.toTokenKind(contents.toString, terminator)
 
       if (unterminated) {
         TokenKind.Error(LexerError.UnterminatedStringLike(kind))
@@ -638,13 +639,12 @@ class Lexer(source: Source) extends Iterator[Token] {
         case ('\n', _) if delimiter == RawString =>
           delimiters.popWhile(_ == RawString)
           // will be removed in Parser for the last line
-          contents.addOne(advance())
-          return close(shouldPop = false)
+          terminator = "\n"
+          return advanceWith(close(shouldPop = false))
         case ('\r', '\n') if delimiter == RawString =>
           delimiters.popWhile(_ == RawString)
           // will be removed in Parser for the last line
-          contents.addOne(advance())
-          contents.addOne(advance())
+          terminator = "\r\n"
           return close(shouldPop = false)
 
         // escapes

--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -635,9 +635,17 @@ class Lexer(source: Source) extends Iterator[Token] {
           return advance2With(close())
         case ('\'', _) if delimiter == CharString =>
           return advanceWith(close())
-        case ('\n', _) | ('\r', '\n') if delimiter == RawString =>
+        case ('\n', _) if delimiter == RawString =>
           delimiters.popWhile(_ == RawString)
-          return advanceWith(close(shouldPop = false))
+          // will be removed in Parser for the last line
+          contents.addOne(advance())
+          return close(shouldPop = false)
+        case ('\r', '\n') if delimiter == RawString =>
+          delimiters.popWhile(_ == RawString)
+          // will be removed in Parser for the last line
+          contents.addOne(advance())
+          contents.addOne(advance())
+          return close(shouldPop = false)
 
         // escapes
         case ('\\', _) if delimiter.allowsEscapes =>

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -13,6 +13,7 @@ import kiama.util.{Position, Range, Source}
 
 import scala.annotation.{tailrec, targetName}
 import scala.collection.mutable.ListBuffer
+import scala.collection.mutable
 import scala.language.implicitConversions
 import scala.util.boundary
 import scala.util.boundary.break
@@ -157,7 +158,9 @@ class Parser(tokens: Seq[Token], source: Source) {
       if position < 0 then fail("Unexpected start of file")
 
       tokens(position).failOnErrorToken(position) match {
+        case token if token.kind == `$|` => go(position - 1)
         case token if isSpace(token.kind) && token.kind != Newline => go(position - 1)
+        case token if token.kind.isInstanceOf[RawStr] => true // raw string literals are always terminated by newline
         case token if token.kind == Newline => true
         case _ => false
       }
@@ -216,6 +219,7 @@ class Parser(tokens: Seq[Token], source: Source) {
   def isSpace(kind: TokenKind): Boolean =
     kind match {
       case TokenKind.Space | TokenKind.Comment(_) | TokenKind.Newline => true
+      case TokenKind.`$|` if sawNewlineLast => true
       case _ => false
     }
 
@@ -771,6 +775,7 @@ class Parser(tokens: Seq[Token], source: Source) {
 
   def template[T](of: => T): SpannedTemplate[T] =
     nonterminal:
+      // TODO lint: do not allow nesting non-raw multiline strings in splices in a raw string
       // TODO handle case where the body is not a string, e.g.
       // Expected an extern definition, which can either be a single-line string (e.g., "x + y") or a multi-line string (e.g., """...""")
       val first = spanned(string())
@@ -844,6 +849,19 @@ class Parser(tokens: Seq[Token], source: Source) {
   def string(): String =
     nonterminal:
       expect("string literal") {
+        case RawStr(fst) =>
+          val res = mutable.StringBuilder(fst)
+          @tailrec
+          def go(): String = {
+            peek.kind match {
+              case t@RawStr(s) =>
+                skip()
+                res.addOne('\n'); res.append(s)
+                go()
+              case _ => res.mkString
+            }
+          }
+          go()
         case Str(s, _) => s
       }
 
@@ -1331,7 +1349,7 @@ class Parser(tokens: Seq[Token], source: Source) {
     case _ if isVariable     =>
       val lhs = variable()
       peek.kind match {
-        case _: Str => templateString(Maybe.Some(lhs.id, lhs.id.span))
+        case _: (Str | RawStr) => templateString(Maybe.Some(lhs.id, lhs.id.span))
         case _ =>
           peek.kind match {
             case `+=` | `-=` | `*=` | `/=` =>
@@ -1434,8 +1452,8 @@ class Parser(tokens: Seq[Token], source: Source) {
   }
 
   def isString: Boolean = peek.kind match {
-    case _: Str => true
-    case _      => false
+    case _: (Str | RawStr) => true
+    case _                 => false
   }
 
   def templateString(splicer: Maybe[IdRef]): Term =

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -773,14 +773,21 @@ class Parser(tokens: Seq[Token], source: Source) {
       case _                          => false
     }
 
+  private val _isInRawString = scala.util.DynamicVariable[Boolean](false)
+  private def rawStringNestingGuard[T](body: => T): T =
+    if(_isInRawString.value && isActualMultilineString()) {
+      softFailWith("Can't nest multiline strings in raw strings.")(body)
+    } else {
+      _isInRawString.withValue(isRawString())(body)
+    }
   def template[T](of: => T): SpannedTemplate[T] =
     nonterminal:
-      // TODO lint: do not allow nesting non-raw multiline strings in splices in a raw string
       // TODO handle case where the body is not a string, e.g.
       // Expected an extern definition, which can either be a single-line string (e.g., "x + y") or a multi-line string (e.g., """...""")
-      val first = spanned(string())
-      val (exprs, strs) = manyWhile((`${` ~> spanned(of) <~ `}$`, spanned(string())), `${`).unzip
-      SpannedTemplate(first :: strs, exprs)
+      rawStringNestingGuard:
+        val first = spanned(string())
+        val (exprs, strs) = manyWhile((`${` ~> spanned(of) <~ `}$`, spanned(string())), `${`).unzip
+        SpannedTemplate(first :: strs, exprs)
 
   def spanned[T](p: => T): Spanned[T] =
     nonterminal:
@@ -1454,6 +1461,14 @@ class Parser(tokens: Seq[Token], source: Source) {
   def isString: Boolean = peek.kind match {
     case _: (Str | RawStr) => true
     case _                 => false
+  }
+  private def isRawString(): Boolean = peek.kind match {
+    case _: RawStr => true
+    case _ => false
+  }
+  private def isActualMultilineString(): Boolean = peek.kind match {
+    case Str(s, true) => s.contains("\n")
+    case _ => false
   }
 
   def templateString(splicer: Maybe[IdRef]): Term =

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -856,25 +856,19 @@ class Parser(tokens: Seq[Token], source: Source) {
   def string(): String =
     nonterminal:
       expect("string literal") {
-        case RawStr(fst) =>
+        case RawStr(fst, terminator) =>
           val res = mutable.StringBuilder(fst)
+          var lastTerminator = terminator
           @tailrec
           def go(): String = {
             peek.kind match {
-              case t@RawStr(s) =>
+              case t@RawStr(s, terminator) =>
                 skip()
+                res.append(lastTerminator)
                 res.append(s)
+                lastTerminator = terminator
                 go()
               case _ =>
-                // remove the trailing newline, which will *always* be there as either a \n or \r\n (see Lexer).
-                // Reasoning: Note that escapes are not allowed in raw strings, so the \r couldn't have come from
-                // a `\r` in the raw string. If we were to allow escapes in raw strings, a trailing \r in
-                // the string would break (but *only* this would).
-                assert(res.last == '\n')
-                res.deleteCharAt(res.length() - 1)
-                if (res.last == '\r') {
-                  res.deleteCharAt(res.length() - 1)
-                }
                 res.mkString
             }
           }

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -863,9 +863,19 @@ class Parser(tokens: Seq[Token], source: Source) {
             peek.kind match {
               case t@RawStr(s) =>
                 skip()
-                res.addOne('\n'); res.append(s)
+                res.append(s)
                 go()
-              case _ => res.mkString
+              case _ =>
+                // remove the trailing newline, which will *always* be there as either a \n or \r\n (see Lexer).
+                // Reasoning: Note that escapes are not allowed in raw strings, so the \r couldn't have come from
+                // a `\r` in the raw string. If we were to allow escapes in raw strings, a trailing \r in
+                // the string would break (but *only* this would).
+                assert(res.last == '\n')
+                res.deleteCharAt(res.length() - 1)
+                if (res.last == '\r') {
+                  res.deleteCharAt(res.length() - 1)
+                }
+                res.mkString
             }
           }
           go()

--- a/examples/neg/parsing/raw_string_nesting.check
+++ b/examples/neg/parsing/raw_string_nesting.check
@@ -1,0 +1,3 @@
+[error] examples/neg/parsing/raw_string_nesting.effekt:2:31: Can't nest multiline strings in raw strings.
+  val neststr = s#|Not with ${"""
+                              ^

--- a/examples/neg/parsing/raw_string_nesting.effekt
+++ b/examples/neg/parsing/raw_string_nesting.effekt
@@ -1,0 +1,6 @@
+def main() = {
+  val neststr = s#|Not with ${"""
+                   """
+                 $|} foo
+  println(neststr)
+}

--- a/examples/pos/string/raw_strings.check
+++ b/examples/pos/string/raw_strings.check
@@ -1,0 +1,13 @@
+Hello World!
+Second line \n #1 // doo de
+ #| #|
+Even with interpolation
+ still nice
+And multiline splices
+We can even nest stuff:
+  Inner nested
+ with more lines even nested splices
+Not with 
+                    foo
+ foo
+ bar

--- a/examples/pos/string/raw_strings.check
+++ b/examples/pos/string/raw_strings.check
@@ -7,7 +7,5 @@ And multiline splices
 We can even nest stuff:
   Inner nested
  with more lines even nested splices
-Not with 
-                    foo
  foo
  bar

--- a/examples/pos/string/raw_strings.effekt
+++ b/examples/pos/string/raw_strings.effekt
@@ -1,0 +1,33 @@
+def main() = {
+  val foo = #|Hello World!
+            #|Second line \n #1 // doo de
+            #| #| #|
+  println(foo)
+
+  val bar = s#|Even with ${"interpolation"}
+             #| still nice
+  println(bar)
+
+  val baz = s#|And multiline ${
+             $| "splices"
+             $| }
+  println(baz)
+
+  val nested = s#|We can even nest stuff:
+                #|  ${s#|Inner nested
+                $|     #| with more lines ${
+                $|     $|   "even nested splices"
+                $|     $|}
+                $|   }
+  println(nested)
+
+  val neststr = s#|Not with ${"""
+                   """
+                 $|} foo
+  println(neststr)
+  val neststr2 = s"""${
+    #| foo
+    #| bar
+  }"""
+  println(neststr2)
+}

--- a/examples/pos/string/raw_strings.effekt
+++ b/examples/pos/string/raw_strings.effekt
@@ -21,10 +21,6 @@ def main() = {
                 $|   }
   println(nested)
 
-  val neststr = s#|Not with ${"""
-                   """
-                 $|} foo
-  println(neststr)
   val neststr2 = s"""${
     #| foo
     #| bar


### PR DESCRIPTION
This is a shot at implementing a proof-of-concept for #1128.

It allows raw strings with the following syntax:
```
val someString = #|function thisIsTheString() {
                 #|  return "${
                 $|     "allowing splices"
                 $|  }";
                 #|}
```