### PR TITLE
Fix 'bench::relevant', making sure benchmarks don't drop what they're computing

### DIFF
--- a/examples/benchmarks/runner.effekt
+++ b/examples/benchmarks/runner.effekt
@@ -1,6 +1,29 @@
 import args
 import bench
 
+// Volatile storage for `relevant`'s barrier
+extern js """
+  let $relevantSink;
+"""
+extern chez """
+  (define $relevant-sink (box 0))
+"""
+extern llvm """
+  @relevant_sink = global %Int 0
+"""
+
+/**
+ * A side-effect barrier ("do-not-optimize"): consumes `value` through a volatile write
+ * which no optimizer can prove unobservable, so the results ought not be omitted.
+ */
+extern def relevant(value: Int) at io: Unit =
+  js "($relevantSink = ${value}, $effekt.unit)"
+  chez "(begin (set-box! $relevant-sink ${value}) (void))"
+  llvm """
+    store volatile %Int ${value}, ptr @relevant_sink
+    ret %Pos zeroinitializer
+  """
+
 def benchmark(testSize: Int) { run: Int => Int }: Unit = commandLineArgs() match {
   // test mode
   case Nil() => println(run(testSize))
@@ -12,18 +35,12 @@ def benchmark(testSize: Int) { run: Int => Int }: Unit = commandLineArgs() match
     val n = problemSize.toInt
 
     val before = relativeTimestamp()
-    relevant(run(n))
+    val result = run(n)
     val after = relativeTimestamp()
+    relevant(result) // keep `result` alive, but don't measure the cost of keeping it alive
     val nanos = after - before
     println(nanos)
 }
 
-/**
- * The inliner might remove unused computation (if pure), which is not desired
- * for benchmarking. Since externs are opaque to the optimizer, just wrap the
- * result of the computation to benchmark in `relevant`.
- */
-extern def relevant(value: Int) at io: Unit =
-  default { () }
-
 def main() = ()
+


### PR DESCRIPTION
Resolve #1450 

Uses a volatile/global write where each backend should not try to eliminate it (since it could be observable from the outside).