### PR TITLE
JS: Allocate arena lazily

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -23,6 +23,8 @@ object TransformerCps extends Transformer {
   val THUNK = Variable(JSName("THUNK"))
   val DEALLOC = Variable(JSName("DEALLOC"))
   val TRAMPOLINE = Variable(JSName("TRAMPOLINE"))
+  val VAR = Variable(JSName("VAR"))
+  val REGION = Variable(JSName("REGION"))
 
   class RecursiveUsage(var jumped: Boolean)
   case class RecursiveDefInfo(id: Id, label: Id, vparams: List[Id], bparams: List[Id], ks: Id, k: Id, used: RecursiveUsage)
@@ -418,24 +420,24 @@ object TransformerCps extends Transformer {
       val args = vargs.map(toJS) ++ bargs.map(argumentToJS) ++ List(toJS(ks), toJS(k))
       pure(js.Return(MethodCall(toJS(callee), memberNameRef(method), args:_*)) :: Nil)
 
-    // const r = ks.arena.newRegion(); body
+    // const r = REGION(ks); body
     case cps.Stmt.Region(id, ks, body) =>
       Binding { k =>
-        js.Const(nameDef(id), js.MethodCall(js.Member(toJS(ks), JSName("arena")), JSName("newRegion"))) ::
+        js.Const(nameDef(id), js.Call(REGION, List(toJS(ks)))) ::
           toJS(body).run(k)
       }
 
-    // const x = r.alloc(init); body
+    // const x = r.fresh(init); body
     case cps.Stmt.Alloc(id, init, region, body) =>
       Binding { k =>
         js.Const(nameDef(id), js.MethodCall(nameRef(region), JSName("fresh"), toJS(init))) ::
           toJS(body).run(k)
       }
 
-    // const x = ks.arena.fresh(1); body
+    // const x = VAR(1, ks); body
     case cps.Stmt.Var(id, init, ks, body) =>
       Binding { k =>
-        js.Const(nameDef(id), js.MethodCall(js.Member(toJS(ks), JSName("arena")), JSName("fresh"), toJS(init))) ::
+        js.Const(nameDef(id), js.Call(VAR, List(toJS(init), toJS(ks)))) ::
           toJS(body).run(k)
       }
 

--- a/libraries/js/effekt_runtime.js
+++ b/libraries/js/effekt_runtime.js
@@ -58,6 +58,7 @@ class Arena {
 }
 
 function snapshot(s) {
+  if (s === null) return null
   const snap = { store: s, root: s.root, generation: s.generation }
   s.generation = s.generation + 1
   return snap
@@ -85,9 +86,11 @@ function reroot(target) {
     node.value   = Mem
     cur          = node
   }
+
 }
 
 function restore(store, snap) {
+  if (snap === null) return // nothing saved ~> nothing to restore
   if (snap.root.value !== Mem) {
     // fast path: continuation is resumed immediately with no writes in between
     reroot(snap.root)
@@ -99,7 +102,18 @@ function restore(store, snap) {
 // Common Runtime
 // --------------
 const TOPLEVEL_K = (x, ks) => { throw { computationIsDone: true, result: x } }
-const TOPLEVEL_KS = { stack: null, prompt: Symbol("toplevel"), arena: new Arena(), rest: null }
+const TOPLEVEL_KS = { stack: null, prompt: Symbol("toplevel"), arena: null, rest: null }
+
+// The first variable in a scope creates its arena; until then `ks.arena` is null.
+function VAR(init, ks) {
+  const arena = ks.arena !== null ? ks.arena : (ks.arena = new Arena())
+  return arena.fresh(init)
+}
+
+function REGION(ks) {
+  const arena = ks.arena !== null ? ks.arena : (ks.arena = new Arena())
+  return arena.newRegion()
+}
 
 function THUNK(f) {
   f.thunk = true
@@ -120,7 +134,7 @@ const RETURN = (x, ks) => ks.rest.stack(x, ks.rest)
 function RESET(prog, ks, k) {
   const prompt = Symbol(); // gensym
   const rest = { stack: k, prompt: ks.prompt, arena: ks.arena, rest: ks.rest }
-  return prog(prompt, { stack: null, prompt, arena: new Arena(), rest }, RETURN)
+  return prog(prompt, { stack: null, prompt, arena: null, rest }, RETURN)
 }
 
 function SHIFT(p, body, ks, k) {

--- a/libraries/js/effekt_runtime.js
+++ b/libraries/js/effekt_runtime.js
@@ -125,7 +125,7 @@ function THUNK(f) {
 function CAPTURE(body) {
   return (ks, k) => {
     const res = body(x => TRAMPOLINE(() => k(x, ks)))
-    if (res instanceof Function) return res
+    if (typeof res === "function") return res
     else throw { computationIsDone: true, result: $effekt.unit }
   }
 }

--- a/libraries/js/effekt_runtime.js
+++ b/libraries/js/effekt_runtime.js
@@ -87,6 +87,8 @@ function reroot(target) {
     cur          = node
   }
 
+  // 3. Reclaim the path to reuse the buffer eagerly
+  _rerootPath.length = 0
 }
 
 function restore(store, snap) {


### PR DESCRIPTION
Subsumes #1334

Like on LLVM, let's allocate the arena lazily on first allocation, which makes a few benchmarks faster.