### PR TITLE
Add support for stream literals

### DIFF
--- a/effekt/shared/src/main/scala/effekt/Lexer.scala
+++ b/effekt/shared/src/main/scala/effekt/Lexer.scala
@@ -93,6 +93,7 @@ enum TokenKind {
   case `(`
   case `)`
   case `[`
+  case `#[`
   case `]`
   case `,`
   case `'`
@@ -476,6 +477,10 @@ class Lexer(source: Source) extends Iterator[Token] {
       case ('*', '=') => advance2With(TokenKind.`*=`)
       case ('*', _)   => advanceWith(TokenKind.`*`)
       case ('?', _)   => advanceWith(TokenKind.`?`)
+
+      case ('#', '[') =>
+        depthTracker.brackets += 1 // count this as a "special" kind of bracket, since its closed by one
+        advance2With(TokenKind.`#[`)
 
       case ('$', '{') =>
         interpolationDepths.push(depthTracker.braces + 1)

--- a/effekt/shared/src/main/scala/effekt/Parser.scala
+++ b/effekt/shared/src/main/scala/effekt/Parser.scala
@@ -1316,7 +1316,7 @@ class Parser(tokens: Seq[Token], source: Source) {
               }
         }
       }
-
+      
   def primExpr(): Term = peek.kind match {
     case `if`     => ifExpr()
     case `while`  => whileExpr()
@@ -1327,11 +1327,13 @@ class Parser(tokens: Seq[Token], source: Source) {
     case `new`    => newExpr()
     case `do`                => doExpr()
     case _ if isString       => templateString(Maybe.None(span()))
+    case `#[`                => streamLiteral(Maybe.None(span()))
     case _ if isLiteral      => literal()
     case _ if isVariable     =>
       val lhs = variable()
       peek.kind match {
         case _: Str => templateString(Maybe.Some(lhs.id, lhs.id.span))
+        case `#[` => streamLiteral(Maybe.Some(lhs.id, lhs.id.span))
         case _ =>
           peek.kind match {
             case `+=` | `-=` | `*=` | `/=` =>
@@ -1437,6 +1439,30 @@ class Parser(tokens: Seq[Token], source: Source) {
     case _: Str => true
     case _      => false
   }
+
+  def streamLiteral(splicer: Maybe[IdRef]): Term =
+    nonterminalAt(splicer.span):
+      val start = position
+      (splicer, many(() => spanned(expr()), `#[`, `,`, `]`)) match {
+        case (Maybe(id, _), Many(elements, _)) =>
+          val body = elements.map { element =>
+            Do(
+              IdRef(Nil, "emit", element.span.synthesized),
+              Nil,
+              List(ValueArg.Unnamed(element.unspan)),
+              Nil,
+              element.span.synthesized
+            )
+          }.foldRight(
+            Return(UnitLit(span().synthesized), span().synthesized)
+          ) { (elem, acc) => ExprStmt(elem, acc, elem.span.synthesized) }
+          val blk = BlockLiteral(Nil, Nil, Nil, body, span().synthesized)
+          val target = id match {
+            case None => IdTarget(IdRef(Nil, "locally", span().synthesized))
+            case Some(target) => IdTarget(target)
+          }
+          Call(target, Nil, Nil, List(blk), span().synthesized)
+      }
 
   def templateString(splicer: Maybe[IdRef]): Term =
     nonterminalAt(splicer.span):

--- a/examples/pos/stream_literals.check
+++ b/examples/pos/stream_literals.check
@@ -1,0 +1,2 @@
+Cons(1, Cons(2, Cons(3, Nil())))
+Cons(1, Cons(2, Cons(3, Cons(4, Nil()))))

--- a/examples/pos/stream_literals.effekt
+++ b/examples/pos/stream_literals.effekt
@@ -1,0 +1,13 @@
+import list
+import stream
+
+
+def collectList{body: => Unit / emit[Int]} = list::collect[Int]{body}
+
+def main() = {
+  println(show(collectList#[1,2,3]))
+  println(show(list::collect[Int]{
+    #[1,2]
+    #[3,4]
+  }))
+}


### PR DESCRIPTION
This adds support for stream literals such that:
```
foo#[a,b,c]
```
is desugared to
```
foo{
  do emit(a)
  do emit(b)
  do emit(c)
}
```

and
```
#[a,b,c]
```
is desugared to
```
locally {
  do emit(a)
  do emit(b)
  do emit(c)
}
```

Note that this is more permissive than `[a,b,c].each`, which requires a, b and c to have the same type.