### PR TITLE
Try to link libuv even when it's not found

### DIFF
--- a/effekt/jvm/src/main/scala/effekt/Runner.scala
+++ b/effekt/jvm/src/main/scala/effekt/Runner.scala
@@ -326,7 +326,7 @@ object LLVMRunner extends Runner[String] {
       case (Some(lib), Some(include)) => Seq(s"-L${lib.unixPath}", "-luv", s"-I${include.unixPath}")
       case _ =>
         C.warning(s"Cannot find libuv on ${OS}; please use --clang-libraries and --clang-includes to configure the paths for the libuv dylib and header files, respectively.")
-        Seq()
+        Seq("-luv")
     }
 
   def useLTO(using C: Context): Boolean =


### PR DESCRIPTION
Emitting `Cannot find libuv on ${OS}; please use --clang-libraries and --clang-includes to configure the paths for the libuv dylib and header files, respectively.` is morally correct, however very often Clang can help us out by finding the actual `libuv` library by itself when we pass `-luv` to it. So let's let it help us, there's not much we can lose here (and it helps on my machine / with Nix packaging).