### PR TITLE
WIP: Optimize data representation on JS

### DIFF
--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -65,7 +65,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Function(name, params, stmts) => "function" <+> toDoc(name) <> parens(params map toDoc) <+> jsBlock(stmts map toDoc)
     case Class(name, methods)          => "class" <+> toDoc(name) <+> jsBlock(methods.map(jsMethod))
     case If(cond, thn, Block(Nil))     => "if" <+> parens(toDoc(cond)) <+> toDocBlock(thn)
-    case If(cond, thn, els)            => "if" <+> parens(toDoc(cond)) <+> toDocBlock(thn) <+> "else" <+> toDocBlock(els)
+    case If(cond, thn, els)            => "if" <+> parens(toDoc(cond)) <+> toDocBlock(thn) <+> "else" <+> toDocElse(els)
     case Try(prog, id, handler, Nil)   => "try" <+> jsBlock(prog.map(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.map(toDoc))
     case Try(prog, id, handler, fin)    => "try" <+> jsBlock(prog.map(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.map(toDoc)) <+> "finally" <+> jsBlock(fin.map(toDoc))
     case Throw(expr)                   => "throw" <+> toDoc(expr) <> ";"
@@ -82,8 +82,12 @@ object PrettyPrinter extends ParenPrettyPrinter {
 
   def toDocBlock(stmt: Stmt): Doc = stmt match {
     case Block(stmts) => toDoc(stmt)
-    case If(cond, thn, els) => toDoc(stmt)
     case _ => jsBlock(toDoc(stmt))
+  }
+
+  def toDocElse(stmt: Stmt): Doc = stmt match {
+    case If(cond, thn, els) => toDoc(stmt) // nested if ~> `else if ...`
+    case _ => toDocBlock(stmt)             // otherwise ~> `else { ... }
   }
 
   def jsMethod(c: js.Function): Doc = c match {

--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -35,10 +35,12 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Object(properties)           => group(jsBlock(vsep(properties.map { case (n, d) => toDoc(n) <> ":" <+> toDoc(d) }, comma)))
     case ArrayLiteral(elements)       => brackets(elements map toDoc)
     case Variable(name)               => toDoc(name)
+    case Ascription(c, value)         => commented(c, toDoc(value))
   }
 
   // to be used in low precedence positions
   def toDocParens(e: Expr): Doc = e match {
+    case Ascription(c, value) => commented(c, toDocParens(value))
     case e: IfExpr => parens(toDoc(e))
     case e: Lambda => parens(toDoc(e))
     case o: js.Object => parens(toDoc(e))
@@ -47,6 +49,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
 
   // to be used in really low precedence positions
   def toDocAsAtom(e: Expr): Doc = e match {
+    case Ascription(c, value) => commented(c, toDocAsAtom(value))
     case e: Variable => toDoc(e)
     case e: ArrayLiteral => toDoc(e)
     case e: RawLiteral => toDoc(e)
@@ -69,6 +72,7 @@ object PrettyPrinter extends ParenPrettyPrinter {
     case Try(prog, id, handler, Nil)   => "try" <+> jsBlock(prog.map(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.map(toDoc))
     case Try(prog, id, handler, fin)    => "try" <+> jsBlock(prog.map(toDoc)) <+> "catch" <+> parens(toDoc(id)) <+> jsBlock(handler.map(toDoc)) <+> "finally" <+> jsBlock(fin.map(toDoc))
     case Throw(expr)                   => "throw" <+> toDoc(expr) <> ";"
+    case Ascribed(constructor, stmt)   => commented(constructor, toDoc(stmt))
     case Break()                       => "break;"
     case Continue(label)               => "continue" <> label.map(l => space <> toDoc(l)).getOrElse(emptyDoc) <> ";"
     case While(cond, stmts, label)     =>
@@ -81,13 +85,15 @@ object PrettyPrinter extends ParenPrettyPrinter {
   }
 
   def toDocBlock(stmt: Stmt): Doc = stmt match {
+    case Ascribed(constructor, stmt) => commented(constructor, toDocBlock(stmt))
     case Block(stmts) => toDoc(stmt)
     case _ => jsBlock(toDoc(stmt))
   }
 
   def toDocElse(stmt: Stmt): Doc = stmt match {
-    case If(cond, thn, els) => toDoc(stmt) // nested if ~> `else if ...`
-    case _ => toDocBlock(stmt)             // otherwise ~> `else { ... }
+    case Ascribed(constructor, stmt) => commented(constructor, toDocElse(stmt))
+    case If(cond, thn, els) => toDoc(stmt)
+    case _ => toDocBlock(stmt)
   }
 
   def jsMethod(c: js.Function): Doc = c match {
@@ -115,4 +121,6 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def jsBlock(content: Doc): Doc = braces(nest(line <> content) <> line)
 
   def jsBlock(docs: List[Doc]): Doc = jsBlock(vcat(docs))
+
+  def commented(name: JSName, value: Doc): Doc = "/*" <+> toDoc(name) <+> "*/" <+> value
 }

--- a/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/PrettyPrinter.scala
@@ -104,6 +104,8 @@ object PrettyPrinter extends ParenPrettyPrinter {
   def toDoc(pattern: Pattern): Doc = pattern match {
     case Pattern.Variable(name) => toDoc(name)
     case Pattern.Array(ps) => brackets(ps map toDoc)
+    case Pattern.Object(fields) =>
+      group(jsBlock(vsep(fields.map { case (f, p) => toDoc(f) <> ":" <+> toDoc(p) }, comma)))
   }
 
   // some helpers

--- a/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
@@ -96,8 +96,8 @@ enum Dispatch {
   /** A `switch` selects on the tag. */
   case ByTag(tag: Tag)
 
-  /** A test against the one value that carries no tag; whatever fails it, `rest` tells apart. */
-  case ByTest(absent: js.Expr, rest: Dispatch)
+  /** A test against `null`, use `rest` for everything else. */
+  case ByTest(rest: Dispatch)
 }
 
 /**
@@ -157,13 +157,13 @@ trait Transformer {
 
       val dispatch = (absent, singletons, objects) match {
         // a) one is `null`, other are objects                              ~> if (x === null) ... else ...
-        case (Some(nothing), _, _) => Dispatch.ByTest(nothing.value, amongObjects)
+        case (Some(_), _, _) => Dispatch.ByTest(amongObjects)
         // b) every constructor is a singleton                              ~> switch (x)
-        case (_, _, Nil)           => Dispatch.ByTag(Tag.Itself)
+        case (_, _, Nil)     => Dispatch.ByTag(Tag.Itself)
         // c) every constructor is an object (potentially carrying its tag) ~> switch (x.__tag) (or nothing when there is one)
-        case (_, Nil, _)           => amongObjects
+        case (_, Nil, _)     => amongObjects
         // d) several are numbers, the rest are objects                     ~> switch (typeof x === "number" ? x : x.__tag)
-        case _                     => Dispatch.ByTag(Tag.NumberOr(tagOfObject))
+        case _               => Dispatch.ByTag(Tag.NumberOr(tagOfObject))
       }
 
       Layout(dispatch, encoded.toMap)

--- a/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Transformer.scala
@@ -9,6 +9,97 @@ import effekt.symbols.{ Module, Symbol, Wildcard, Bindings }
 
 import scala.collection.mutable
 
+
+val `fresh` = JSName("fresh")
+val `ref`   = JSName("ref")
+val `__tag` = JSName("__tag")
+
+/** How the values of one constructor are written, and where its fields then live. */
+sealed trait Encoding {
+  def name: JSName
+
+  /** The members a value has, in declaration order, or none when it is not an object. */
+  def members: List[JSName] = this match {
+    case Encoding.AsObject(_, _, fields)           => fields
+    case Encoding.AsTaggedObject(_, _, fields)     => fields
+    case Encoding.AsNull(_) | Encoding.AsTag(_, _) => Nil
+  }
+
+  /** A value of this constructor, ascribed with it, since the value itself does not say which. */
+  def make(values: List[js.Expr]): js.Expr = this match {
+    case e: Encoding.AsNull                 => e.value                 // null
+    case e: Encoding.AsTag                  => e.label                 // 1, the value being its tag
+    case Encoding.AsObject(name, _, fields) => js.Ascription(name, js.Object(fields zip values))
+    case Encoding.AsTaggedObject(name, tag, fields) =>
+      js.Ascription(name, js.Object((`__tag` -> js.RawExpr(tag.toString)) :: (fields zip values)))
+  }
+}
+
+/**
+ * An encoding that writes a tag, which is what a `case` label selects on.
+ *
+ * [[Encoding.AsNull]] is the one that writes none, and it carries no tag to write (told apart by an `if`)
+ */
+sealed trait Tagged extends Encoding {
+  def tag: Int
+
+  /** The `case` label that selects this constructor. */
+  def label: js.Expr = js.Ascription(name, js.RawExpr(tag.toString))
+}
+
+object Encoding {
+  /** `null`, being the only field-free constructor of a data type that has objects too. */
+  case class AsNull(name: JSName) extends Encoding {
+    def value: js.Expr = js.Ascription(name, js.Null)
+  }
+
+  /** `1`, being one field-free constructor of several, or of a data type with no objects. */
+  case class AsTag(name: JSName, tag: Int) extends Tagged
+
+  /** `{ head: h, tail: t }`, the only object, so nothing has to say which constructor it is. */
+  case class AsObject(name: JSName, tag: Int, fields: List[JSName]) extends Tagged
+
+  /** `{ __tag: 1, head: h, tail: t }`, one object of several. */
+  case class AsTaggedObject(name: JSName, tag: Int, fields: List[JSName]) extends Tagged
+}
+
+/** Where the tag of a value comes from (for a value that has one) */
+enum Tag {
+
+  /** the value is its tag: it is a number */
+  case Itself
+
+  /** stored in the object */
+  case Stored
+
+  /** fixed, needing no read, as no other constructor of the data type is an object */
+  case Fixed(label: js.Expr)
+
+  /** a number is its own tag, and anything else is an object, whose tag is `ofObject`. */
+  case NumberOr(ofObject: Tag)
+
+  /** Reads the tag off a value, which a `switch` then selects on. */
+  def read(value: js.Expr): js.Expr = this match {
+    case Itself             => value
+    case Stored             => js.Member(value, `__tag`)
+    case Fixed(label)       => label
+    case NumberOr(ofObject) => js.IfExpr(js"typeof ${value} === ${JsString("number")}", value, ofObject.read(value))
+  }
+}
+
+/** What a match does to find out which constructor a value is which */
+enum Dispatch {
+
+  /** The constructor is known: the data type is a record. */
+  case Known
+
+  /** A `switch` selects on the tag. */
+  case ByTag(tag: Tag)
+
+  /** A test against the one value that carries no tag; whatever fails it, `rest` tells apart. */
+  case ByTest(absent: js.Expr, rest: Dispatch)
+}
+
 /**
  * Parent all JS transformers.
  *
@@ -24,45 +115,65 @@ trait Transformer {
 
   // Representation of Data / Codata
   // ----
-  def tagFor(constructor: Id)(using D: DeclarationContext, C: Context): js.Expr = {
-    js.RawExpr(D.getConstructorTag(constructor).toString)
-  }
+  case class Layout(dispatch: Dispatch, encodings: Map[Id, Encoding])
 
-  def generateConstructor(constructor: Constructor, tagValue: Int): js.Stmt = {
-    val fields = constructor.fields
-    // class Id {
-    //   constructor(param...) { this.param = param; ...  }
-    //   __reflect() { return { name: "NAME", data: [this.param...] }
-    //   __equals(other) { ... }
-    // }
-    val params = fields.map { f => nameDef(f.id) }
+  val layouts: mutable.Map[Id, Layout] = mutable.Map.empty
 
-    def set(field: JSName, value: js.Expr): js.Stmt = js.Assign(js.Member(js"this", field), value)
-    def get(field: JSName): js.Expr = js.Member(js"this", field)
+  /** The layout of the data type that declares this constructor, decided from its shape alone. */
+  def layoutFor(constructor: Id)(using D: DeclarationContext, C: Context): Layout =
+    val data = D.findConstructor(constructor).flatMap(D.findData).getOrElse {
+      C.panic(s"No data type declares the constructor ${constructor.name.name}")
+    }
+    layouts.getOrElseUpdate(data.id, {
+      val constructors = data.constructors.zipWithIndex
 
-    val initParams = params.map { param => set(param, js.Variable(param))  }
-    val initTag    = set(`tag`, js.RawExpr(tagValue.toString))
-    val jsConstructor: js.Function = js.Function(JSName("constructor"), params, initTag :: initParams)
+      // 1. the shape of the whole data type decides how its constructors are written
+      val (objects, singletons) = constructors.partition { case (c, _) => c.fields.nonEmpty }
+      val encoded = constructors.map { case (c, tag) =>
+        val name = nameDef(c.id)
+        val members = c.fields.map { f => memberNameRef(f.id) }
+        c.id -> ((c.fields, singletons, objects) match {
+          // a) only singleton constructor, when there are full objects ~> null
+          case (Nil, _ :: Nil, _ :: _) => Encoding.AsNull(name)
+          // b) any other singleton constructor:                        ~> 1
+          case (Nil, _, _)             => Encoding.AsTag(name, tag)
+          // c) only constructor that is an object (no tag needed)      ~> { head_0: h }
+          case (_, _, _ :: Nil)        => Encoding.AsObject(name, tag, members)
+          // d) one object of several (tag is needed)                   ~> { __tag: 1, head_0: h }
+          case _                       => Encoding.AsTaggedObject(name, tag, members)
+        })
+      }
 
-    val jsReflect: js.Function = js.Function(`reflect`, Nil, List(js.Return(js.Object(List(
-      `tag`  -> js.RawExpr(tagValue.toString),
-      `name` -> JsString(constructor.id.name.name),
-      `data` -> js.ArrayLiteral(fields map { f => get(memberNameRef(f.id)) }))))))
+      // 2. match tells constructors apart based on the encodings above, building the dispatch
+      val absent     = encoded.collectFirst { case (_, e: Encoding.AsNull)   => e }
+      val onlyObject = encoded.collectFirst { case (_, e: Encoding.AsObject) => e }
 
-    val other = freshName("other")
-    def otherGet(field: JSName): js.Expr = js.Member(js.Variable(other), field)
-    def compare(field: JSName): js.Expr = js"!${$effekt.call("equals", get(field), otherGet(field))}"
-    val noop    = js.Block(Nil)
-    val abort   = js.Return(js"false")
-    val succeed = js.Return(js"true")
-    val otherExists   = js.If(js"!${js.Variable(other)}", abort, noop)
-    val compareTags   = js.If(compare(`tag`), abort, noop)
-    val compareFields = params.map(f => js.If(compare(f), abort, noop))
+      val (tagOfObject, amongObjects) = onlyObject match {
+        // either it is the only object, so the dispatch is clear
+        case Some(only) => (Tag.Fixed(only.label), Dispatch.Known)
+        // or there are several objects, so the dispatch is by `switch (x.__tag)`
+        case None       => (Tag.Stored,            Dispatch.ByTag(Tag.Stored))
+      }
 
-    val jsEquals: js.Function = js.Function(`equals`, List(other), otherExists :: compareTags :: compareFields ::: List(succeed))
+      val dispatch = (absent, singletons, objects) match {
+        // a) one is `null`, other are objects                              ~> if (x === null) ... else ...
+        case (Some(nothing), _, _) => Dispatch.ByTest(nothing.value, amongObjects)
+        // b) every constructor is a singleton                              ~> switch (x)
+        case (_, _, Nil)           => Dispatch.ByTag(Tag.Itself)
+        // c) every constructor is an object (potentially carrying its tag) ~> switch (x.__tag) (or nothing when there is one)
+        case (_, Nil, _)           => amongObjects
+        // d) several are numbers, the rest are objects                     ~> switch (typeof x === "number" ? x : x.__tag)
+        case _                     => Dispatch.ByTag(Tag.NumberOr(tagOfObject))
+      }
 
-    js.Class(nameDef(constructor.id), List(jsConstructor, jsReflect, jsEquals))
-  }
+      Layout(dispatch, encoded.toMap)
+    })
+
+  def dispatchFor(constructor: Id)(using D: DeclarationContext, C: Context): Dispatch =
+    layoutFor(constructor).dispatch
+
+  def encodingFor(constructor: Id)(using D: DeclarationContext, C: Context): Encoding =
+    layoutFor(constructor).encodings(constructor)
 
   // Names
   // -----
@@ -92,14 +203,6 @@ trait Transformer {
   def jsModuleName(path: String): String = "$" + path.replace('/', '_').replace('-', '_')
 
   def jsModuleFile(path: String): String = path.replace('/', '_').replace('-', '_') + ".js"
-
-  val `fresh` = JSName("fresh")
-  val `ref`   = JSName("ref")
-  val `tag`   = JSName("__tag")
-  val `name`  = JSName("__name")
-  val `data`  = JSName("__data")
-  val `reflect`  = JSName("__reflect")
-  val `equals`  = JSName("__equals")
 
   def nameDef(id: Id): JSName = uniqueName(id)
 

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -494,30 +494,30 @@ object TransformerCps extends Transformer {
     def first(clauses: List[Clause[Encoding]]): List[js.Stmt] =
       clauses.headOption.map(bodyOf) getOrElse otherwise
 
-    def whenPresent(rest: Dispatch, clauses: Clauses): js.Stmt = (rest, clauses.tagged) match {
-      // 1. nothing left to dispatch on
-      case (_             , Nil)             => js.Block(otherwise)
-      // 2. one clause / constructor left ~> ascribe the branch, but no switch needed
+    def branch(dispatch: Dispatch, clauses: List[Clause[Encoding]]): js.Stmt = (dispatch, clauses) match {
+      // 1. one constructor left ~> ascribe the branch, but no switch needed
       case (Dispatch.Known, one :: Nil)      => js.Ascribed(one.encoding.name, js.Block(bodyOf(one)))
-      // 3. several clauses left ~> a `switch` is needed
-      case (_             , opens :: others) => js.Block(select(rest, Clauses(opens, others)))
+      // 2. no clause            ~> fallthrough to the `otherwise`
+      case (_             , Nil)             => js.Block(otherwise)
+      // 3. several clauses left ~> tell them apart according to `dispatch`
+      case (_             , opens :: others) => js.Block(select(dispatch, Clauses(opens, others)))
     }
-
-    def testing(opens: Clause[Encoding], absent: js.Expr, nothing: js.Stmt, present: js.Stmt): js.Stmt =
-      opens.encoding match {
-        // Warning: no `break` may be emitted in either branch: it would bind to an enclosing loop.
-        case _: Encoding.AsNull => js.If(js"${scrutinee} === ${absent}", nothing, present) // first clause is the null one
-        case _                  => js.If(js"${scrutinee} !== ${absent}", present, nothing) // first clause is the tagged (non-null) one
-      }
 
     def select(dispatch: Dispatch, clauses: Clauses): List[js.Stmt] = dispatch match {
       // const h = l.head_0; body
       case Dispatch.Known => first(clauses.all)
 
-      // if (l === /* Nil_0 */ null) { body } else /* Cons_0 */ { ... },
-      //   (or `!==` with the branches the other way round, so that the clauses stay in order)
-      case Dispatch.ByTest(absent, rest) =>
-        testing(clauses.opens, absent, js.Block(first(clauses.absent)), whenPresent(rest, clauses)) :: Nil
+      // if (l === null) /* Nil_0 */ { ... } else /* Cons_0 */ { ... }, or `!==` with the branches
+      //   the other way round, so that the clauses stay in the order the match writes them.
+      case Dispatch.ByTest(rest) =>
+        val nothing = branch(Dispatch.Known, clauses.absent)
+        val present = branch(rest, clauses.tagged)
+
+        // Warning: no `break` may be emitted in either branch: it would bind to an enclosing loop.
+        clauses.opens.encoding match {
+          case _: Encoding.AsNull => js.If(js"${scrutinee} === ${js.Null}", nothing, present) :: Nil // first clause is the `null` one
+          case _                  => js.If(js"${scrutinee} !== ${js.Null}", present, nothing) :: Nil // first class is the tagged (non-`null`) one
+        }
 
       // switch (l.__tag) { case /* Cons_0 */ 1: const h = l.head_0; ...; default: ... }
       case Dispatch.ByTag(tag) => clauses.tagged match {

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -544,8 +544,13 @@ object TransformerCps extends Transformer {
   def toJS(scrutinee: js.Expr, clause: Clause[Encoding])(using C: TransformerContext): Binding[List[js.Stmt]] =
     val used = cps.Variables.free(clause.body)
 
-    val extractedFields = (clause.vparams zip clause.encoding.members).collect {
-      case (p, field) if used contains p => js.Const(nameDef(p), js.Member(scrutinee, field))
+    val bound = (clause.vparams zip clause.encoding.members).collect {
+      case (p, field) if used contains p => field -> js.Pattern.Variable(nameDef(p))
+    }
+    val extractedFields = bound match {
+      case Nil                => Nil
+      case (field, p) :: Nil  => js.Const(p, js.Member(scrutinee, field)) :: Nil
+      case _                  => js.Const(js.Pattern.Object(bound), scrutinee) :: Nil
     }
 
     Binding { k => extractedFields ++ toJS(clause.body).run(k) }

--- a/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/TransformerCps.scala
@@ -49,6 +49,7 @@ object TransformerCps extends Transformer {
     errors: Context
   )
   implicit def autoContext(using C: TransformerContext): Context = C.errors
+  implicit def autoDeclarations(using C: TransformerContext): DeclarationContext = C.declarations
 
 
   /**
@@ -158,12 +159,11 @@ object TransformerCps extends Transformer {
     js.RawExpr(t.strings, t.args.map(toJS))
 
   def toJS(d: core.Declaration): List[js.Stmt] = d match {
-    case core.Data(did, tparams, ctors) =>
-      ctors.zipWithIndex.map { case (ctor, index) => generateConstructor(ctor, index) }
+    // every value says which constructor it is at the moment
+    case core.Data(id, tparams, constructors) => Nil
 
     // interfaces are structurally typed at the moment, no need to generate anything.
-    case core.Interface(id, tparams, operations) =>
-      Nil
+    case core.Interface(id, tparams, operations) => Nil
   }
 
   def toJS(id: Id, b: cps.Block)(using TransformerContext): js.Expr = b match {
@@ -217,14 +217,15 @@ object TransformerCps extends Transformer {
   }
 
   def toJS(e: cps.Expr)(using D: TransformerContext): js.Expr = e match {
-    case Expr.ValueVar(id)           => nameRef(id)
-    case Expr.Literal((), core.Type.TUnit)            => $effekt.field("unit")
-    case Expr.Literal(s: String, core.Type.TString)     => JsString(escape(s))
-    case Expr.Literal(b: Byte, core.Type.TByte)       => js.RawExpr(UByte.unsafeFromByte(b).toHexString)
-    case literal: Expr.Literal       => js.RawExpr(literal.value.toString) // TODO This should match on the type...
-    case Expr.PureApp(id, vargs)     => inlineExtern(id, vargs)
-    case Expr.Make(data, tag, vargs) => js.New(nameRef(tag), vargs map toJS)
-    case Expr.Box(b)                 => argumentToJS(b)
+    case Expr.ValueVar(id)                          => nameRef(id)
+    case Expr.Literal((), core.Type.TUnit)          => $effekt.field("unit")
+    case Expr.Literal(s: String, core.Type.TString) => JsString(escape(s))
+    case Expr.Literal(b: Byte, core.Type.TByte)     => js.RawExpr(UByte.unsafeFromByte(b).toHexString)
+    case literal: Expr.Literal                      => js.RawExpr(literal.value.toString) // TODO This should match on the type...
+    case Expr.PureApp(id, vargs)                    => inlineExtern(id, vargs)
+    // /* Cons_0 */ { head_0: h, tail_0: t }
+    case Expr.Make(data, constructor, vargs)        => encodingFor(constructor).make(vargs map toJS)
+    case Expr.Box(b)                                => argumentToJS(b)
   }
 
   def toJS(s: cps.Stmt)(using D: TransformerContext): Binding[List[js.Stmt]] = s match {
@@ -291,30 +292,7 @@ object TransformerCps extends Transformer {
         js.Const(nameDef(id), js.Call(nameRef(callee), vargs.map(toJS) ++ bargs.map(argumentToJS))) :: toJS(body).run(k)
       }
 
-    case cps.Stmt.Match(sc, Nil, None) =>
-      pure(js.Return($effekt.call("unreachable")) :: Nil)
-
-    case cps.Stmt.Match(sc, List((tag, clause)), None) =>
-      val scrutinee = toJS(sc)
-      val (_, stmts) = toJS(scrutinee, tag, clause)
-      stmts
-
-    // (function () { switch (sc.tag) {  case 0: return f17.apply(null, sc.data) }
-    case cps.Stmt.Match(sc, clauses, default) =>
-      val scrutinee = toJS(sc)
-
-      pure(js.Switch(js.Member(scrutinee, `tag`),
-        clauses.map { case (tag, clause) =>
-          val (e, binding) = toJS(scrutinee, tag, clause);
-
-          val stmts = binding.stmts
-
-          stmts.lastOption match {
-            case Some(terminator : (js.Stmt.Return | js.Stmt.Break | js.Stmt.Continue)) => (e, stmts)
-            case other => (e, stmts :+ js.Break())
-          }
-        },
-        default.map { s => toJS(s).stmts }) :: Nil)
+    case m: cps.Stmt.Match => pure(toJS(m))
 
     case cps.Stmt.Jump(k, vargs, ks) if D.directStyle.exists(c => c.k == k) => D.directStyle match {
       case Some(ContinuationInfo(k2, params2, ks2)) =>
@@ -471,21 +449,106 @@ object TransformerCps extends Transformer {
       pure(js.Return($effekt.call("hole", JsString(span.range.from.format))) :: Nil)
   }
 
-  def toJS(scrutinee: js.Expr, variant: Id, clause: cps.Clause)(using C: TransformerContext): (js.Expr, Binding[List[js.Stmt]]) =
-    clause match {
-      case cps.Clause(vparams, body) =>
-        val fields = C.declarations.getConstructor(variant).fields.map(_.id)
-        val tag = js.RawExpr(C.declarations.getConstructorTag(variant).toString)
+  /** One arm of a match: the constructor it takes, how that constructor is written, and its body. */
+  case class Clause[+E <: Encoding](constructor: Id, encoding: E, vparams: List[Id], body: cps.Stmt)
 
-        val freeVars = cps.Variables.free(body)
-        def isUsed(x: Id) = freeVars contains x
+  /**
+   * The clauses of a match, in the order it writes them, and never none: `opens` is the one it tries
+   * first. [[absent]] and [[tagged]] are views of the same list, not a split of it, so the order is
+   * kept rather than recorded, and a `null` clause can never reach a `case` label.
+   */
+  case class Clauses(opens: Clause[Encoding], rest: List[Clause[Encoding]]) {
 
-        val extractedFields = (vparams zip fields).collect { case (p, f) if isUsed(p) =>
-          js.Const(nameDef(p), js.Member(scrutinee, memberNameRef(f)))
-        }
+    def all: List[Clause[Encoding]] = opens :: rest
 
-        (tag, Binding { k => extractedFields ++ toJS(body).run(k) })
+    /** The clauses whose values are `null`, which only a test finds. */
+    def absent: List[Clause[Encoding]] = all.collect { case c @ Clause(_, _: Encoding.AsNull, _, _) => c }
+
+    /** The clauses whose values write a tag, which is what a `case` label selects. */
+    def tagged: List[Clause[Tagged]] = all.collect {
+      case Clause(constructor, encoding: Tagged, vparams, body) =>
+        Clause(constructor, encoding, vparams, body)
     }
+  }
+
+  object Clauses {
+    /** A match names at least one clause, and the caller has it, so it is passed rather than looked for. */
+    def of(opens: (Id, cps.Clause), rest: List[(Id, cps.Clause)])(using D: TransformerContext): Clauses =
+      def clause(named: (Id, cps.Clause)): Clause[Encoding] = named match {
+        case (constructor, cps.Clause(vparams, body)) =>
+          Clause(constructor, encodingFor(constructor), vparams, body)
+      }
+      Clauses(clause(opens), rest.map(clause))
+  }
+
+  def toJS(m: cps.Stmt.Match)(using D: TransformerContext): List[js.Stmt] =
+    val scrutinee = toJS(m.scrutinee)
+
+    def otherwise: List[js.Stmt] =
+      m.default.map { s => toJS(s).stmts } getOrElse (js.Return($effekt.call("unreachable")) :: Nil)
+
+    def bodyOf(clause: Clause[Encoding]): List[js.Stmt] = toJS(scrutinee, clause).stmts
+
+    // a match names each constructor once, so at most one clause applies; where one is named twice
+    // the first wins, as it would for a repeated `case` label
+    def first(clauses: List[Clause[Encoding]]): List[js.Stmt] =
+      clauses.headOption.map(bodyOf) getOrElse otherwise
+
+    def whenPresent(rest: Dispatch, clauses: Clauses): js.Stmt = (rest, clauses.tagged) match {
+      // 1. nothing left to dispatch on
+      case (_             , Nil)             => js.Block(otherwise)
+      // 2. one clause / constructor left ~> ascribe the branch, but no switch needed
+      case (Dispatch.Known, one :: Nil)      => js.Ascribed(one.encoding.name, js.Block(bodyOf(one)))
+      // 3. several clauses left ~> a `switch` is needed
+      case (_             , opens :: others) => js.Block(select(rest, Clauses(opens, others)))
+    }
+
+    def testing(opens: Clause[Encoding], absent: js.Expr, nothing: js.Stmt, present: js.Stmt): js.Stmt =
+      opens.encoding match {
+        // Warning: no `break` may be emitted in either branch: it would bind to an enclosing loop.
+        case _: Encoding.AsNull => js.If(js"${scrutinee} === ${absent}", nothing, present) // first clause is the null one
+        case _                  => js.If(js"${scrutinee} !== ${absent}", present, nothing) // first clause is the tagged (non-null) one
+      }
+
+    def select(dispatch: Dispatch, clauses: Clauses): List[js.Stmt] = dispatch match {
+      // const h = l.head_0; body
+      case Dispatch.Known => first(clauses.all)
+
+      // if (l === /* Nil_0 */ null) { body } else /* Cons_0 */ { ... },
+      //   (or `!==` with the branches the other way round, so that the clauses stay in order)
+      case Dispatch.ByTest(absent, rest) =>
+        testing(clauses.opens, absent, js.Block(first(clauses.absent)), whenPresent(rest, clauses)) :: Nil
+
+      // switch (l.__tag) { case /* Cons_0 */ 1: const h = l.head_0; ...; default: ... }
+      case Dispatch.ByTag(tag) => clauses.tagged match {
+        case Nil => otherwise
+        case one :: Nil if m.default.isEmpty => bodyOf(one)
+        case tagged => js.Switch(tag.read(scrutinee), tagged.map { clause =>
+          val stmts = bodyOf(clause)
+          // a clause the switch would otherwise run on into needs the `break` it spells out
+          stmts.lastOption match {
+            case Some(terminator : (js.Stmt.Return | js.Stmt.Break | js.Stmt.Continue)) => (clause.encoding.label, stmts)
+            case other => (clause.encoding.label, stmts :+ js.Break())
+          }
+        }, m.default.map { s => toJS(s).stmts }) :: Nil
+      }
+    }
+
+    // every clause of a match belongs to the same data type, so any one of them says how to tell them apart
+    m.clauses match {
+      case Nil => otherwise
+      case (opens @ (constructor, _)) :: rest => select(dispatchFor(constructor), Clauses.of(opens, rest))
+    }
+
+  // const h = l.head_0; const t = l.tail_0; body
+  def toJS(scrutinee: js.Expr, clause: Clause[Encoding])(using C: TransformerContext): Binding[List[js.Stmt]] =
+    val used = cps.Variables.free(clause.body)
+
+    val extractedFields = (clause.vparams zip clause.encoding.members).collect {
+      case (p, field) if used contains p => js.Const(nameDef(p), js.Member(scrutinee, field))
+    }
+
+    Binding { k => extractedFields ++ toJS(clause.body).run(k) }
 
   def toJS(d: cps.Def)(using D: TransformerContext): js.Stmt = d match {
     case cps.Def(id, block) =>
@@ -560,12 +623,12 @@ object TransformerCps extends Transformer {
   }
 
   private def canBeDirect(k: Id, stmt: Stmt)(using T: TransformerContext): Boolean =
-    def notIn(term: Stmt | Block | Expr | (Id, Clause) | Cont) =
+    def notIn(term: Stmt | Block | Expr | (Id, cps.Clause) | Cont) =
       val freeVars = term match {
         case s: Stmt => free(s)
         case b: Block => free(b)
         case p: Expr => free(p)
-        case (id, Clause(_, body)) => free(body)
+        case (id, cps.Clause(_, body)) => free(body)
         case c: Cont => free(c)
       }
       !freeVars.contains(k)
@@ -577,7 +640,7 @@ object TransformerCps extends Transformer {
       case Stmt.Invoke(callee, method, vargs, bargs, ks, k2) => notIn(stmt)
       case Stmt.If(cond, thn, els) => canBeDirect(k, thn) && canBeDirect(k, els)
       case Stmt.Match(scrutinee, clauses, default) => clauses.forall {
-        case (id, Clause(vparams, body)) => canBeDirect(k, body)
+        case (id, cps.Clause(vparams, body)) => canBeDirect(k, body)
       } && default.forall(body => canBeDirect(k, body))
       case Stmt.LetDef(id, binding, body) => notIn(binding) && canBeDirect(k, body)
       case Stmt.LetExpr(id, binding, body) => notIn(binding) && canBeDirect(k, body)

--- a/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
@@ -119,6 +119,9 @@ enum Expr {
 
   // e.g. x
   case Variable(name: JSName)
+
+  // e.g. /* Cons_0 */ { head_0: h }
+  case Ascription(constructor: JSName, value: Expr)
 }
 export Expr.*
 
@@ -170,6 +173,9 @@ enum Stmt {
 
   // e.g. if (<EXPR>) { <STMT> } else { <STMT> }
   case If(cond: Expr, thn: Stmt, els: Stmt)
+
+  // e.g. else /* Cons_0 */ { <STMT>* }
+  case Ascribed(constructor: JSName, stmt: Stmt)
 
   // e.g. try { <STMT>* } catch(x) { <STMT>* }
   case Try(prog: List[Stmt], name: JSName, handler: List[Stmt], fin: List[Stmt] = Nil)
@@ -226,6 +232,7 @@ def MaybeBlock(stmts: List[Stmt]): Stmt = stmts match {
 }
 
 val Undefined = RawLiteral("undefined")
+val Null = RawLiteral("null")
 
 def Lambda(params: List[JSName], stmts: List[Stmt]): Expr = stmts match {
   case Nil => sys error "Lambda should have at least one statement as body"

--- a/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
+++ b/effekt/shared/src/main/scala/effekt/generator/js/Tree.scala
@@ -136,6 +136,9 @@ implicit class JavaScriptInterpolator(private val sc: StringContext) extends Any
 enum Pattern {
   case Variable(name: JSName)
   case Array(ps: List[Pattern])
+
+  // e.g. { head_0: h, tail_0: t }
+  case Object(fields: List[(JSName, Pattern)])
 }
 
 enum Stmt {


### PR DESCRIPTION
> [!CAUTION]
> This is pretty WIP: in order to merge it, we first need to do #1381 or equivalent in order to replace the `genericX` family of functions.

Resolves #1425 

I looked into how we compile/represent ADTs in JS, and redone the whole thing.

The representation is now the fastest sane one I could find:
1. if every constructor is a singleton [no fields]: `0`, `1`, `2`, matched on by `switch (x)`
2. if one constructor is a singleton, it becomes a `null` with a `if (x === null) ... else ...` match
3. if every constructor is an non-singleton, it becomes `{ __tag: 1, head_0: h, ... }` with a `switch (x.__tag)` match
4. and if there are many singletons and non-singletons, it becomes `0`, `1`, `2`, ..., `{ __tag: 3, ... }` with a `switch (typeof x === "number" ? x : x.__tag)`

Every site that denotes a constructor is ascribed with a comment so that we can still orient ourselves around the codebase (and might be used together with #1218 to provide types)
```js
k(/* Cons_0 */ { head_0: a, tail_0: v }, ks);

if (l_0 === null) /* Nil_0 */ {
  return () => k_0(l_0, ks_0);
} else /* Cons_0 */ {
  const { head_0: a_0, tail_0: rest_0 } = l_0;
  ...
}

switch (s.__tag) { case /* Line_0 */ 1: ... case /* Box_0 */ 2: ... }
```

I also added support for object patterns so that we can emit:
```js
const { head_0: h, tail_0: t } = l
// instead of
const h = l.head_0
const t = l.tail_0
```

The cost is that there can't be any `__reflect` or `__equals` anymore (hence the need to do something like #1381).

Data-heavy benchmarks like `nofib` and `folklore_to_fact` improve by 20-30% geomean, other benchmarks by ~5-10% (effect_handlers_bench only by 2% geomean). Larger real programs improve by 10-20% in their speed which is quite nice.

I tried lots of other variants of this:
- keeping classes, using `instanceof`: sometimes a bit faster, but V8 can't compile it into a jump table (so the tests become `O(#clauses)`), so in general and on larger projects, it's much slower
- `if` chains on the `tag` are neutral or slower
- `null` as a `case` label again loses the jump table
- helpful wrapper functions like `function Cons_0(h, t) { return { head: h, tail: t } }` cost 3% geomean, but some benchmarks like `cryptarithm1` are 2x slower [!]
- arrays like `[tag, head, tail]` are even worse than what we had
- positional `{ tag, _0: head, _1: tail, ... }` (with and without padding) were the fastest wrt geomean of all benchmarks, but performing very badly on real programs
- named tag constants like `const Cons_0 = 1` are ~1% of geomean slower since V8 can't eliminate them when they're in closures (and most things we do are in a closure) 
- singletons instances (#1425): better than what we had before, but much slower than this change